### PR TITLE
Improve coscheduling's PodGroup cleanup

### DIFF
--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -174,6 +174,7 @@ func (cs *Coscheduling) getOrCreatePodGroupInfo(pod *v1.Pod, ts time.Time) (*Pod
 			// If the deleteTimestamp isn't nil, it means that the PodGroup is marked as expired before.
 			// So we need to set the deleteTimestamp as nil again to mark the PodGroup active.
 			if pgInfo.deletionTimestamp != nil {
+				pgInfo.minAvailable = podMinAvailable
 				pgInfo.deletionTimestamp = nil
 				cs.podGroupInfos.Store(pgKey, pgInfo)
 			}


### PR DESCRIPTION
When a new pod with a PodGroup is submitted, if the PodGroup exists but has to be cleaned up (GC) yet, the current implementation resets the PodGroup active but still uses the existing PodGroup's minAvailable. Thus, deleting a PodGroup, updating its minAvailable and resubmitting it won't work.

This PR makes a simple improvement by updating the existing PodGroup's minAvailable value by the new Pod's. It works for general cases and allows us to use a larger GC interval.

