### PR TITLE
[WIP] A refactoring of coscheduling code

### DIFF
--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -36,16 +36,26 @@ import (
 type Coscheduling struct {
 	frameworkHandle framework.FrameworkHandle
 	podLister       corelisters.PodLister
-	// Key is the name of Namespace/PodGroup.
+	// key is <namespace>/<PodGroup name> and value is *PodGroupInfo.
 	podGroupInfos sync.Map
 }
 
 // PodGroupInfo is a wrapper to a PodGroup with additional information.
-// TODO implement a timeout based gc for the PodGroupInfos map
+// TODO: implement a timeout based gc for the PodGroupInfos map.
 type PodGroupInfo struct {
+	// key is a unique PodGroup ID and currently implemented as <namespace>/<podgroup name>.
+	key string
+	// name is the PodGroup name and defined through a Pod label.
+	// The PodGroup name of a regular pod is the pod name.
 	name string
-	// timestamp stores the timestamp of the initialization time of PodGroup.
+	// priority is the priority of pods in a PodGroup.
+	// All pods in a PodGroup should have the same priority.
+	priority int32
+	// timestamp stores the timestamp of the initialization time of a PodGroup.
 	timestamp time.Time
+	// minAvailable is the minimum number of pods to be co-scheduled in a PodGroup.
+	// All pods in a PodGroup should have the same minAvailable.
+	minAvailable int32
 }
 
 var _ framework.QueueSortPlugin = &Coscheduling{}
@@ -60,7 +70,7 @@ const (
 	PodGroupName = "pod-group.scheduling.sigs.k8s.io/name"
 	// PodGroupMinAvailable specifies the minimum number of pods to be scheduled together in a pod group.
 	PodGroupMinAvailable = "pod-group.scheduling.sigs.k8s.io/min-available"
-	// PermitWaitingTime is the wait timeout returned by Permit plugin
+	// PermitWaitingTime is the wait timeout returned by Permit plugin.
 	// TODO make it configurable
 	PermitWaitingTime = 1 * time.Second
 )
@@ -83,17 +93,16 @@ func New(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin
 // 2. Compare the timestamps of the initialization time of PodGroups.
 // 3. Compare the keys of PodGroups.
 func (cs *Coscheduling) Less(podInfo1 *framework.PodInfo, podInfo2 *framework.PodInfo) bool {
-	pod1 := podInfo1.Pod
-	pod2 := podInfo2.Pod
-	priority1 := pod.GetPodPriority(pod1)
-	priority2 := pod.GetPodPriority(pod2)
+	pgInfo1 := cs.setPodGroupInfo(podInfo1.Pod, podInfo1.InitialAttemptTimestamp)
+	pgInfo2 := cs.setPodGroupInfo(podInfo2.Pod, podInfo2.InitialAttemptTimestamp)
+
+	priority1 := pgInfo1.priority
+	priority2 := pgInfo2.priority
 
 	if priority1 != priority2 {
 		return priority1 > priority2
 	}
 
-	pgInfo1 := cs.getPodGroupInfo(podInfo1)
-	pgInfo2 := cs.getPodGroupInfo(podInfo2)
 	time1 := pgInfo1.timestamp
 	time2 := pgInfo2.timestamp
 
@@ -101,46 +110,77 @@ func (cs *Coscheduling) Less(podInfo1 *framework.PodInfo, podInfo2 *framework.Po
 		return time1.Before(time2)
 	}
 
-	key1 := fmt.Sprintf("%v/%v", podInfo1.Pod.Namespace, pgInfo1.name)
-	key2 := fmt.Sprintf("%v/%v", podInfo2.Pod.Namespace, pgInfo2.name)
+	key1 := pgInfo1.key
+	key2 := pgInfo2.key
 	return key1 < key2
 }
 
-func (cs *Coscheduling) getPodGroupInfo(p *framework.PodInfo) *PodGroupInfo {
-	podGroupName, min, err := GetPodGroupLabels(p.Pod)
-	if err == nil && podGroupName != "" && min > 1 {
-		key := fmt.Sprintf("%v/%v", p.Pod.Namespace, podGroupName)
-		pgInfo, ok := cs.podGroupInfos.Load(key)
-		if !ok {
-			pgInfo = &PodGroupInfo{
-				name:      podGroupName,
-				timestamp: p.InitialAttemptTimestamp,
-			}
-			cs.podGroupInfos.Store(key, pgInfo)
-		}
-		return pgInfo.(*PodGroupInfo)
-	}
+// getPodGroupkey returns a key of a PodGroup in the form of namespace/podGroupName.
+func getPodGroupKey(namespace, podGroupName string) string {
+	return fmt.Sprintf("%v/%v", namespace, podGroupName)
+}
 
-	// If the pod is regular pod, return object of PodGroupInfo but not store in PodGroupInfos.
-	// The purpose is to facilitate unified comparison.
-	return &PodGroupInfo{name: "", timestamp: p.InitialAttemptTimestamp}
+// getPodGroupInfo returns the PodGroup that a pod belongs to.
+func (cs *Coscheduling) getPodGroupInfo(p *v1.Pod) (*PodGroupInfo, bool) {
+	podGroupName, _, _ := GetPodGroupLabels(p)
+	key := getPodGroupKey(p.Namespace, podGroupName)
+	pgInfo, exist := cs.podGroupInfos.Load(key)
+	if !exist {
+		return nil, false
+	}
+	return pgInfo.(*PodGroupInfo), true
+}
+
+// setPodGroupInfo creates or updates a PodGroup and returns it.
+// (1) Create a new PodGroup if the PodGroup does not exist.
+// (2) Update minAvailable and priority values of the existing PodGroup.
+// (3) Return the new created or existing PodGroup.
+func (cs *Coscheduling) setPodGroupInfo(p *v1.Pod, t time.Time) *PodGroupInfo {
+	podGroupName, minAvailable, _ := GetPodGroupLabels(p)
+	key := getPodGroupKey(p.Namespace, podGroupName)
+	pgInfo, exist := cs.podGroupInfos.Load(key)
+	if !exist {
+		pgInfo = &PodGroupInfo{
+			name:         podGroupName,
+			key:          key,
+			priority:     pod.GetPodPriority(p),
+			timestamp:    t,
+			minAvailable: minAvailable,
+		}
+		cs.podGroupInfos.Store(key, pgInfo)
+	} else {
+		pgInfo.(*PodGroupInfo).minAvailable = minAvailable
+		pgInfo.(*PodGroupInfo).priority = pod.GetPodPriority(p)
+	}
+	return pgInfo.(*PodGroupInfo)
 }
 
 // PreFilter validates that if the total number of pods belonging to the same `PodGroup` is less than `minAvailable`.
-// If so, the scheduling process will be interrupted directly to avoid the partial Pods holding system resources
-// until a timeout. It will reduce the overall scheduling time for the whole group
+// If so, the scheduling process will be interrupted directly to avoid the partial Pods and hold the system resources
+// until a timeout. It will reduce the overall scheduling time for the whole group.
 func (cs *Coscheduling) PreFilter(ctx context.Context, state *framework.CycleState, p *v1.Pod) *framework.Status {
-	podGroupName, minAvailable, err := GetPodGroupLabels(p)
-	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+	pgInfo := cs.setPodGroupInfo(p, time.Now())
+
+	// check if the values of minAvailable are same.
+	_, podMinAvailable, _ := GetPodGroupLabels(p)
+	minAvailable := pgInfo.minAvailable
+	if podMinAvailable != minAvailable {
+		klog.Warningf("Pod %v has a different minAvailable (%v) as the PodGroup %v (%v)", p, podMinAvailable, pgInfo.key, minAvailable)
 	}
-	if podGroupName == "" || minAvailable <= 1 {
-		return framework.NewStatus(framework.Success, "")
+	// check if the priorities are same.
+	priority := pgInfo.priority
+	podPriority := pod.GetPodPriority(p)
+	if podPriority != priority {
+		klog.Warningf("Pod %v has a different priority (%v) as the PodGroup %v (%v)", p, podPriority, pgInfo.key, priority)
 	}
 
+	if minAvailable <= 1 {
+		return framework.NewStatus(framework.Success, "")
+	}
+	podGroupName := pgInfo.name
 	total := cs.calculateTotalPods(podGroupName, p.Namespace)
 	if total < minAvailable {
-		klog.V(3).Infof("The count of podGroup %v/%v/%v is not up to minAvailable(%d) in PreFilter: %d",
+		klog.V(3).Infof("The count of podGroup %v/%v/%v is less than minAvailable(%d) in PreFilter: %d",
 			p.Namespace, podGroupName, p.Name, minAvailable, total)
 		return framework.NewStatus(framework.Unschedulable, "less than minAvailable")
 	}
@@ -148,21 +188,22 @@ func (cs *Coscheduling) PreFilter(ctx context.Context, state *framework.CycleSta
 	return framework.NewStatus(framework.Success, "")
 }
 
-// PreFilterExtensions returns nil
+// PreFilterExtensions returns nil.
 func (cs *Coscheduling) PreFilterExtensions() framework.PreFilterExtensions {
 	return nil
 }
 
 // Permit is the functions invoked by the framework at "permit" extension point.
 func (cs *Coscheduling) Permit(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
-	podGroupName, minAvailable, err := GetPodGroupLabels(p)
-	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error()), 0
+	pgInfo, exist := cs.getPodGroupInfo(p)
+	if !exist {
+		return framework.NewStatus(framework.Error, "failed to find a PodGroup associated with the pod"), 0
 	}
-	if podGroupName == "" || minAvailable <= 1 {
+	minAvailable := pgInfo.minAvailable
+	if minAvailable <= 1 {
 		return framework.NewStatus(framework.Success, ""), 0
 	}
-
+	podGroupName := pgInfo.name
 	namespace := p.Namespace
 	// TODO get actually scheduled(bind successfully) account from the SharedLister
 	running := cs.calculateRunningPods(podGroupName, namespace)
@@ -203,37 +244,37 @@ func (cs *Coscheduling) Unreserve(ctx context.Context, state *framework.CycleSta
 	})
 }
 
-// GetPodGroupLabels will check the pod if belongs to some podGroup. If so, it will return the
-// podGroupName、minAvailable of podGroup. If not, it will return "" as podGroupName.
-func GetPodGroupLabels(p *v1.Pod) (string, int, error) {
+// GetPodGroupLabels will check the pod if belongs to a  PodGroup. If so, it will return the
+// podGroupName、minAvailable of the PodGroup. If not, it will return pod name and 0.
+func GetPodGroupLabels(p *v1.Pod) (string, int32, error) {
 	podGroupName, exist := p.Labels[PodGroupName]
 	if !exist || podGroupName == "" {
-		return "", 0, nil
+		return p.Name, 0, nil
 	}
 	minAvailable, exist := p.Labels[PodGroupMinAvailable]
 	if !exist || minAvailable == "" {
-		return "", 0, nil
+		return podGroupName, 0, nil
 	}
 	minNum, err := strconv.Atoi(minAvailable)
 	if err != nil {
-		klog.Errorf("GetPodGroupLabels err in coschduling %v/%v : %v", p.Namespace, p.Name, err.Error())
-		return "", 0, err
+		klog.Errorf("GetPodGroupLabels err in coscheduling %v/%v : %v", p.Namespace, p.Name, err.Error())
+		return podGroupName, 0, err
 	}
-	return podGroupName, minNum, nil
+	return podGroupName, int32(minNum), nil
 }
 
-func (cs *Coscheduling) calculateTotalPods(podGroupName, namespace string) int {
-	// TODO get the total pods from the scheduler cache and queue instead of the hack manner
+func (cs *Coscheduling) calculateTotalPods(podGroupName, namespace string) int32 {
+	// TODO get the total pods from the scheduler cache and queue instead of the hack manner.
 	selector := labels.Set{PodGroupName: podGroupName}.AsSelector()
 	pods, err := cs.podLister.Pods(namespace).List(selector)
 	if err != nil {
 		klog.Error(err)
 		return 0
 	}
-	return len(pods)
+	return int32(len(pods))
 }
 
-func (cs *Coscheduling) calculateRunningPods(podGroupName, namespace string) int {
+func (cs *Coscheduling) calculateRunningPods(podGroupName, namespace string) int32 {
 	pods, err := cs.frameworkHandle.SnapshotSharedLister().Pods().FilteredList(func(pod *v1.Pod) bool {
 		if pod.Labels[PodGroupName] == podGroupName && pod.Namespace == namespace && pod.Status.Phase == v1.PodRunning {
 			return true
@@ -246,18 +287,18 @@ func (cs *Coscheduling) calculateRunningPods(podGroupName, namespace string) int
 		return 0
 	}
 
-	return len(pods)
+	return int32(len(pods))
 }
 
-func (cs *Coscheduling) calculateWaitingPods(podGroupName, namespace string) int {
+func (cs *Coscheduling) calculateWaitingPods(podGroupName, namespace string) int32 {
 	waiting := 0
 	// Calculate the waiting pods.
-	// TODO keep a cache of podgroup size.
+	// TODO keep a cache of PodGroup size.
 	cs.frameworkHandle.IterateOverWaitingPods(func(waitingPod framework.WaitingPod) {
 		if waitingPod.GetPod().Labels[PodGroupName] == podGroupName && waitingPod.GetPod().Namespace == namespace {
 			waiting++
 		}
 	})
 
-	return waiting
+	return int32(waiting)
 }

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -505,6 +505,7 @@ func TestPreFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			coscheduling.setPodGroupInfo(tt.pod, time.Now())
 			if got := coscheduling.PreFilter(nil, nil, tt.pod); got.Code() != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, got)
 			}
@@ -549,7 +550,11 @@ func TestPermit(t *testing.T) {
 			cfgPls := &config.Plugins{Permit: &config.PluginSet{}}
 			if err := registry.Register(Name,
 				func(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
-					return &Coscheduling{frameworkHandle: handle, podLister: &fakeLister{}}, nil
+					coscheduling := &Coscheduling{frameworkHandle: handle, podLister: &fakeLister{}}
+					for _, pod := range tt.pods {
+						coscheduling.setPodGroupInfo(pod, time.Now())
+					}
+					return coscheduling, nil
 				}); err != nil {
 				t.Fatalf("fail to register filter plugin (%s)", Name)
 			}


### PR DESCRIPTION
The PR aims to improve the current coscheduling implementation by using PodGroupInfo as the main data structure and unifying the processing of regular pods and PodGroup to simplify the plugin implementation. It also improves error checking. Please refer to issue #20. 

1. Extend PodGroupInfo to include all PodGroup related information and use it as the only information source for plugins. `PodGroupLabels` is only used to get `podGroupName` and `minAvailable` and generate the key for `PodGroupInfos` map. All plugins use the data in`PodGroupInfo`. 

```
type PodGroupInfo struct {
    // key is a unique PodGroup ID and currently implemented as <namespace>/<podgroup name>.
    key string
    // name is the PodGroup name and defined through a Pod label.
    // The PodGroup name of a regular pod is the pod name.
    name string
    // priority is the priority of pods in a PodGroup.
    // All pods in a PodGroup should have the same priority.
    priority int32
    // timestamp stores the timestamp of the initialization time of a PodGroup.
    timestamp time.Time
    // minAvailable is the minimum number of pods to be co-scheduled in a PodGroup.
    // All pods in a PodGroup should have the same minAvailable.
    minAvailable int32
}
```

2. A regular pod is considered a PodGroup with a single Pod. The PodGroup name is the pod name. As a result, plugins handle PodGroups and regular pods in the same way.  

3. Explicitly separate `getPodGroupInfo` and `setPodGroupInfo`. The former obtains PodGroup information from the map while the latter create a new PodGroup (if not existing) or update the existing PodGroupInfo (called by `Less` and `PreFilter`).   

```
// getPodGroupInfo returns the PodGroup that a pod belongs to.
func (cs *Coscheduling) getPodGroupInfo(p *v1.Pod) (*PodGroupInfo, bool) {
    podGroupName, _, _ := GetPodGroupLabels(p)
    key := getPodGroupKey(p.Namespace, podGroupName)
    pgInfo, exist := cs.podGroupInfos.Load(key)
    if !exist {
        return nil, false
    }
    return pgInfo.(*PodGroupInfo), true
}
```

```
// setPodGroupInfo creates or updates a PodGroup and returns it.
// (1) Create a new PodGroup if the PodGroup does not exist.
// (2) Update minAvailable and priority values of the existing PodGroup.
// (3) Return the new created or existing PodGroup.
func (cs *Coscheduling) setPodGroupInfo(p *v1.Pod, t time.Time) *PodGroupInfo {
    podGroupName, minAvailable, _ := GetPodGroupLabels(p)
    key := getPodGroupKey(p.Namespace, podGroupName)
    pgInfo, exist := cs.podGroupInfos.Load(key)
    if !exist {
        pgInfo = &PodGroupInfo{
            name:         podGroupName,
            key:          key,
            priority:     pod.GetPodPriority(p),
            timestamp:    t,
            minAvailable: minAvailable,
        }
        cs.podGroupInfos.Store(key, pgInfo)
    } else {
        pgInfo.(*PodGroupInfo).minAvailable = minAvailable
        pgInfo.(*PodGroupInfo).priority = pod.GetPodPriority(p)
    }
    return pgInfo.(*PodGroupInfo)
}
```

3. `setPodGroupInfo`creates a new PodGroup if the PodGroup does not exist. If a PodGroup exists, it updates the existing PodGroup's `minAvailable` and `priority`.  Without a mechanism to remove/update the stale PodGroup data in PodGroupInfos map, such an update is an improvement over the current implemenation as it can handle scenarios when an existing pod/podgroup is deleted, updated (e.g., minAvailable or resource spec.) and then relaunched. 

4.  Check if all the pods of a PodGroup have the same priority and minAvailable and report a warning if not.

5. Modified the test file accordingly. With the above changes, each individual plugin test will need to call setPodGroupInfo first.

6. Fixed some typos and made various wording changes to comments.

Tests in a local cluster worked as expected.