### PR TITLE
Fix Version Output For Automated Container Builds

### DIFF
--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -15,7 +15,8 @@ FROM golang:1.15.0
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
-RUN make build-scheduler
+ARG RELEASE_VERSION
+RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler
 
 FROM alpine:3.12
 


### PR DESCRIPTION
Updates the container image build process to use the RELEASE_VERSION variable to set the kube-scheduler version at compile time. This is required because git commands cannot be used in the container image build environment that generates images for k8s.gcr.io.

Fixes the issue described in https://github.com/kubernetes-sigs/scheduler-plugins/pull/72#discussion_r502599766.