### PR TITLE
Update "make clean" To Only Delete Specific Files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,4 +83,5 @@ verify-gofmt:
 
 .PHONY: clean
 clean:
-	rm -rf ./bin
+	rm -f ./bin/controller
+	rm -f ./bin/kube-scheduler


### PR DESCRIPTION
This is an attempt to fix the broken automated container image builds
for k8s.gcr.io. The below error is currently being reported in the build
logs.

fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
docker build -t gcr.io/k8s-staging-scheduler-plugins/kube-scheduler: .
invalid argument "gcr.io/k8s-staging-scheduler-plugins/kube-scheduler:"
for "-t, --tag" flag: invalid reference format
See 'docker build --help'.