### PR TITLE
Temporary disable coscheduling integration test

### DIFF
--- a/test/integration/coscheduling_test.go
+++ b/test/integration/coscheduling_test.go
@@ -40,6 +40,11 @@ import (
 var lowPriority, midPriority, highPriority = int32(0), int32(100), int32(1000)
 
 func TestCoschedulingPlugin(t *testing.T) {
+	// Temporary disable this test until https://github.com/kubernetes-sigs/scheduler-plugins/issues/19
+	// gets fixed.
+	if testing.Short() || true {
+		t.Skip("skipping test in short mode.")
+	}
 	registry := framework.Registry{coscheduling.Name: coscheduling.New}
 	profile := schedapi.KubeSchedulerProfile{
 		SchedulerName: v1.DefaultSchedulerName,


### PR DESCRIPTION
Until #19 gets fixed, we should disable the coscheduling integration test to not impact other code changes.