### PR TITLE
Use concrete type in unversioned (internal) API fields

### DIFF
--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -27,12 +27,12 @@ type CoschedulingArgs struct {
 	metav1.TypeMeta
 
 	// PermitWaitingTime is the wait timeout in seconds.
-	PermitWaitingTimeSeconds *int64
+	PermitWaitingTimeSeconds int64
 	// PodGroupGCInterval is the period to run gc of PodGroup in seconds.
-	PodGroupGCIntervalSeconds *int64
+	PodGroupGCIntervalSeconds int64
 	// If the deleted PodGroup stays longer than the PodGroupExpirationTime,
 	// the PodGroup will be deleted from PodGroupInfos.
-	PodGroupExpirationTimeSeconds *int64
+	PodGroupExpirationTimeSeconds int64
 }
 
 // modes type.
@@ -57,7 +57,7 @@ type NodeResourcesAllocatableArgs struct {
 	Resources []schedulerconfig.ResourceSpec `json:"resources,omitempty"`
 
 	// Whether to prioritize nodes with least or most allocatable resources.
-	Mode *ModeType `json:"mode,omitempty"`
+	Mode ModeType `json:"mode,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/config/v1beta1/defaults.go
+++ b/pkg/apis/config/v1beta1/defaults.go
@@ -25,7 +25,7 @@ var (
 	defaultPodGroupGCIntervalSeconds     int64 = 30
 	defaultPodGroupExpirationTimeSeconds int64 = 600
 
-	defaultNodeResourcesAllocatableMode ModeType = Least
+	defaultNodeResourcesAllocatableMode = Least
 
 	// defaultResourcesToWeightMap is used to set the default resourceToWeight map for CPU and memory
 	// used by the NodeResourcesAllocatable scoring plugin.
@@ -52,12 +52,12 @@ func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 }
 
 func SetDefaults_NodeResourcesAllocatableArgs(obj *NodeResourcesAllocatableArgs) {
-	if obj.Resources == nil {
+	if len(obj.Resources) == 0 {
 		obj.Resources = defaultNodeResourcesAllocatableResourcesToWeightMap
 	}
 
-	if obj.Mode == nil {
-		obj.Mode = &defaultNodeResourcesAllocatableMode
+	if obj.Mode == "" {
+		obj.Mode = defaultNodeResourcesAllocatableMode
 	}
 }
 

--- a/pkg/apis/config/v1beta1/types.go
+++ b/pkg/apis/config/v1beta1/types.go
@@ -58,7 +58,7 @@ type NodeResourcesAllocatableArgs struct {
 	Resources []schedulerconfig.ResourceSpec `json:"resources,omitempty"`
 
 	// Whether to prioritize nodes with least or most allocatable resources.
-	Mode *ModeType `json:"mode,omitempty"`
+	Mode ModeType `json:"mode,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1beta1/zz_generated.conversion.go
@@ -95,9 +95,15 @@ func Convert_config_CapacitySchedulingArgs_To_v1beta1_CapacitySchedulingArgs(in 
 }
 
 func autoConvert_v1beta1_CoschedulingArgs_To_config_CoschedulingArgs(in *CoschedulingArgs, out *config.CoschedulingArgs, s conversion.Scope) error {
-	out.PermitWaitingTimeSeconds = (*int64)(unsafe.Pointer(in.PermitWaitingTimeSeconds))
-	out.PodGroupGCIntervalSeconds = (*int64)(unsafe.Pointer(in.PodGroupGCIntervalSeconds))
-	out.PodGroupExpirationTimeSeconds = (*int64)(unsafe.Pointer(in.PodGroupExpirationTimeSeconds))
+	if err := v1.Convert_Pointer_int64_To_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int64_To_int64(&in.PodGroupGCIntervalSeconds, &out.PodGroupGCIntervalSeconds, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int64_To_int64(&in.PodGroupExpirationTimeSeconds, &out.PodGroupExpirationTimeSeconds, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -107,9 +113,15 @@ func Convert_v1beta1_CoschedulingArgs_To_config_CoschedulingArgs(in *Coschedulin
 }
 
 func autoConvert_config_CoschedulingArgs_To_v1beta1_CoschedulingArgs(in *config.CoschedulingArgs, out *CoschedulingArgs, s conversion.Scope) error {
-	out.PermitWaitingTimeSeconds = (*int64)(unsafe.Pointer(in.PermitWaitingTimeSeconds))
-	out.PodGroupGCIntervalSeconds = (*int64)(unsafe.Pointer(in.PodGroupGCIntervalSeconds))
-	out.PodGroupExpirationTimeSeconds = (*int64)(unsafe.Pointer(in.PodGroupExpirationTimeSeconds))
+	if err := v1.Convert_int64_To_Pointer_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_int64_To_Pointer_int64(&in.PodGroupGCIntervalSeconds, &out.PodGroupGCIntervalSeconds, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_int64_To_Pointer_int64(&in.PodGroupExpirationTimeSeconds, &out.PodGroupExpirationTimeSeconds, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -120,7 +132,7 @@ func Convert_config_CoschedulingArgs_To_v1beta1_CoschedulingArgs(in *config.Cosc
 
 func autoConvert_v1beta1_NodeResourcesAllocatableArgs_To_config_NodeResourcesAllocatableArgs(in *NodeResourcesAllocatableArgs, out *config.NodeResourcesAllocatableArgs, s conversion.Scope) error {
 	out.Resources = *(*[]configv1.ResourceSpec)(unsafe.Pointer(&in.Resources))
-	out.Mode = (*config.ModeType)(unsafe.Pointer(in.Mode))
+	out.Mode = config.ModeType(in.Mode)
 	return nil
 }
 
@@ -131,7 +143,7 @@ func Convert_v1beta1_NodeResourcesAllocatableArgs_To_config_NodeResourcesAllocat
 
 func autoConvert_config_NodeResourcesAllocatableArgs_To_v1beta1_NodeResourcesAllocatableArgs(in *config.NodeResourcesAllocatableArgs, out *NodeResourcesAllocatableArgs, s conversion.Scope) error {
 	out.Resources = *(*[]configv1.ResourceSpec)(unsafe.Pointer(&in.Resources))
-	out.Mode = (*ModeType)(unsafe.Pointer(in.Mode))
+	out.Mode = ModeType(in.Mode)
 	return nil
 }
 

--- a/pkg/apis/config/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1beta1/zz_generated.deepcopy.go
@@ -104,11 +104,6 @@ func (in *NodeResourcesAllocatableArgs) DeepCopyInto(out *NodeResourcesAllocatab
 		*out = make([]v1.ResourceSpec, len(*in))
 		copy(*out, *in)
 	}
-	if in.Mode != nil {
-		in, out := &in.Mode, &out.Mode
-		*out = new(ModeType)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -54,21 +54,6 @@ func (in *CapacitySchedulingArgs) DeepCopyObject() runtime.Object {
 func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.PermitWaitingTimeSeconds != nil {
-		in, out := &in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds
-		*out = new(int64)
-		**out = **in
-	}
-	if in.PodGroupGCIntervalSeconds != nil {
-		in, out := &in.PodGroupGCIntervalSeconds, &out.PodGroupGCIntervalSeconds
-		*out = new(int64)
-		**out = **in
-	}
-	if in.PodGroupExpirationTimeSeconds != nil {
-		in, out := &in.PodGroupExpirationTimeSeconds, &out.PodGroupExpirationTimeSeconds
-		*out = new(int64)
-		**out = **in
-	}
 	return
 }
 
@@ -98,11 +83,6 @@ func (in *NodeResourcesAllocatableArgs) DeepCopyInto(out *NodeResourcesAllocatab
 		in, out := &in.Resources, &out.Resources
 		*out = make([]v1.ResourceSpec, len(*in))
 		copy(*out, *in)
-	}
-	if in.Mode != nil {
-		in, out := &in.Mode, &out.Mode
-		*out = new(ModeType)
-		**out = **in
 	}
 	return
 }

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -123,7 +123,7 @@ func New(obj runtime.Object, handle framework.FrameworkHandle) (framework.Plugin
 			},
 		},
 	)
-	go wait.Until(cs.podGroupInfoGC, time.Duration(*cs.args.PodGroupGCIntervalSeconds)*time.Second, nil)
+	go wait.Until(cs.podGroupInfoGC, time.Duration(cs.args.PodGroupGCIntervalSeconds)*time.Second, nil)
 
 	return cs, nil
 }
@@ -259,7 +259,7 @@ func (cs *Coscheduling) Permit(ctx context.Context, state *framework.CycleState,
 		klog.V(3).Infof("The count of podGroup %v/%v/%v is not up to minAvailable(%d) in Permit: current(%d)",
 			pod.Namespace, podGroupName, pod.Name, minAvailable, current)
 		// TODO Change the timeout to a dynamic value depending on the size of the `PodGroup`
-		return framework.NewStatus(framework.Wait, ""), time.Duration(*cs.args.PermitWaitingTimeSeconds) * time.Second
+		return framework.NewStatus(framework.Wait, ""), time.Duration(cs.args.PermitWaitingTimeSeconds) * time.Second
 	}
 
 	klog.V(3).Infof("The count of PodGroup %v/%v/%v is up to minAvailable(%d) in Permit: current(%d)",
@@ -380,7 +380,7 @@ func responsibleForPod(pod *v1.Pod) bool {
 func (cs *Coscheduling) podGroupInfoGC() {
 	cs.podGroupInfos.Range(func(key, value interface{}) bool {
 		pgInfo := value.(*PodGroupInfo)
-		if pgInfo.deletionTimestamp != nil && pgInfo.deletionTimestamp.Add(time.Duration(*cs.args.PodGroupExpirationTimeSeconds)*time.Second).Before(cs.clock.Now()) {
+		if pgInfo.deletionTimestamp != nil && pgInfo.deletionTimestamp.Add(time.Duration(cs.args.PodGroupExpirationTimeSeconds)*time.Second).Before(cs.clock.Now()) {
 			klog.V(3).Infof("%v is out of date and has been deleted in PodGroup GC", key)
 			cs.podGroupInfos.Delete(key)
 		}

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -39,18 +39,13 @@ import (
 	_ "sigs.k8s.io/scheduler-plugins/pkg/apis/config/scheme"
 )
 
-func newInt64(i int64) *int64 {
-	val := i
-	return &val
-}
-
 // FakeNew is used for test.
 func FakeNew(clock util.Clock, args config.CoschedulingArgs, stop chan struct{}) (*Coscheduling, error) {
 	cs := &Coscheduling{
 		clock: clock,
 		args:  args,
 	}
-	go wait.Until(cs.podGroupInfoGC, time.Duration(*cs.args.PodGroupGCIntervalSeconds)*time.Second, stop)
+	go wait.Until(cs.podGroupInfoGC, time.Duration(cs.args.PodGroupGCIntervalSeconds)*time.Second, stop)
 	return cs, nil
 }
 
@@ -536,9 +531,9 @@ func TestPodGroupClean(t *testing.T) {
 
 			c := clock.NewFakeClock(time.Now())
 			cs, err := FakeNew(c, config.CoschedulingArgs{
-				PermitWaitingTimeSeconds:      newInt64(1),
-				PodGroupGCIntervalSeconds:     newInt64(3),
-				PodGroupExpirationTimeSeconds: newInt64(10),
+				PermitWaitingTimeSeconds:      1,
+				PodGroupGCIntervalSeconds:     3,
+				PodGroupExpirationTimeSeconds: 10,
 			}, stop)
 
 			if err != nil {
@@ -557,9 +552,9 @@ func TestPodGroupClean(t *testing.T) {
 				t.Fatalf("fail to clean up PodGroup : %s", tt.pod.Name)
 			}
 
-			c.Step(time.Duration(*cs.args.PodGroupExpirationTimeSeconds)*time.Second + time.Second)
+			c.Step(time.Duration(cs.args.PodGroupExpirationTimeSeconds)*time.Second + time.Second)
 			// Wait for asynchronous deletion.
-			err = wait.Poll(time.Millisecond*200, time.Duration(*cs.args.PodGroupGCIntervalSeconds+1)*time.Second, func() (bool, error) {
+			err = wait.Poll(time.Millisecond*200, time.Duration(cs.args.PodGroupGCIntervalSeconds+1)*time.Second, func() (bool, error) {
 				_, ok = cs.podGroupInfos.Load(fmt.Sprintf("%v/%v", tt.pod.Namespace, tt.podGroupName))
 				return !ok, nil
 			})

--- a/pkg/noderesources/allocatable.go
+++ b/pkg/noderesources/allocatable.go
@@ -88,8 +88,8 @@ func NewAllocatable(allocArgs runtime.Object, h framework.FrameworkHandle) (fram
 		if !ok {
 			return nil, fmt.Errorf("want args to be of type NodeResourcesAllocatableArgs, got %T", allocArgs)
 		}
-		if args.Mode != nil {
-			mode = *args.Mode
+		if args.Mode != "" {
+			mode = args.Mode
 			if mode != config.Least && mode != config.Most {
 				return nil, fmt.Errorf("invalid mode, got %s", mode)
 			}

--- a/pkg/noderesources/allocatable_test.go
+++ b/pkg/noderesources/allocatable_test.go
@@ -112,28 +112,28 @@ func TestNodeResourcesAllocatable(t *testing.T) {
 		{
 			pod:          &v1.Pod{Spec: noResources},
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 4000, 10000), makeNodeInfo("machine2", 4000, 10000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeLeast},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MinNodeScore}, {Name: "machine2", Score: framework.MinNodeScore}},
 			name:         "nothing scheduled, nothing requested",
 		},
 		{
 			pod:          cpuAndMemory,
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 4000, 10000), makeNodeInfo("machine2", 6000, 10000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeLeast},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MaxNodeScore}, {Name: "machine2", Score: framework.MinNodeScore}},
 			name:         "nothing scheduled, resources requested, differently sized machines, least mode",
 		},
 		{
 			pod:          cpuAndMemory,
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 4000, 10000), makeNodeInfo("machine2", 6000, 10000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeMost},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeMost},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MinNodeScore}, {Name: "machine2", Score: framework.MaxNodeScore}},
 			name:         "nothing scheduled, resources requested, differently sized machines, most mode",
 		},
 		{
 			pod:          &v1.Pod{Spec: noResources},
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 4000, 10000), makeNodeInfo("machine2", 4000, 10000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeLeast},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MinNodeScore}, {Name: "machine2", Score: framework.MinNodeScore}},
 			name:         "no resources requested, pods scheduled",
 			pods: []*v1.Pod{
@@ -146,7 +146,7 @@ func TestNodeResourcesAllocatable(t *testing.T) {
 		{
 			pod:          &v1.Pod{Spec: noResources},
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 10000, 20000), makeNodeInfo("machine2", 10000, 20000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeLeast},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MinNodeScore}, {Name: "machine2", Score: framework.MinNodeScore}},
 			name:         "no resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
@@ -156,7 +156,7 @@ func TestNodeResourcesAllocatable(t *testing.T) {
 		{
 			pod:          cpuAndMemory,
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 10000, 20000), makeNodeInfo("machine2", 10000, 20000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeLeast},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MinNodeScore}, {Name: "machine2", Score: framework.MinNodeScore}},
 			name:         "resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
@@ -166,28 +166,28 @@ func TestNodeResourcesAllocatable(t *testing.T) {
 		{
 			pod:          bigCpu,
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 4000, 1000), makeNodeInfo("machine2", 5000, 1000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeLeast},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MaxNodeScore}, {Name: "machine2", Score: framework.MinNodeScore}},
 			name:         "resources requested with more than the node, differently sized machines, least mode",
 		},
 		{
 			pod:          bigCpu,
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 4000, 1000), makeNodeInfo("machine2", 5000, 1000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeMost},
+			args:         config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeMost},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MinNodeScore}, {Name: "machine2", Score: framework.MaxNodeScore}},
 			name:         "resources requested with more than the node, differently sized machines, most mode",
 		},
 		{
 			pod:          cpuAndMemory,
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 1000, 2000), makeNodeInfo("machine2", 1005, 1000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: cpuResourceAllocatableSet, Mode: &modeLeast},
+			args:         config.NodeResourcesAllocatableArgs{Resources: cpuResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MaxNodeScore}, {Name: "machine2", Score: framework.MinNodeScore}},
 			name:         "nothing scheduled, resources requested, differently sized machines, cpu weighted, most mode",
 		},
 		{
 			pod:          cpuAndMemory,
 			nodeInfos:    []*framework.NodeInfo{makeNodeInfo("machine1", 1000, 2000), makeNodeInfo("machine2", 1005, 1000)},
-			args:         config.NodeResourcesAllocatableArgs{Resources: cpuResourceAllocatableSet, Mode: &modeMost},
+			args:         config.NodeResourcesAllocatableArgs{Resources: cpuResourceAllocatableSet, Mode: modeMost},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MinNodeScore}, {Name: "machine2", Score: framework.MaxNodeScore}},
 			name:         "nothing scheduled, resources requested, differently sized machines, cpu weighted, least mode",
 		},
@@ -197,7 +197,7 @@ func TestNodeResourcesAllocatable(t *testing.T) {
 				makeNodeInfo("machine1", 1000, 1000*1<<20),
 				makeNodeInfo("machine2", 2000, 2000*1<<20),
 				makeNodeInfo("machine3", 3000, 3000*1<<20)},
-			args: config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeLeast},
+			args: config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeLeast},
 			expectedList: []framework.NodeScore{
 				{Name: "machine1", Score: framework.MaxNodeScore},
 				{Name: "machine2", Score: (framework.MinNodeScore + framework.MaxNodeScore) / 2},
@@ -210,7 +210,7 @@ func TestNodeResourcesAllocatable(t *testing.T) {
 				makeNodeInfo("machine1", 1000, 1000*1<<20),
 				makeNodeInfo("machine2", 2000, 2000*1<<20),
 				makeNodeInfo("machine3", 3000, 3000*1<<20)},
-			args: config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: &modeMost},
+			args: config.NodeResourcesAllocatableArgs{Resources: defaultResourceAllocatableSet, Mode: modeMost},
 			expectedList: []framework.NodeScore{
 				{Name: "machine1", Score: framework.MinNodeScore},
 				{Name: "machine2", Score: (framework.MinNodeScore + framework.MaxNodeScore) / 2},


### PR DESCRIPTION
Kubernetes supports smooth conversion between different versions of API objects, however, when the type in versioned pkg is defined as a pointer, the corresponding unversioned type doesn't need to defined as a pointer - as it's used internally and converted from the outbound versioned API object.

This PR corrects the nits across scheduler-plugin codebase.

Another change is on const string, I'm inclined to follow the pattern of upstream (e.g., `Protocol`) to make it as a concrete type, even in versioned pkg:

- https://github.com/kubernetes/kubernetes/blob/aad834b0733b17579dc07f7ced775278a5b9d978/staging/src/k8s.io/api/core/v1/types.go#L4378-L4382
- https://github.com/kubernetes/kubernetes/blob/aad834b0733b17579dc07f7ced775278a5b9d978/pkg/apis/core/v1/defaults.go#L74-L78