### PR TITLE
cherry-pick: update install doc to match release v0.19.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,20 @@ docker pull k8s.gcr.io/scheduler-plugins/controller:$TAG
 You can find [how to install release image](doc/install.md) here.
 
 ## Compatibility Matrix
-The below compatibility matrix shows the k8s client package(client-go, apimachinery, etc) versions that the
-scheduler-plugins are compiled with.
 
-The minor version of the scheduler-plugins matches the minor version of the k8s client
-packages that it is compiled with. For example scheduler-plugins v0.18.x releases are built with k8s v1.18.x
+The below compatibility matrix shows the k8s client package (client-go, apimachinery, etc) versions
+that the scheduler-plugins are compiled with.
+
+The minor version of the scheduler-plugins matches the minor version of the k8s client packages that
+it is compiled with. For example scheduler-plugins `v0.18.x` releases are built with k8s `v1.18.x`
 dependencies.
 
-The scheduler-plugins patch versions come in two different varieties(single digit or three digits). The single digit
-patch versions(i.e. v0.18.9) exactly align with the the k8s client package versions that the scheduler plugins are built
-with. The three digit patch versions(i.e. v0.18.800) are used to indicated that the k8s client package versions have not
-changed since the previous release, and that only scheduler plugins code(features or bug fixes) was changed.
+The scheduler-plugins patch versions come in two different varieties (single digit or three digits).
+The single digit patch versions (e.g., `v0.18.9`) exactly align with the the k8s client package
+versions that the scheduler plugins are built with. The three digit patch versions, which are built
+on demand, (e.g., `v0.18.800`) are used to indicated that the k8s client package versions have not
+changed since the previous release, and that only scheduler plugins code (features or bug fixes) was
+changed.
 
 Scheduler Plugins  | Compiled With k8s Version | Container Image                                     | Arch           |
 -------------------|---------------------------|-----------------------------------------------------|----------------|

--- a/manifests/coscheduling/scheduler-config.yaml
+++ b/manifests/coscheduling/scheduler-config.yaml
@@ -24,11 +24,9 @@ profiles:
     postBind:
       enabled:
         - name: Coscheduling
-# optional plugin configs
   pluginConfig:
   - name: Coscheduling
     args:
       permitWaitingTimeSeconds: 10
       deniedPGExpirationTimeSeconds: 3
       kubeConfigPath: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
-      kubeMaster: "REPLACE_ME_WITH_KUBE_MASTER"

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -1,0 +1,83 @@
+# First part
+# Apply extra privileges to system:kube-scheduler.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-scheduler:plugins
+rules:
+- apiGroups: ["scheduling.sigs.k8s.io"]
+  resources: ["podgroups", "elasticquotas"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-scheduler:plugins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler:plugins
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:kube-scheduler
+---
+# Second part
+# Install the controller image.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scheduler-plugins
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scheduler-plugins-controller
+  namespace: scheduler-plugins
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scheduler-plugins-controller
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["scheduling.sigs.k8s.io"]
+  resources: ["podgroups", "elasticquotas"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scheduler-plugins-controller
+subjects:
+- kind: ServiceAccount
+  name: scheduler-plugins-controller
+  namespace: scheduler-plugins
+roleRef:
+  kind: ClusterRole
+  name: scheduler-plugins-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: scheduler-plugins-controller
+  namespace: scheduler-plugins
+  labels:
+    app: scheduler-plugins-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler-plugins-controller
+  template:
+    metadata:
+      labels:
+        app: scheduler-plugins-controller
+    spec:
+      serviceAccount: scheduler-plugins-controller
+      containers:
+      - name: scheduler-plugins-controller
+        image: k8s.gcr.io/scheduler-plugins/controller:v0.19.8


### PR DESCRIPTION
This PR cherry-picks commit f6ed2337c9d2496984fa9b8d363d23be7c4c86e0 from the master branch to the release-1.19 branch. This ensures that end user documentation for the v0.19.x release series is preserved on the proper branch.

Fixes #161 

/kind documentation