### PR TITLE
[Sample] Cross node preemption plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ update-vendor:
 	hack/update-vendor.sh
 
 .PHONY: unit-test
-unit-test: update-vendor
+unit-test: autogen
 	hack/unit-test.sh
 
 .PHONY: install-etcd

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling"
+	"sigs.k8s.io/scheduler-plugins/pkg/crossnodepreemption"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesources"
 	"sigs.k8s.io/scheduler-plugins/pkg/qos"
 	// Ensure scheme package is initialized.
@@ -38,6 +39,8 @@ func main() {
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(coscheduling.Name, coscheduling.New),
 		app.WithPlugin(noderesources.AllocatableName, noderesources.NewAllocatable),
+		// Sample plugins below.
+		app.WithPlugin(crossnodepreemption.Name, crossnodepreemption.New),
 		app.WithPlugin(qos.Name, qos.New),
 	)
 	if err := command.Execute(); err != nil {

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -33,7 +33,8 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/util"
-	config "sigs.k8s.io/scheduler-plugins/pkg/apis/config"
+
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/config"
 )
 
 // Coscheduling is a plugin that implements the mechanism of gang scheduling.

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -33,8 +33,8 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/pkg/scheduler/util"
-	"sigs.k8s.io/scheduler-plugins/pkg/apis/config"
 
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/config"
 	// Ensure scheme package is initialized.
 	_ "sigs.k8s.io/scheduler-plugins/pkg/apis/config/scheme"
 )

--- a/pkg/crossnodepreemption/README.md
+++ b/pkg/crossnodepreemption/README.md
@@ -1,0 +1,45 @@
+# Overview
+
+The PostFilter extension point was introduced in Kubernetes Scheduler since 1.19,
+and the default implementation in upstream is to preempt Pods **on the same node**
+to make room for the unschedulable Pod.
+
+In contrast to the "same-node-preemption" strategy, we can come up with a "cross-node-preemption"
+strategy to preempt Pods across multiple nodes, which is useful when a Pod cannot be
+scheduled due to "cross node" constraints such as PodTopologySpread and PodAntiAffinity.
+This was also mentioned in the original design document of [Preemption].
+
+[Preemption]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-preemption.md#supporting-cross-node-preemption
+
+This plugin is built as a sample to demonstrate how to use PostFilter extension point,
+as well as inspiring users to built their own innovative strategies, such as preepmpting
+a group of Pods.
+
+> ⚠️ CAVEAT: Current implementation doesn't do any branch cutting, but uses a DFS algorithm
+> to iterate all possible preemption strategies. DO NOT use it in your production env.
+
+## Maturity Level
+
+<!-- Check one of the values: Sample, Alpha, Beta, GA -->
+
+- [x] 💡 Sample (for demonstrating and inspiring purpose)
+- [ ] 👶 Alpha (used in companies for pilot projects)
+- [ ] 👦 Beta (used in companies and developed actively)
+- [ ] 👨 Stable (used in companies for production workloads)
+
+## Example config:
+
+```yaml
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+clientConnection:
+  kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+profiles:
+- schedulerName: default-scheduler
+  plugins:
+    postFilter:
+      enabled:
+      - name: CrossNodePreemption
+```

--- a/pkg/crossnodepreemption/candidate.go
+++ b/pkg/crossnodepreemption/candidate.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crossnodepreemption
+
+import (
+	v1 "k8s.io/api/core/v1"
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+)
+
+type candidate struct {
+	victims []*v1.Pod
+	name    string
+}
+
+// Victims returns s.victims.
+func (s *candidate) Victims() *extenderv1.Victims {
+	return &extenderv1.Victims{
+		Pods:             s.victims,
+		NumPDBViolations: 0,
+	}
+}
+
+// Name returns s.name.
+func (s *candidate) Name() string {
+	return s.name
+}

--- a/pkg/crossnodepreemption/cross_node_preemption.go
+++ b/pkg/crossnodepreemption/cross_node_preemption.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crossnodepreemption
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/scheduler/core"
+	dp "k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+)
+
+const (
+	// Name of the plugin used in the plugin registry and configurations.
+	Name = "CrossNodePreemption"
+)
+
+// CrossNodePreemption is a PostFilter plugin implements the preemption logic.
+type CrossNodePreemption struct {
+	fh framework.FrameworkHandle
+}
+
+var _ framework.PostFilterPlugin = &CrossNodePreemption{}
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *CrossNodePreemption) Name() string {
+	return Name
+}
+
+// New initializes a new plugin and returns it.
+func New(_ runtime.Object, fh framework.FrameworkHandle) (framework.Plugin, error) {
+	pl := CrossNodePreemption{
+		fh: fh,
+	}
+	return &pl, nil
+}
+
+// PostFilter invoked at the postFilter extension point.
+func (pl *CrossNodePreemption) PostFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, m framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
+	nnn, err := pl.preempt(ctx, state, pod, m)
+	if err != nil {
+		return nil, framework.NewStatus(framework.Error, err.Error())
+	}
+	if nnn == "" {
+		return nil, framework.NewStatus(framework.Unschedulable)
+	}
+	return &framework.PostFilterResult{NominatedNodeName: nnn}, framework.NewStatus(framework.Success)
+}
+
+func (pl *CrossNodePreemption) preempt(ctx context.Context, state *framework.CycleState, pod *v1.Pod, m framework.NodeToStatusMap) (string, error) {
+	cs := pl.fh.ClientSet()
+	ph := pl.fh.PreemptHandle()
+	nodeLister := pl.fh.SnapshotSharedLister().NodeInfos()
+
+	// 0) Fetch the latest version of <pod>.
+	// TODO(Huang-Wei): get pod from informer cache instead of API server.
+	pod, err := util.GetUpdatedPod(cs, pod)
+	if err != nil {
+		klog.Errorf("Error getting the updated preemptor pod object: %v", err)
+		return "", err
+	}
+
+	// 1) Ensure the preemptor is eligible to preempt other pods.
+	if !dp.PodEligibleToPreemptOthers(pod, nodeLister, m[pod.Status.NominatedNodeName]) {
+		klog.V(5).Infof("Pod %v/%v is not eligible for more preemption.", pod.Namespace, pod.Name)
+		return "", nil
+	}
+
+	// 2) Find all preemption candidates.
+	candidates, err := FindCandidates(ctx, state, pod, m, ph, nodeLister)
+	if err != nil || len(candidates) == 0 {
+		return "", err
+	}
+
+	// 3) Interact with registered Extenders to filter out some candidates if needed.
+	candidates, err = dp.CallExtenders(ph.Extenders(), pod, nodeLister, candidates)
+	if err != nil {
+		return "", err
+	}
+
+	// 4) Find the best candidate.
+	bestCandidate := dp.SelectCandidate(candidates)
+	if bestCandidate == nil || len(bestCandidate.Name()) == 0 {
+		return "", nil
+	}
+
+	// 5) Perform preparation work before nominating the selected candidate.
+	if err := dp.PrepareCandidate(bestCandidate, pl.fh, cs, pod); err != nil {
+		return "", err
+	}
+
+	return bestCandidate.Name(), nil
+}
+
+// FindCandidates calculates a slice of preemption candidates.
+// Each candidate is executable to make the given <pod> schedulable.
+func FindCandidates(ctx context.Context, state *framework.CycleState, pod *v1.Pod, m framework.NodeToStatusMap,
+	ph framework.PreemptHandle, nodeLister framework.NodeInfoLister) ([]dp.Candidate, error) {
+	allNodes, err := nodeLister.List()
+	if err != nil {
+		return nil, err
+	}
+	if len(allNodes) == 0 {
+		return nil, core.ErrNoNodesAvailable
+	}
+
+	potentialNodes := nodesWherePreemptionMightHelp(allNodes, m)
+
+	// A brute-force algorithm to try ALL possible pod combinations.
+	// CAVEAT: don't use this in production env.
+	return bruteForceDryRunPreemption(ctx, ph, state, pod, potentialNodes, nodeLister), nil
+}
+
+func bruteForceDryRunPreemption(ctx context.Context, ph framework.PreemptHandle, state *framework.CycleState,
+	pod *v1.Pod, potentialNodes []*framework.NodeInfo, nodeLister framework.NodeInfoLister) []dp.Candidate {
+	// Loop over <potentialNodes> and collect the pods that has lower priority than <pod>.
+	priority := podutil.GetPodPriority(pod)
+	var pods []*v1.Pod
+	for _, node := range potentialNodes {
+		for i := range node.Pods {
+			p := node.Pods[i].Pod
+			if podutil.GetPodPriority(p) < priority {
+				pods = append(pods, p)
+			}
+		}
+	}
+
+	var path []*v1.Pod
+	var result []dp.Candidate
+	// We have 2^len(pods) choices in total.
+	f := func(_pods []*v1.Pod) []dp.Candidate {
+		return dryRunOnePass(ctx, pod, _pods, nodeLister, ph, state)
+	}
+	// Pass a slice pointer (&result) so as to change its elements in dfs().
+	dfs(pods, 0, path, &result, f)
+
+	return result
+}
+
+func dfs(pods []*v1.Pod, i int, path []*v1.Pod, result *[]dp.Candidate, f dryRunFunc) {
+	if i >= len(pods) {
+		*result = append(*result, f(path)...)
+		return
+	}
+
+	// Pick, or not pick current pod.
+	dfs(pods, i+1, append(path, pods[i]), result, f)
+	dfs(pods, i+1, path, result, f)
+}
+
+type dryRunFunc func([]*v1.Pod) []dp.Candidate
+
+func dryRunOnePass(ctx context.Context, preemptor *v1.Pod, pods []*v1.Pod, nodeLister framework.NodeInfoLister,
+	ph framework.PreemptHandle, state *framework.CycleState) []dp.Candidate {
+	stateCopy := state.Clone()
+	var nodeCopies []*framework.NodeInfo
+	// Remove all victim pods.
+	for i := range pods {
+		pod := pods[i]
+		nodeInfo, _ := nodeLister.Get(pod.Spec.NodeName)
+		nodeCopy := nodeInfo.Clone()
+		nodeCopies = append(nodeCopies, nodeCopy)
+		nodeCopy.RemovePod(pod)
+		ph.RunPreFilterExtensionRemovePod(ctx, stateCopy, pod, pod, nodeCopy)
+	}
+	// See if all Filter plugins passed.
+	// NOTE: a complete search space is ALL nodes, but that would be expensive.
+	var candidates []dp.Candidate
+	for _, nodeInfo := range nodeCopies {
+		fits, _, _ := core.PodPassesFiltersOnNode(ctx, ph, stateCopy, preemptor, nodeInfo)
+		if fits {
+			candidates = append(candidates, &candidate{victims: pods, name: nodeInfo.Node().Name})
+		}
+	}
+	return candidates
+}
+
+// nodesWherePreemptionMightHelp returns a list of nodes with failed predicates
+// that may be satisfied by removing pods from the node.
+func nodesWherePreemptionMightHelp(nodes []*framework.NodeInfo, m framework.NodeToStatusMap) []*framework.NodeInfo {
+	var potentialNodes []*framework.NodeInfo
+	for _, node := range nodes {
+		name := node.Node().Name
+		// We reply on the status by each plugin - 'Unschedulable' or 'UnschedulableAndUnresolvable'
+		// to determine whether preemption may help or not on the node.
+		if m[name].Code() == framework.UnschedulableAndUnresolvable {
+			continue
+		}
+		potentialNodes = append(potentialNodes, node)
+	}
+	return potentialNodes
+}

--- a/pkg/crossnodepreemption/cross_node_preemption_test.go
+++ b/pkg/crossnodepreemption/cross_node_preemption_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crossnodepreemption
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	dp "k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+
+	testutil "sigs.k8s.io/scheduler-plugins/test/util"
+)
+
+var (
+	lowPriority, midPriority, highPriority = int32(0), int32(10), int32(100)
+)
+
+func TestFindCandidates(t *testing.T) {
+	fooSelector := st.MakeLabelSelector().Exists("foo").Obj()
+	onePodRes := map[v1.ResourceName]string{v1.ResourcePods: "1"}
+	tests := []struct {
+		name            string
+		pod             *v1.Pod
+		pods            []*v1.Pod
+		nodes           []*v1.Node
+		nodesStatuses   framework.NodeToStatusMap
+		registerPlugins []st.RegisterPluginFunc
+		want            []dp.Candidate
+	}{
+		{
+			name: "resolve PodTopologySpread constraint",
+			pod: st.MakePod().Name("p").UID("p").Label("foo", "").Priority(highPriority).
+				SpreadConstraint(1, "zone", v1.DoNotSchedule, fooSelector).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").Obj(),
+				st.MakePod().Name("pod-x").UID("pod-x").Node("node-x").Priority(highPriority).Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Capacity(onePodRes).Obj(),
+			},
+			nodesStatuses: framework.NodeToStatusMap{
+				"node-a": framework.NewStatus(framework.Unschedulable),
+				"node-b": framework.NewStatus(framework.Unschedulable),
+				"node-x": framework.NewStatus(framework.Unschedulable),
+			},
+			registerPlugins: []st.RegisterPluginFunc{
+				st.RegisterPluginAsExtensions(noderesources.FitName, noderesources.NewFit, "Filter", "PreFilter"),
+				st.RegisterPluginAsExtensions(podtopologyspread.Name, podtopologyspread.New, "PreFilter", "Filter"),
+			},
+			want: []dp.Candidate{
+				&candidate{
+					victims: []*v1.Pod{
+						st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").Obj(),
+						st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").Obj(),
+					},
+					name: "node-a",
+				},
+				&candidate{
+					victims: []*v1.Pod{
+						st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").Obj(),
+						st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").Obj(),
+					},
+					name: "node-b",
+				},
+			},
+		},
+		{
+			name: "resolve PodAntiAffinity constraint",
+			pod: st.MakePod().Name("p").UID("p").Label("foo", "").Priority(highPriority).
+				PodAntiAffinityExists("foo", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").Obj(),
+				st.MakePod().Name("pod-x").UID("pod-x").Node("node-x").Priority(highPriority).Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Capacity(onePodRes).Obj(),
+			},
+			nodesStatuses: framework.NodeToStatusMap{
+				"node-a": framework.NewStatus(framework.Unschedulable),
+				"node-b": framework.NewStatus(framework.Unschedulable),
+				"node-x": framework.NewStatus(framework.Unschedulable),
+			},
+			registerPlugins: []st.RegisterPluginFunc{
+				st.RegisterPluginAsExtensions(noderesources.FitName, noderesources.NewFit, "Filter", "PreFilter"),
+				st.RegisterPluginAsExtensions(interpodaffinity.Name, interpodaffinity.New, "PreFilter", "Filter"),
+			},
+			want: []dp.Candidate{
+				&candidate{
+					victims: []*v1.Pod{
+						st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").Obj(),
+						st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").Obj(),
+					},
+					name: "node-a",
+				},
+				&candidate{
+					victims: []*v1.Pod{
+						st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").Obj(),
+						st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").Obj(),
+					},
+					name: "node-b",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registeredPlugins := append(
+				tt.registerPlugins,
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			)
+			cs := clientsetfake.NewSimpleClientset()
+			fwk, err := st.NewFramework(
+				registeredPlugins,
+				frameworkruntime.WithClientSet(cs),
+				frameworkruntime.WithEventRecorder(&events.FakeRecorder{}),
+				frameworkruntime.WithPodNominator(testutil.NewPodNominator()),
+				frameworkruntime.WithSnapshotSharedLister(testutil.NewFakeSharedLister(tt.pods, tt.nodes)),
+				frameworkruntime.WithInformerFactory(informers.NewSharedInformerFactory(cs, 0)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			state := framework.NewCycleState()
+			ctx := context.Background()
+			// Some tests rely on PreFilter plugin to compute its CycleState.
+			preFilterStatus := fwk.RunPreFilterPlugins(ctx, state, tt.pod)
+			if !preFilterStatus.IsSuccess() {
+				t.Errorf("Unexpected preFilterStatus: %v", preFilterStatus)
+			}
+
+			got, err := FindCandidates(ctx, state, tt.pod, tt.nodesStatuses, fwk.PreemptHandle(), fwk.SnapshotSharedLister().NodeInfos())
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Sort the values (inner victims) and the candidate itself (by its NominatedNodeName).
+			for i := range got {
+				victims := got[i].Victims().Pods
+				sort.Slice(victims, func(i, j int) bool {
+					return victims[i].Name < victims[j].Name
+				})
+			}
+			sort.Slice(got, func(i, j int) bool {
+				return got[i].Name() < got[j].Name()
+			})
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(candidate{})); diff != "" {
+				t.Errorf("Unexpected candidates (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/test/integration/coscheduling_test.go
+++ b/test/integration/coscheduling_test.go
@@ -264,8 +264,8 @@ func TestCoschedulingPlugin(t *testing.T) {
 }
 
 // podScheduled returns true if a node is assigned to the given pod.
-func podScheduled(c clientset.Interface, podNamespace, podName string) bool {
-	pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func podScheduled(cs clientset.Interface, podNamespace, podName string) bool {
+	pod, err := cs.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
 		// This could be a connection error so we want to retry.
 		return false

--- a/test/integration/cross_node_preemption_test.go
+++ b/test/integration/cross_node_preemption_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/scheduler"
+	schedapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	fwkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	testutils "k8s.io/kubernetes/test/integration/util"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	"sigs.k8s.io/scheduler-plugins/pkg/crossnodepreemption"
+	"sigs.k8s.io/scheduler-plugins/test/util"
+)
+
+func TestCrossNodePreemptionPlugin(t *testing.T) {
+	fooSelector := st.MakeLabelSelector().Exists("foo").Obj()
+	zeroPodRes := map[v1.ResourceName]string{v1.ResourcePods: "0"}
+	pause := imageutils.GetPauseImageName()
+
+	tests := []struct {
+		name  string
+		pod   *v1.Pod
+		pods  []*v1.Pod
+		nodes []*v1.Node
+	}{
+		{
+			name: "PodTopologySpread: preempt 2 pods in zone1",
+			pod: st.MakePod().Name("p").UID("p").Label("foo", "").Priority(highPriority).Container(pause).
+				SpreadConstraint(1, "zone", v1.DoNotSchedule, fooSelector).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").ZeroTerminationGracePeriod().Container(pause).Obj(),
+				st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").ZeroTerminationGracePeriod().Container(pause).Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Capacity(zeroPodRes).Obj(),
+			},
+		},
+		{
+			name: "PodAntiAffinity: preempt 2 pods in zone1",
+			pod: st.MakePod().Name("p").UID("p").Label("foo", "").Priority(highPriority).Container(pause).
+				PodAntiAffinityExists("foo", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod-a").UID("pod-a").Node("node-a").Label("foo", "").ZeroTerminationGracePeriod().Container(pause).Obj(),
+				st.MakePod().Name("pod-b").UID("pod-b").Node("node-b").Label("foo", "").ZeroTerminationGracePeriod().Container(pause).Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Capacity(zeroPodRes).Obj(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := fwkruntime.Registry{crossnodepreemption.Name: crossnodepreemption.New}
+			profile := schedapi.KubeSchedulerProfile{
+				SchedulerName: v1.DefaultSchedulerName,
+				Plugins: &schedapi.Plugins{
+					PostFilter: &schedapi.PluginSet{
+						Enabled: []schedapi.Plugin{
+							{Name: crossnodepreemption.Name},
+						},
+					},
+				},
+			}
+			testCtx := util.InitTestSchedulerWithOptions(
+				t,
+				testutils.InitTestMaster(t, "sched-crossnodepreemption", nil),
+				true,
+				scheduler.WithProfiles(profile),
+				scheduler.WithFrameworkOutOfTreeRegistry(registry),
+			)
+			defer testutils.CleanupTest(t, testCtx)
+
+			cs, ns := testCtx.ClientSet, testCtx.NS.Name
+			// Create nodes and pods.
+			for _, node := range tt.nodes {
+				if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create node: %v", err)
+				}
+			}
+			for _, pod := range tt.pods {
+				if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, pod, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create Pod %q: %v", pod.Name, err)
+				}
+			}
+
+			// Create the preemptor Pod.
+			if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, tt.pod, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create preemptor Pod %q: %v", tt.pod.Name, err)
+			}
+			// Ensure the preemtor Pod is scheduled successfully.
+			if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
+				return podScheduled(cs, ns, tt.pod.Name), nil
+			}); err != nil {
+				t.Errorf("preemptor pod %q failed to be scheduled: %v", tt.pod.Name, err)
+			}
+
+			// Lastly, existing Pods are expected to be preempted.
+			for _, pod := range tt.pods {
+				if err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+					return podNotExist(cs, ns, pod.Name), nil
+				}); err != nil {
+					t.Errorf("preemptor pod %q failed to be scheduled: %v", tt.pod.Name, err)
+				}
+			}
+		})
+	}
+}
+
+// podNotExist returns true if the given pod not exists.
+func podNotExist(cs clientset.Interface, podNamespace, podName string) bool {
+	_, err := cs.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	return errors.IsNotFound(err)
+}

--- a/test/util/fake.go
+++ b/test/util/fake.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+var _ framework.SharedLister = &fakeSharedLister{}
+
+type fakeSharedLister struct {
+	nodeInfos                        []*framework.NodeInfo
+	nodeInfoMap                      map[string]*framework.NodeInfo
+	havePodsWithAffinityNodeInfoList []*framework.NodeInfo
+}
+
+func NewFakeSharedLister(pods []*v1.Pod, nodes []*v1.Node) *fakeSharedLister {
+	nodeInfoMap := createNodeInfoMap(pods, nodes)
+	nodeInfos := make([]*framework.NodeInfo, 0, len(nodeInfoMap))
+	havePodsWithAffinityNodeInfoList := make([]*framework.NodeInfo, 0, len(nodeInfoMap))
+	for _, v := range nodeInfoMap {
+		nodeInfos = append(nodeInfos, v)
+		if len(v.PodsWithAffinity) > 0 {
+			havePodsWithAffinityNodeInfoList = append(havePodsWithAffinityNodeInfoList, v)
+		}
+	}
+	return &fakeSharedLister{
+		nodeInfos:                        nodeInfos,
+		nodeInfoMap:                      nodeInfoMap,
+		havePodsWithAffinityNodeInfoList: havePodsWithAffinityNodeInfoList,
+	}
+}
+
+func createNodeInfoMap(pods []*v1.Pod, nodes []*v1.Node) map[string]*framework.NodeInfo {
+	nodeNameToInfo := make(map[string]*framework.NodeInfo)
+	for _, pod := range pods {
+		nodeName := pod.Spec.NodeName
+		if _, ok := nodeNameToInfo[nodeName]; !ok {
+			nodeNameToInfo[nodeName] = framework.NewNodeInfo()
+		}
+		nodeNameToInfo[nodeName].AddPod(pod)
+	}
+
+	for _, node := range nodes {
+		if _, ok := nodeNameToInfo[node.Name]; !ok {
+			nodeNameToInfo[node.Name] = framework.NewNodeInfo()
+		}
+		nodeInfo := nodeNameToInfo[node.Name]
+		nodeInfo.SetNode(node)
+	}
+	return nodeNameToInfo
+}
+
+func (f *fakeSharedLister) NodeInfos() framework.NodeInfoLister {
+	return f
+}
+
+func (f *fakeSharedLister) List() ([]*framework.NodeInfo, error) {
+	return f.nodeInfos, nil
+}
+
+func (f *fakeSharedLister) HavePodsWithAffinityList() ([]*framework.NodeInfo, error) {
+	return f.havePodsWithAffinityNodeInfoList, nil
+}
+
+func (f *fakeSharedLister) Get(nodeName string) (*framework.NodeInfo, error) {
+	return f.nodeInfoMap[nodeName], nil
+}
+
+/*
+ * Copied from upstream.
+ */
+
+// nominatedPodMap is a structure that stores pods nominated to run on nodes.
+// It exists because nominatedNodeName of pod objects stored in the structure
+// may be different than what scheduler has here. We should be able to find pods
+// by their UID and update/delete them.
+type nominatedPodMap struct {
+	// nominatedPods is a map keyed by a node name and the value is a list of
+	// pods which are nominated to run on the node. These are pods which can be in
+	// the activeQ or unschedulableQ.
+	nominatedPods map[string][]*v1.Pod
+	// nominatedPodToNode is map keyed by a Pod UID to the node name where it is
+	// nominated.
+	nominatedPodToNode map[ktypes.UID]string
+
+	sync.RWMutex
+}
+
+func (npm *nominatedPodMap) add(p *v1.Pod, nodeName string) {
+	// always delete the pod if it already exist, to ensure we never store more than
+	// one instance of the pod.
+	npm.delete(p)
+
+	nnn := nodeName
+	if len(nnn) == 0 {
+		nnn = NominatedNodeName(p)
+		if len(nnn) == 0 {
+			return
+		}
+	}
+	npm.nominatedPodToNode[p.UID] = nnn
+	for _, np := range npm.nominatedPods[nnn] {
+		if np.UID == p.UID {
+			klog.V(4).Infof("Pod %v/%v already exists in the nominated map!", p.Namespace, p.Name)
+			return
+		}
+	}
+	npm.nominatedPods[nnn] = append(npm.nominatedPods[nnn], p)
+}
+
+func (npm *nominatedPodMap) delete(p *v1.Pod) {
+	nnn, ok := npm.nominatedPodToNode[p.UID]
+	if !ok {
+		return
+	}
+	for i, np := range npm.nominatedPods[nnn] {
+		if np.UID == p.UID {
+			npm.nominatedPods[nnn] = append(npm.nominatedPods[nnn][:i], npm.nominatedPods[nnn][i+1:]...)
+			if len(npm.nominatedPods[nnn]) == 0 {
+				delete(npm.nominatedPods, nnn)
+			}
+			break
+		}
+	}
+	delete(npm.nominatedPodToNode, p.UID)
+}
+
+// UpdateNominatedPod updates the <oldPod> with <newPod>.
+func (npm *nominatedPodMap) UpdateNominatedPod(oldPod, newPod *v1.Pod) {
+	npm.Lock()
+	defer npm.Unlock()
+	// In some cases, an Update event with no "NominatedNode" present is received right
+	// after a node("NominatedNode") is reserved for this pod in memory.
+	// In this case, we need to keep reserving the NominatedNode when updating the pod pointer.
+	nodeName := ""
+	// We won't fall into below `if` block if the Update event represents:
+	// (1) NominatedNode info is added
+	// (2) NominatedNode info is updated
+	// (3) NominatedNode info is removed
+	if NominatedNodeName(oldPod) == "" && NominatedNodeName(newPod) == "" {
+		if nnn, ok := npm.nominatedPodToNode[oldPod.UID]; ok {
+			// This is the only case we should continue reserving the NominatedNode
+			nodeName = nnn
+		}
+	}
+	// We update irrespective of the nominatedNodeName changed or not, to ensure
+	// that pod pointer is updated.
+	npm.delete(oldPod)
+	npm.add(newPod, nodeName)
+}
+
+// NewPodNominator creates a nominatedPodMap as a backing of framework.PodNominator.
+func NewPodNominator() framework.PodNominator {
+	return &nominatedPodMap{
+		nominatedPods:      make(map[string][]*v1.Pod),
+		nominatedPodToNode: make(map[ktypes.UID]string),
+	}
+}
+
+// NominatedNodeName returns nominated node name of a Pod.
+func NominatedNodeName(pod *v1.Pod) string {
+	return pod.Status.NominatedNodeName
+}
+
+// DeleteNominatedPodIfExists deletes <pod> from nominatedPods.
+func (npm *nominatedPodMap) DeleteNominatedPodIfExists(pod *v1.Pod) {
+	npm.Lock()
+	npm.delete(pod)
+	npm.Unlock()
+}
+
+// AddNominatedPod adds a pod to the nominated pods of the given node.
+// This is called during the preemption process after a node is nominated to run
+// the pod. We update the structure before sending a request to update the pod
+// object to avoid races with the following scheduling cycles.
+func (npm *nominatedPodMap) AddNominatedPod(pod *v1.Pod, nodeName string) {
+	npm.Lock()
+	npm.add(pod, nodeName)
+	npm.Unlock()
+}
+
+// NominatedPodsForNode returns pods that are nominated to run on the given node,
+// but they are waiting for other pods to be removed from the node.
+func (npm *nominatedPodMap) NominatedPodsForNode(nodeName string) []*v1.Pod {
+	npm.RLock()
+	defer npm.RUnlock()
+	// TODO: we may need to return a copy of []*Pods to avoid modification
+	// on the caller side.
+	return npm.nominatedPods[nodeName]
+}


### PR DESCRIPTION
The PostFilter extension point was introduced in Kubernetes Scheduler since 1.19,
and the default implementation in upstream is to preempt Pods **on the same node**
to make room for the unschedulable Pod.

In contrast to the "same-node-preemption" strategy, we can come up with a "cross-node-preemption"
strategy to preempt Pods across multiple nodes, which is useful when a Pod cannot be
scheduled due to "cross node" constraints such as PodTopologySpread and PodAntiAffinity.
This was also mentioned in the original design document of [Preemption].

[Preemption]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-preemption.md#supporting-cross-node-preemption

This plugin is built as a sample to demonstrate how to use PostFilter extension point,
as well as inspiring users to built their own innovative strategies, such as preepmpting
a group of Pods.

> ⚠️ CAVEAT: Current implementation doesn't do any branch cutting, but uses a DFS algorithm
> to iterate all possible preemption strategies. DO NOT use it in your production env.