### PR TITLE
Speed Up Docker Image Build Times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,15 @@ RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
 all: build
 
 .PHONY: build
-build: autogen
-	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/kube-scheduler cmd/scheduler/main.go
+build: build-controller build-scheduler
+
+.PHONY: build-controller
+build-controller: autogen
 	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/controller cmd/controller/controller.go
+
+.PHONY: build-scheduler
+build-scheduler: autogen
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/kube-scheduler cmd/scheduler/main.go
 
 .PHONY: local-image
 local-image: clean

--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -15,7 +15,7 @@ FROM golang:1.15.0
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
-RUN make
+RUN make build-controller
 
 FROM alpine:3.12
 

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -15,7 +15,7 @@ FROM golang:1.15.0
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
-RUN make
+RUN make build-scheduler
 
 FROM alpine:3.12
 


### PR DESCRIPTION
Prior to this change the docker image builds would always compile both
binaries(scheduler and controller). Now only build the a controller
binary for the controller docker image, and only build the scheduler
binary for the scheduler docker image.