### PR TITLE
Bump To Go 1.15.10

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.15.8
+FROM golang:1.15.10
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.15.8
+FROM golang:1.15.10
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .


### PR DESCRIPTION
The k/k repo for 1.19 and 1.20 have been udpated to use Go 1.15.10. See
below PR for reference.

https://github.com/kubernetes/kubernetes/pull/100520