### PR TITLE
Add make sub-command to build docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /bin/
 /_output/
 /_artifacts/
+/build/kube-scheduler
 
 # used for the code generators only
 /vendor/

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 BUILDENVVAR=CGO_ENABLED=0
+REG_PORT=5000
 
 .PHONY: all
 all: build
@@ -21,6 +22,13 @@ all: build
 .PHONY: build
 build: autogen
 	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/kube-scheduler cmd/main.go
+
+.PHONY: local_image
+local_image: autogen
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-w' -o ./build/kube-scheduler cmd/main.go
+	chmod +x ./build/kube-scheduler
+	docker build -t localhost:$(REG_PORT)/scheduler-plugins:latest ./build
+	rm ./build/kube-scheduler
 
 .PHONY: update-vendor
 update-vendor:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.12
+
+COPY kube-scheduler /bin/kube-scheduler
+CMD ["kube-scheduler"]


### PR DESCRIPTION
To setup an e2e test pipeline, we need to build the scheduler-plugin image.

This PR adds a `make local_image` command to achieve that.