### PR TITLE
Cleanup and update Coscheduling parameters

### DIFF
--- a/manifests/coscheduling/scheduler-config.yaml
+++ b/manifests/coscheduling/scheduler-config.yaml
@@ -29,4 +29,6 @@ profiles:
   - name: Coscheduling
     args:
       permitWaitingTimeSeconds: 10
+      deniedPGExpirationTimeSeconds: 3
       kubeConfigPath: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+      kubeMaster: "REPLACE_ME_WIHT_KUBE_MASTER"

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -23,28 +23,28 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// CoschedulingArgs defines the parameters for Coscheduling plugin.
 type CoschedulingArgs struct {
 	metav1.TypeMeta
 
 	// PermitWaitingTime is the wait timeout in seconds.
 	PermitWaitingTimeSeconds int64
-	// PodGroupGCInterval is the period to run gc of PodGroup in seconds.
-	PodGroupGCIntervalSeconds int64
-	// If the deleted PodGroup stays longer than the PodGroupExpirationTime,
-	// the PodGroup will be deleted from PodGroupInfos.
-	PodGroupExpirationTimeSeconds int64
+	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup store.
+	DeniedPGExpirationTimeSeconds int64
 	// KubeMaster is the url of api-server
 	KubeMaster string
 	// KubeConfigPath for scheduler
 	KubeConfigPath string
 }
 
-// modes type.
+// ModeType is a "string" type.
 type ModeType string
 
 const (
+	// Least is the string "Least".
 	Least ModeType = "Least"
-	Most  ModeType = "Most"
+	// Most is the string "Most".
+	Most ModeType = "Most"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -66,6 +66,7 @@ type NodeResourcesAllocatableArgs struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// CapacitySchedulingArgs defines the scheduling parameters for CapacityScheduling plugin.
 type CapacitySchedulingArgs struct {
 	metav1.TypeMeta
 

--- a/pkg/apis/config/v1beta1/defaults.go
+++ b/pkg/apis/config/v1beta1/defaults.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +k8s:defaulter-gen=true
+
 package v1beta1
 
 import (
@@ -21,9 +23,8 @@ import (
 )
 
 var (
-	defaultPermitWaitingTimeSeconds      int64 = 10
-	defaultPodGroupGCIntervalSeconds     int64 = 30
-	defaultPodGroupExpirationTimeSeconds int64 = 600
+	defaultPermitWaitingTimeSeconds      int64 = 60
+	defaultDeniedPGExpirationTimeSeconds int64 = 20
 
 	defaultNodeResourcesAllocatableMode = Least
 
@@ -39,19 +40,20 @@ var (
 	defaultKubeConfigPath string = "/etc/kubernetes/scheduler.conf"
 )
 
-func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
+// SetDefaultsCoschedulingArgs sets the default parameters for Coscheduling plugin.
+func SetDefaultsCoschedulingArgs(obj *CoschedulingArgs) {
 	if obj.PermitWaitingTimeSeconds == nil {
 		obj.PermitWaitingTimeSeconds = &defaultPermitWaitingTimeSeconds
 	}
-	if obj.PodGroupGCIntervalSeconds == nil {
-		obj.PodGroupGCIntervalSeconds = &defaultPodGroupGCIntervalSeconds
+	if obj.DeniedPGExpirationTimeSeconds == nil {
+		obj.DeniedPGExpirationTimeSeconds = &defaultDeniedPGExpirationTimeSeconds
 	}
-	if obj.PodGroupExpirationTimeSeconds == nil {
-		obj.PodGroupExpirationTimeSeconds = &defaultPodGroupExpirationTimeSeconds
-	}
+
+	// TODO(k/k#96427): get KubeConfigPath and KubeMaster from configuration or command args.
 }
 
-func SetDefaults_NodeResourcesAllocatableArgs(obj *NodeResourcesAllocatableArgs) {
+// SetDefaultsNodeResourcesAllocatableArgs sets the defaults parameters for NodeResourceAllocatable.
+func SetDefaultsNodeResourcesAllocatableArgs(obj *NodeResourcesAllocatableArgs) {
 	if len(obj.Resources) == 0 {
 		obj.Resources = defaultNodeResourcesAllocatableResourcesToWeightMap
 	}
@@ -61,7 +63,8 @@ func SetDefaults_NodeResourcesAllocatableArgs(obj *NodeResourcesAllocatableArgs)
 	}
 }
 
-func SetDefaults_CapacitySchedulingArgs(obj *CapacitySchedulingArgs) {
+// SetDefaultsCapacitySchedulingArgs sets the default parameters for CapacityScheduling plugin.
+func SetDefaultsCapacitySchedulingArgs(obj *CapacitySchedulingArgs) {
 	if obj.KubeConfigPath == nil {
 		obj.KubeConfigPath = &defaultKubeConfigPath
 	}

--- a/pkg/apis/config/v1beta1/types.go
+++ b/pkg/apis/config/v1beta1/types.go
@@ -29,23 +29,22 @@ type CoschedulingArgs struct {
 
 	// PermitWaitingTime is the wait timeout in seconds.
 	PermitWaitingTimeSeconds *int64 `json:"permitWaitingTimeSeconds,omitempty"`
-	// PodGroupGCInterval is the period to run gc of PodGroup in seconds.
-	PodGroupGCIntervalSeconds *int64 `json:"podGroupGCIntervalSeconds,omitempty"`
-	// If the deleted PodGroup stays longer than the PodGroupExpirationTime,
-	// the PodGroup will be deleted from PodGroupInfos.
-	PodGroupExpirationTimeSeconds *int64 `json:"podGroupExpirationTimeSeconds,omitempty"`
+	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup store.
+	DeniedPGExpirationTimeSeconds *int64 `json:"deniedPGExpirationTimeSeconds,omitempty"`
 	// KubeMaster is the url of api-server
-	KubeMaster string `json:"kubeMaster,omitempty"`
+	KubeMaster *string `json:"kubeMaster,omitempty"`
 	// KubeConfigPath for scheduler
-	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
+	KubeConfigPath *string `json:"kubeConfigPath,omitempty"`
 }
 
-// modes type.
+// ModeType is a type "string".
 type ModeType string
 
 const (
+	// Least is the string "Least".
 	Least ModeType = "Least"
-	Most  ModeType = "Most"
+	// Most is the string "Most".
+	Most ModeType = "Most"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1beta1/zz_generated.conversion.go
@@ -98,14 +98,15 @@ func autoConvert_v1beta1_CoschedulingArgs_To_config_CoschedulingArgs(in *Cosched
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_Pointer_int64_To_int64(&in.PodGroupGCIntervalSeconds, &out.PodGroupGCIntervalSeconds, s); err != nil {
+	if err := v1.Convert_Pointer_int64_To_int64(&in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_Pointer_int64_To_int64(&in.PodGroupExpirationTimeSeconds, &out.PodGroupExpirationTimeSeconds, s); err != nil {
+	if err := v1.Convert_Pointer_string_To_string(&in.KubeMaster, &out.KubeMaster, s); err != nil {
 		return err
 	}
-	out.KubeMaster = in.KubeMaster
-	out.KubeConfigPath = in.KubeConfigPath
+	if err := v1.Convert_Pointer_string_To_string(&in.KubeConfigPath, &out.KubeConfigPath, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -118,14 +119,15 @@ func autoConvert_config_CoschedulingArgs_To_v1beta1_CoschedulingArgs(in *config.
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_int64_To_Pointer_int64(&in.PodGroupGCIntervalSeconds, &out.PodGroupGCIntervalSeconds, s); err != nil {
+	if err := v1.Convert_int64_To_Pointer_int64(&in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_int64_To_Pointer_int64(&in.PodGroupExpirationTimeSeconds, &out.PodGroupExpirationTimeSeconds, s); err != nil {
+	if err := v1.Convert_string_To_Pointer_string(&in.KubeMaster, &out.KubeMaster, s); err != nil {
 		return err
 	}
-	out.KubeMaster = in.KubeMaster
-	out.KubeConfigPath = in.KubeConfigPath
+	if err := v1.Convert_string_To_Pointer_string(&in.KubeConfigPath, &out.KubeConfigPath, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/apis/config/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1beta1/zz_generated.deepcopy.go
@@ -64,13 +64,8 @@ func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 		*out = new(int64)
 		**out = **in
 	}
-	if in.PodGroupGCIntervalSeconds != nil {
-		in, out := &in.PodGroupGCIntervalSeconds, &out.PodGroupGCIntervalSeconds
-		*out = new(int64)
-		**out = **in
-	}
-	if in.PodGroupExpirationTimeSeconds != nil {
-		in, out := &in.PodGroupExpirationTimeSeconds, &out.PodGroupExpirationTimeSeconds
+	if in.DeniedPGExpirationTimeSeconds != nil {
+		in, out := &in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds
 		*out = new(int64)
 		**out = **in
 	}

--- a/pkg/apis/config/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/config/v1beta1/zz_generated.defaults.go
@@ -28,22 +28,22 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&CapacitySchedulingArgs{}, func(obj interface{}) { SetObjectDefaults_CapacitySchedulingArgs(obj.(*CapacitySchedulingArgs)) })
-	scheme.AddTypeDefaultingFunc(&CoschedulingArgs{}, func(obj interface{}) { SetObjectDefaults_CoschedulingArgs(obj.(*CoschedulingArgs)) })
+	scheme.AddTypeDefaultingFunc(&CapacitySchedulingArgs{}, func(obj interface{}) { SetObjectDefaultsCapacitySchedulingArgs(obj.(*CapacitySchedulingArgs)) })
+	scheme.AddTypeDefaultingFunc(&CoschedulingArgs{}, func(obj interface{}) { SetObjectDefaultsCoschedulingArgs(obj.(*CoschedulingArgs)) })
 	scheme.AddTypeDefaultingFunc(&NodeResourcesAllocatableArgs{}, func(obj interface{}) {
-		SetObjectDefaults_NodeResourcesAllocatableArgs(obj.(*NodeResourcesAllocatableArgs))
+		SetObjectDefaultsNodeResourcesAllocatableArgs(obj.(*NodeResourcesAllocatableArgs))
 	})
 	return nil
 }
 
-func SetObjectDefaults_CapacitySchedulingArgs(in *CapacitySchedulingArgs) {
-	SetDefaults_CapacitySchedulingArgs(in)
+func SetObjectDefaultsCapacitySchedulingArgs(in *CapacitySchedulingArgs) {
+	SetDefaultsCapacitySchedulingArgs(in)
 }
 
-func SetObjectDefaults_CoschedulingArgs(in *CoschedulingArgs) {
-	SetDefaults_CoschedulingArgs(in)
+func SetObjectDefaultsCoschedulingArgs(in *CoschedulingArgs) {
+	SetDefaultsCoschedulingArgs(in)
 }
 
-func SetObjectDefaults_NodeResourcesAllocatableArgs(in *NodeResourcesAllocatableArgs) {
-	SetDefaults_NodeResourcesAllocatableArgs(in)
+func SetObjectDefaultsNodeResourcesAllocatableArgs(in *NodeResourcesAllocatableArgs) {
+	SetDefaultsNodeResourcesAllocatableArgs(in)
 }

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -88,6 +88,7 @@ func TestLess(t *testing.T) {
 	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
 	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 	scheudleDuration := 10 * time.Second
+	deniedPGExpirationTime := 3 * time.Second
 	var lowPriority, highPriority = int32(10), int32(100)
 	ns1, ns2 := "namespace1", "namespace2"
 	for _, tt := range []struct {
@@ -255,7 +256,7 @@ func TestLess(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, pgInformer, podInformer)
+			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
 			coscheduling := &Coscheduling{pgMgr: pgMgr}
 			if got := coscheduling.Less(tt.p1, tt.p2); got != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, got)
@@ -303,9 +304,10 @@ func TestPermit(t *testing.T) {
 	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
 	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 	scheudleDuration := 10 * time.Second
+	deniedPGExpirationTime := 3 * time.Second
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, pgInformer, podInformer)
+			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
 			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: fakeHandler{}, scheduleTimeout: &scheudleDuration}
 			code, _ := coscheduling.Permit(context.Background(), framework.NewCycleState(), tt.pod, "test")
 			if code.Code() != tt.expected {


### PR DESCRIPTION
1. Removed the configuration parameters for the old PodGroup label based implementation.
2. Made `lastDeniedPodGroupExpirationTime ` configurable.
3. Fixed some format, naming and comments issues.   

@Huang-Wei  Here are some suggestions about apiVersion and plugin arguments.
1.  I'm not sure whether we need to keep the old config version in `pkg/apis/config`.  How about just switching to `v1beta1`, but renaming it `v1alpha1`? No idea why we use `v1beta1`.   
1. Can we get `KubeconfigPath` and KubeMaster from the command line args or kubeconfig define in the scheduler policy file?
1. Use SetDefaults to set the default parameter values for all plugins.
1. More consistent naming and conventions (e.g., using pointers instead of primitive types) 