### PR TITLE
Sync Build Automation From Master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,21 +14,46 @@
 
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 BUILDENVVAR=CGO_ENABLED=0
-REG_PORT=5000
+
+LOCAL_REGISTRY=localhost:5000/scheduler-plugins
+LOCAL_IMAGE=kube-scheduler:latest
+
+# RELEASE_REGISTRY is the container registry to push
+# into. The default is to push to the staging
+# registry, not production(k8s.gcr.io).
+RELEASE_REGISTRY?=gcr.io/k8s-staging-scheduler-plugins
+RELEASE_VERSION?=v$(shell date +%Y%m%d)-$(shell git describe --tags --match "v*")
+RELEASE_IMAGE:=kube-scheduler:$(RELEASE_VERSION)
+
+# VERSION is the scheduler's version
+#
+# The RELEASE_VERSION variable can have one of two formats:
+# v20201009-v0.18.800-46-g939c1c0 - automated build for a commit(not a tag) and also a local build
+# v20200521-v0.18.800             - automated build for a tag
+VERSION=$(shell echo $(RELEASE_VERSION) | awk -F - '{print $$2}')
 
 .PHONY: all
 all: build
 
 .PHONY: build
-build: autogen
-	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/kube-scheduler cmd/main.go
+build: build-scheduler
 
-.PHONY: local_image
-local_image: autogen
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-w' -o ./build/kube-scheduler cmd/main.go
-	chmod +x ./build/kube-scheduler
-	docker build -t localhost:$(REG_PORT)/scheduler-plugins:latest ./build
-	rm ./build/kube-scheduler
+.PHONY: build-scheduler
+build-scheduler: autogen
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-X k8s.io/component-base/version.gitVersion=$(VERSION) -w' -o bin/kube-scheduler cmd/main.go
+
+.PHONY: local-image
+local-image: clean
+	docker build -f ./build/scheduler/Dockerfile --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(LOCAL_REGISTRY)/$(LOCAL_IMAGE) .
+
+.PHONY: release-image
+release-image: clean
+	docker build -f ./build/scheduler/Dockerfile --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(RELEASE_REGISTRY)/$(RELEASE_IMAGE) .
+
+.PHONY: push-release-image
+push-release-image: release-image
+	gcloud auth configure-docker
+	docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)
 
 .PHONY: update-vendor
 update-vendor:
@@ -53,3 +78,7 @@ integration-test: install-etcd autogen
 .PHONY: verify-gofmt
 verify-gofmt:
 	hack/verify-gofmt.sh
+
+.PHONY: clean
+clean:
+	rm -rf ./bin

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -11,8 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+FROM golang:1.15.0
+
+WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
+COPY . .
+ARG RELEASE_VERSION
+RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler
 
 FROM alpine:3.12
 
-COPY kube-scheduler /bin/kube-scheduler
+COPY --from=0 /go/src/sigs.k8s.io/scheduler-plugins/bin/kube-scheduler /bin/kube-scheduler
+
+WORKDIR /bin
 CMD ["kube-scheduler"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - RELEASE_VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - push-release-image
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'


### PR DESCRIPTION
Backport the changes from the master branch to the release-1.18 branch
for the k8s.gcr.io automated container image builds process.