### PR TITLE
helm chart to install scheduler-plugins as a secondary scheduler

### DIFF
--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -80,5 +80,5 @@ spec:
       serviceAccount: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
-        image: k8s.gcr.io/scheduler-plugins/controller:v0.19.8
+        image: k8s.gcr.io/scheduler-plugins/controller:v0.19.9
         imagePullPolicy: IfNotPresent

--- a/manifests/install/charts/as-a-second-scheduler/.helmignore
+++ b/manifests/install/charts/as-a-second-scheduler/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/manifests/install/charts/as-a-second-scheduler/Chart.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: scheduler-plugins
+description: deploy scheduler plugin as a second scheduler in cluster
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.19.9
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.19.9

--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -1,0 +1,1 @@
+# Chart to run scheduler plugin as a second scheduler in cluster.

--- a/manifests/install/charts/as-a-second-scheduler/templates/_helpers.tpl
+++ b/manifests/install/charts/as-a-second-scheduler/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "scheduler-plugins-as-a-second-scheduler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "scheduler-plugins-as-a-second-scheduler.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "scheduler-plugins-as-a-second-scheduler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "scheduler-plugins-as-a-second-scheduler.labels" -}}
+helm.sh/chart: {{ include "scheduler-plugins-as-a-second-scheduler.chart" . }}
+{{ include "scheduler-plugins-as-a-second-scheduler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "scheduler-plugins-as-a-second-scheduler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "scheduler-plugins-as-a-second-scheduler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduler-config
+  namespace: {{ .Values.scheduler.namespace }}
+data:
+  scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta1
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: false
+    profiles:
+    - schedulerName: scheduler-plugins-scheduler
+      plugins:
+        queueSort:
+          enabled:
+          - name: Coscheduling
+          disabled:
+          - name: "*"
+        preFilter:
+          enabled:
+          - name: Coscheduling
+        permit:
+          enabled:
+          - name: Coscheduling
+        reserve:
+          enabled:
+          - name: Coscheduling
+        postBind:
+          enabled:
+          - name: Coscheduling
+      pluginConfig:
+      - name: Coscheduling
+        args:
+          permitWaitingTimeSeconds: 10
+          deniedPGExpirationTimeSeconds: 3

--- a/manifests/install/charts/as-a-second-scheduler/templates/crds/podgroup.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/crds/podgroup.yaml
@@ -1,0 +1,58 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podgroups.scheduling.sigs.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes-sigs/scheduler-plugins/pull/50"
+spec:
+  group: scheduling.sigs.k8s.io
+  names:
+    kind: PodGroup
+    plural: podgroups
+    singular: podgroup
+    shortNames:
+    - pg
+    - pgs
+  scope: Namespaced
+  versions:
+  - name: "v1alpha1"
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              minMember:
+                type: integer
+                minimum: 1
+              scheduleTimeoutSeconds:
+                type: integer
+              minResources:
+                type: object
+                additionalProperties:
+                  type: string
+          status:
+            type: object
+            properties:
+              phase:
+                type: string
+              occupiedBy:
+                type: string
+              scheduled:
+                type: integer
+                default: 0
+              running:
+                type: integer
+                default: 0
+              succeeded:
+                type: integer
+                default: 0
+              failed:
+                type: integer
+                default: 0
+              scheduleStartTime:
+                type: string
+                format: date-time

--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -1,0 +1,74 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .Values.controller.name }}
+  namespace: {{ .Values.controller.namespace }}
+  labels:
+    app: scheduler-plugins-controller
+spec:
+  replicas: {{ .Values.controller.replicaCount }}
+  selector:
+    matchLabels:
+      app: scheduler-plugins-controller
+  template:
+    metadata:
+      labels:
+        app: scheduler-plugins-controller
+    spec:
+      serviceAccount: scheduler-plugins-controller
+      containers:
+      - name: scheduler-plugins-controller
+        image: {{ .Values.controller.image }}
+        imagePullPolicy: IfNotPresent
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: scheduler
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Values.scheduler.namespace }}
+spec:
+  selector:
+    matchLabels:
+      component: scheduler
+  replicas: {{ .Values.scheduler.replicaCount }}
+  template:
+    metadata:
+      labels:
+        component: scheduler
+    spec:
+      serviceAccountName: scheduler-plugins-scheduler
+      containers:
+      - command:
+        - /bin/kube-scheduler
+        - --address=0.0.0.0
+        - --leader-elect=false
+        - --config=/etc/kubernetes/scheduler-config.yaml
+        - --scheduler-name=scheduler-plugins-scheduler
+        image: {{ .Values.scheduler.image }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10251
+          initialDelaySeconds: 15
+        name: scheduler-plugins-scheduler
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10251
+        resources:
+          requests:
+            cpu: '0.1'
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - name: scheduler-config
+          mountPath: /etc/kubernetes
+          readOnly: true
+      hostNetwork: false
+      hostPID: false
+      volumes:
+      - name: scheduler-config
+        configMap:
+          name: scheduler-config

--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -1,0 +1,100 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scheduler-plugins-scheduler
+rules:
+- apiGroups: ["", "events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resourceNames: ["kube-scheduler"]
+  resources: ["leases"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resourceNames: ["kube-scheduler"]
+  resources: ["endpoints"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["delete", "get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["bindings", "pods/binding"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods/status"]
+  verbs: ["patch", "update"]
+- apiGroups: [""]
+  resources: ["replicationcontrollers", "services"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps", "extensions"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["csinodes", "storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["scheduling.sigs.k8s.io"]
+  resources: ["podgroups", "elasticquotas"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scheduler-plugins-scheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scheduler-plugins-scheduler
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Values.scheduler.namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scheduler-plugins-controller
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["scheduling.sigs.k8s.io"]
+  resources: ["podgroups", "elasticquotas"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scheduler-plugins-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.controller.name }}
+  namespace: {{ .Values.controller.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: scheduler-plugins-controller
+  apiGroup: rbac.authorization.k8s.io
+

--- a/manifests/install/charts/as-a-second-scheduler/templates/serviceaccount.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.controller.namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Values.scheduler.namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.controller.name }}
+  namespace: {{ .Values.controller.namespace }}

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -1,0 +1,15 @@
+# Default values for scheduler-plugins-as-a-second-scheduler.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+scheduler:
+  name: scheduler-plugins-scheduler
+  image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.19.9
+  namespace: scheduler-plugins
+  replicaCount: 1
+
+controller:
+  name: scheduler-plugins-controller
+  image: k8s.gcr.io/scheduler-plugins/controller:v0.19.9
+  namespace: scheduler-plugins
+  replicaCount: 1


### PR DESCRIPTION
This PR added a helm chart for scheduler-plugins to run it as a second scheduler #189 .