### PR TITLE
Coscheduling: make scheduling parameters configurable

### DIFF
--- a/manifests/coscheduling/scheduler-config.yaml
+++ b/manifests/coscheduling/scheduler-config.yaml
@@ -21,3 +21,10 @@ profiles:
     unreserve:
       enabled:
         - name: Coscheduling
+# optional plugin configs
+  pluginConfig: 
+  - name: Coscheduling
+    args:
+      permitWaitingTime: 1s
+      podGroupGCInterval: 10s
+      podGroupExpirationTime: 30s

--- a/manifests/coscheduling/scheduler-config.yaml
+++ b/manifests/coscheduling/scheduler-config.yaml
@@ -25,6 +25,6 @@ profiles:
   pluginConfig: 
   - name: Coscheduling
     args:
-      permitWaitingTime: 1s
-      podGroupGCInterval: 10s
-      podGroupExpirationTime: 30s
+      permitWaitingTimeSeconds: 1
+      podGroupGCIntervalSeconds: 10
+      podGroupExpirationTimeSeconds: 30

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -41,7 +41,7 @@ func FakeNew(clock util.Clock, stop chan struct{}) (*Coscheduling, error) {
 	cs := &Coscheduling{
 		clock: clock,
 	}
-	go wait.Until(cs.podGroupInfoGC, cs.args.PodGroupGCInterval, stop)
+	go wait.Until(cs.podGroupInfoGC, time.Duration(cs.args.PodGroupGCIntervalSeconds)*time.Second, stop)
 	return cs, nil
 }
 
@@ -541,7 +541,7 @@ func TestPodGroupClean(t *testing.T) {
 				t.Fatalf("fail to clean up PodGroup : %s", tt.pod.Name)
 			}
 
-			c.Step(cs.args.PodGroupExpirationTime + time.Second)
+			c.Step(time.Duration(cs.args.PodGroupExpirationTimeSeconds)*time.Second + time.Second)
 			// Wait for asynchronous deletion.
 			err = wait.Poll(time.Millisecond*200, 1*time.Second, func() (bool, error) {
 				_, ok = cs.podGroupInfos.Load(fmt.Sprintf("%v/%v", tt.pod.Namespace, tt.podGroupName))
@@ -550,49 +550,6 @@ func TestPodGroupClean(t *testing.T) {
 
 			if err != nil {
 				t.Fatalf("fail to gc PodGroup in coscheduling: %s", tt.pod.Name)
-			}
-		})
-	}
-}
-
-func TestParsePluginArgs(t *testing.T) {
-	for _, tt := range []struct {
-		name     string
-		arg      []byte
-		args     Args
-		expected Args
-	}{
-		{
-			name: "Empty arguments",
-			arg:  nil,
-			expected: Args{
-				PermitWaitingTime:      10 * time.Second,
-				PodGroupGCInterval:     30 * time.Second,
-				PodGroupExpirationTime: 10 * time.Minute,
-			},
-		},
-		{
-			name: "Set all three parameters",
-			arg:  []byte(`{"permitWaitingTime": "5s", "podGroupGCInterval": "10s", "podGroupExpirationTime": "10m"}`),
-			expected: Args{
-				PermitWaitingTime:      5 * time.Second,
-				PodGroupGCInterval:     10 * time.Second,
-				PodGroupExpirationTime: 10 * time.Minute,
-			},
-		},
-		{
-			name: "Set some parameters",
-			arg:  []byte(`{"permitWaitingTime": "5s", "podGroupExpirationTime": "10m"}`),
-			expected: Args{
-				PermitWaitingTime:      5 * time.Second,
-				PodGroupGCInterval:     30 * time.Second,
-				PodGroupExpirationTime: 10 * time.Minute,
-			},
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := parsePluginArgs(tt.arg, &tt.args); tt.args != tt.expected || err != nil {
-				t.Errorf("expected %v, got %v, error = %v", tt.expected, tt.args, err)
 			}
 		})
 	}


### PR DESCRIPTION
1. Made three cleanup parameters configurable as plugin args.

```
// Config defines the scheduling parameters for Coscheduling plugin
type Args struct {
    // PermitWaitingTime is the wait timeout in seconds.
    PermitWaitingTimeSeconds int64
    // PodGroupGCInterval is the period to run gc of PodGroup in seconds.
    PodGroupGCIntervalSeconds int64
    // If the deleted PodGroup stays longer than the PodGroupExpirationTime,
    // the PodGroup will be deleted from PodGroupInfos.
    PodGroupExpirationTimeSeconds int64
}
```
2. Added optional args to scheduler-config.yaml

```
# optional plugin configs
  pluginConfig:
  - name: Coscheduling
    args:
      permitWaitingTimeSeconds: 1
      podGroupGCIntervalSeconds: 10
      podGroupExpirationTimeSeconds: 30
```