### PR TITLE
Add UT for sort for PG pod and no PG pod

### DIFF
--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -93,7 +93,7 @@ func New(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin
 // Less is used to sort pods in the scheduling queue.
 // 1. Compare the priorities of Pods.
 // 2. Compare the initialization timestamps of PodGroups/Pods.
-// 3. Compare the keys of PodGroups/Pods.
+// 3. Compare the keys of PodGroups/Pods, i.e., if two pods are tied at priority and creation time, the one without podGroup will go ahead of the one with podGroup.
 func (cs *Coscheduling) Less(podInfo1, podInfo2 *framework.PodInfo) bool {
 	pgInfo1, _ := cs.getOrCreatePodGroupInfo(podInfo1.Pod, podInfo1.InitialAttemptTimestamp)
 	pgInfo2, _ := cs.getOrCreatePodGroupInfo(podInfo2.Pod, podInfo2.InitialAttemptTimestamp)

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -221,7 +221,7 @@ func TestLess(t *testing.T) {
 		},
 
 		{
-			name: "p1.priority less than p2.priority, p1 and p2 belong to podGroup1",
+			name: "p1.priority less than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "namespace1", Labels: labels1},
@@ -241,7 +241,7 @@ func TestLess(t *testing.T) {
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
-			name: "p1.priority greater than p2.priority, p1 and p2 belong to podGroup1",
+			name: "p1.priority greater than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "namespace1", Labels: labels1},
@@ -283,7 +283,7 @@ func TestLess(t *testing.T) {
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
 		{
-			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 and p2 belong to podGroup1",
+			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "namespace1", Labels: labels1},
@@ -305,10 +305,32 @@ func TestLess(t *testing.T) {
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
-			name: "equal priority. equal create time, p1 and p2 belong to podGroup1",
+			name: "equal priority and creation time, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "namespace1", Labels: labels1},
+					Spec: v1.PodSpec{
+						Priority: &highPriority,
+					},
+				},
+				InitialAttemptTimestamp: t1,
+			},
+			p2: &framework.PodInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "namespace2", Labels: labels2},
+					Spec: v1.PodSpec{
+						Priority: &highPriority,
+					},
+				},
+				InitialAttemptTimestamp: t1,
+			},
+			expected: true, // p1 should be ahead of p2 in the queue
+		},
+		{
+			name: "equal priority and creation time, p2 belong to podGroup2",
+			p1: &framework.PodInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "namespace1"},
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},


### PR DESCRIPTION
Based on current implements, with `Less()`, the pod not belong to any `podGroup` will go ahead of pod belong to `PodGroup`, if by design, add UT for it.