### PR TITLE
Revert "Simplify Multi Arch Build Targets"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 ARCHS = amd64 arm64
-GOOS?=$(shell uname -s | tr A-Z a-z)
-GOARCH?=amd64
+COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
 BUILDENVVAR=CGO_ENABLED=0
 
 LOCAL_REGISTRY=localhost:5000/scheduler-plugins
@@ -42,13 +41,35 @@ all: build
 .PHONY: build
 build: build-controller build-scheduler
 
+.PHONY: build.amd64
+build.amd64: build-controller.amd64 build-scheduler.amd64
+
+.PHONY: build.arm64v8
+build.arm64v8: build-controller.arm64v8 build-scheduler.arm64v8
+
 .PHONY: build-controller
 build-controller: autogen
-	GOOS=$(GOOS) GOARCH=$(GOARCH) $(BUILDENVVAR) go build -ldflags '-w' -o bin/controller cmd/controller/controller.go
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o bin/controller cmd/controller/controller.go
+
+.PHONY: build-controller.amd64
+build-controller.amd64: autogen
+	$(COMMONENVVAR) $(BUILDENVVAR) GOARCH=amd64 go build -ldflags '-w' -o bin/controller cmd/controller/controller.go
+
+.PHONY: build-controller.arm64v8
+build-controller.arm64v8: autogen
+	GOOS=linux $(BUILDENVVAR) GOARCH=arm64 go build -ldflags '-w' -o bin/controller cmd/controller/controller.go
 
 .PHONY: build-scheduler
 build-scheduler: autogen
-	GOOS=$(GOOS) GOARCH=$(GOARCH) $(BUILDENVVAR) go build -ldflags '-X k8s.io/component-base/version.gitVersion=$(VERSION) -w' -o bin/kube-scheduler cmd/scheduler/main.go
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-X k8s.io/component-base/version.gitVersion=$(VERSION) -w' -o bin/kube-scheduler cmd/scheduler/main.go
+
+.PHONY: build-scheduler.amd64
+build-scheduler.amd64: autogen
+	$(COMMONENVVAR) $(BUILDENVVAR) GOARCH=amd64 go build -ldflags '-X k8s.io/component-base/version.gitVersion=$(VERSION) -w' -o bin/kube-scheduler cmd/scheduler/main.go
+
+.PHONY: build-scheduler.arm64v8
+build-scheduler.arm64v8: autogen
+	GOOS=linux $(BUILDENVVAR) GOARCH=arm64 go build -ldflags '-X k8s.io/component-base/version.gitVersion=$(VERSION) -w' -o bin/kube-scheduler cmd/scheduler/main.go
 
 .PHONY: local-image
 local-image: clean


### PR DESCRIPTION
This reverts commit 9ca52707ffc1826e7ce53f45c710e00ce0b279ce.

The automated container image build job is failing after #133 was merged. This should fix the automated container build job.

Fixes #113 

See https://storage.googleapis.com/kubernetes-jenkins/logs/post-scheduler-plugins-push-images/1369039476537430016/build-log.txt for a detailed error message.

```
Status: Downloaded newer image for golang:1.15.8
 ---> 7185d074e387
Step 3/11 : WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 ---> Running in e8973e2ddaa4
Removing intermediate container e8973e2ddaa4
 ---> 55d3adb106b0
Step 4/11 : COPY . .
 ---> 6249893cbc2f
Step 5/11 : ARG ARCH
 ---> Running in a5c8b206f40f
Removing intermediate container a5c8b206f40f
 ---> 97a132381121
Step 6/11 : ARG RELEASE_VERSION
 ---> Running in 293000fe06cc
Removing intermediate container 293000fe06cc
 ---> 5e3372b2e5cd
Step 7/11 : RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler.$ARCH
 ---> Running in a18224485db4
[91mmake: *** No rule to make target 'build-scheduler.amd64'.  Stop.
The command '/bin/sh -c RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler.$ARCH' returned a non-zero code: 2
make: *** [Makefile:60: release-image.amd64] Error 2
ERROR: (gcloud.builds.submit) build 99bd2d78-f27f-4b00-b5b4-146452508512 completed with status "FAILURE"
ERROR
ERROR: build step 0 "gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4" failed: step exited with non-zero status: 2
```