### PR TITLE
Add comments on calculateBoundPods method

### DIFF
--- a/pkg/coscheduling/core/core.go
+++ b/pkg/coscheduling/core/core.go
@@ -216,6 +216,7 @@ func (pgMgr *PodGroupManager) GetPodGroup(pod *corev1.Pod) (string, *v1alpha1.Po
 	return fmt.Sprintf("%v/%v", pod.Namespace, pgName), pg
 }
 
+// calculateBoundPods returns the count of pods that have occupied resources (including assumed and bound)
 func (pgMgr *PodGroupManager) calculateBoundPods(podGroupName, namespace string) int {
 	nodeInfos, err := pgMgr.snapshotSharedLister.NodeInfos().List()
 	if err != nil {


### PR DESCRIPTION
to clarify the ISSUE [#90 ](https://github.com/kubernetes-sigs/scheduler-plugins/issues/90) and avoid others confuse, I added a comment to the `calculateBoundPods` methods in coscheduling.
@denkensk 