### PR TITLE
Work Around Git Command Failure In Image Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LOCAL_CONTROLLER_IMAGE=controller:latest
 # into. The default is to push to the staging
 # registry, not production(k8s.gcr.io).
 RELEASE_REGISTRY?=gcr.io/k8s-staging-scheduler-plugins
-RELEASE_VERSION?=$(shell git describe --tags --match "v*")
+RELEASE_VERSION?=$(shell git describe --tags --match "v*" || date +%Y-%m-%d-%H-%M-%S)
 RELEASE_IMAGE:=kube-scheduler:$(RELEASE_VERSION)
 RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
 


### PR DESCRIPTION
The automated container image builds are failing with the below error in
the logs.

fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
docker build -t gcr.io/k8s-staging-scheduler-plugins/kube-scheduler: .
invalid argument "gcr.io/k8s-staging-scheduler-plugins/kube-scheduler:" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.

This work around will fall back to using the date command if the
"git describe" command fails. This will ensure that the RELEASE_VERSION
variable is always set to a non-empty string.