### PR TITLE
Add additionalProperties field for podgroup.minResources field

### DIFF
--- a/manifests/coscheduling/crd.yaml
+++ b/manifests/coscheduling/crd.yaml
@@ -28,3 +28,9 @@ spec:
               minMember:
                 type: integer
                 minimum: 1
+              scheduleTimeoutSeconds:
+                type: integer
+              minResources:
+                type: object
+                additionalProperties:
+                  type: string


### PR DESCRIPTION
Per discussion in https://github.com/kubernetes-sigs/scheduler-plugins/pull/124#discussion_r539087299, in CRD v1 (Open API schema v3), in terms of a field of type `map`, it's sterilized to nil unless a `additionalProperties` field is specified.

- Without this PR

```
root@wei-dev:~/manifests# k apply -f cr1.yaml
error: error validating "cr1.yaml": error validating data: ValidationError(PodGroup.spec.minResources): invalid type for io.k8s.sigs.scheduling.v1alpha1.Po
dGroup.spec.minResources: got "map", expected "integer"; if you choose to ignore these errors, turn validation off with --validate=false
```

- With this PR, but without `additionalProperties` defined

```
root@wei-dev:~/manifests# k apply -f cr1.yaml
podgroup.scheduling.sigs.k8s.io/pg1 created

root@wei-dev:~/manifests# k get pg pg1 -o yaml
apiVersion: scheduling.sigs.k8s.io/v1alpha1
kind: PodGroup
metadata:
...
spec:
  minMember: 3
  minResources: {} # <-- nil map
  scheduleTimeoutSeconds: 10
```