### PR TITLE
Add a Makefile default action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
+BUILDENVVAR=CGO_ENABLED=0
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build: autogen
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/kube-scheduler cmd/main.go
+
 .PHONY: update-vendor
 update-vendor:
 	hack/update-vendor.sh


### PR DESCRIPTION
Add a `build` Makefile action (`make` is defaulted to `make build` now) to build the main binary, and place as bin/kube-scheduler.

/hold
I will update the prow job config, and verify here.