### PR TITLE
Fix Automated Container Image Builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
-    - VERSION=$_GIT_TAG
+    - RELEASE_VERSION=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
     args:
     - push-release-image


### PR DESCRIPTION
Use the RELEASE_VERSION variable instead of the VERSION variable. The
VERSION variable is not used in the Makefile.