### PR TITLE
Update cross_node_preemption: get pod from informer cache instead of API server

### DIFF
--- a/pkg/crossnodepreemption/cross_node_preemption.go
+++ b/pkg/crossnodepreemption/cross_node_preemption.go
@@ -21,9 +21,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+        corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/core"
 	dp "k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
@@ -36,7 +36,7 @@ const (
 
 // CrossNodePreemption is a PostFilter plugin implements the preemption logic.
 type CrossNodePreemption struct {
-	fh framework.FrameworkHandle
+	fh        framework.FrameworkHandle
 	podLister corelisters.PodLister
 }
 
@@ -50,7 +50,7 @@ func (pl *CrossNodePreemption) Name() string {
 // New initializes a new plugin and returns it.
 func New(_ runtime.Object, fh framework.FrameworkHandle) (framework.Plugin, error) {
 	pl := CrossNodePreemption{
-		fh: fh,
+		fh:        fh,
 		podLister: fh.SharedInformerFactory().Core().V1().Pods().Lister(),
 	}
 	return &pl, nil

--- a/pkg/crossnodepreemption/cross_node_preemption.go
+++ b/pkg/crossnodepreemption/cross_node_preemption.go
@@ -21,7 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-        corelisters "k8s.io/client-go/listers/core/v1"
+       corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/core"

--- a/pkg/crossnodepreemption/cross_node_preemption.go
+++ b/pkg/crossnodepreemption/cross_node_preemption.go
@@ -21,7 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-       corelisters "k8s.io/client-go/listers/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/core"


### PR DESCRIPTION
I saw this TODO issue in [cross_node_preemption.go#L75](https://github.com/kubernetes-sigs/scheduler-plugins/blob/ab61ed63f27f29826c0e624185d2538a9e0f9ff0/pkg/crossnodepreemption/cross_node_preemption.go#L75) which is written by @Huang-Wei 
Can I update this TODO issue? If you've already completed the code, I will closed this PR. @Huang-Wei 