### PR TITLE
Bump to Go 1.15.8

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.15.5
+FROM golang:1.15.8
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.15.5
+FROM golang:1.15.8
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .


### PR DESCRIPTION
The main k/k repo was recently updated to Go 1.15.8 for k8s 1.19, 1.20,
and the upcoming 1.21 release.

kubernetes/release#1895