### PR TITLE
Fix the version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ RELEASE_VERSION?=$(shell git describe --tags --match "v*")
 RELEASE_IMAGE:=kube-scheduler:$(RELEASE_VERSION)
 RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
 
+# VERSION is the scheduler's version
+VERSION=$(shell git describe --tags --match 'v[0-9]*' --always)
+
 .PHONY: all
 all: build
 
@@ -39,7 +42,7 @@ build-controller: autogen
 
 .PHONY: build-scheduler
 build-scheduler: autogen
-	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/kube-scheduler cmd/scheduler/main.go
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-X k8s.io/component-base/version.gitVersion=$(VERSION) -w' -o bin/kube-scheduler cmd/scheduler/main.go
 
 .PHONY: local-image
 local-image: clean


### PR DESCRIPTION
**Problem:**

`go build` does not generate the correct kubernetes version.
```
$ bin/kube-scheduler --version
I1008 16:46:17.458477   96883 registry.go:150] Registering EvenPodsSpread predicate and priority function
I1008 16:46:17.458567   96883 registry.go:150] Registering EvenPodsSpread predicate and priority function
Kubernetes v0.0.0-master+$Format:%h$
```

**Fix:**

1. Get the source version information from git
2. Write the version information through ldflags:

**Result:**

```
$ bin/kube-scheduler --version
I1008 16:57:06.583004   98071 registry.go:150] Registering EvenPodsSpread predicate and priority function
I1008 16:57:06.583104   98071 registry.go:150] Registering EvenPodsSpread predicate and priority function
Kubernetes v0.18.800-45-g30549a3
```
