### PR TITLE
Refine coscheduling codes, set waittime to 0

### DIFF
--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -203,7 +203,7 @@ func (cs *Coscheduling) Permit(ctx context.Context, state *framework.CycleState,
 	if err != nil {
 		_, pg := cs.pgMgr.GetPodGroup(pod)
 		if pg == nil {
-			return framework.NewStatus(framework.UnschedulableAndUnresolvable, "PodGroup not found"), waitTime
+			return framework.NewStatus(framework.Unschedulable, "PodGroup not found"), 0
 		}
 		if wait := util.GetWaitTimeDuration(pg, cs.scheduleTimeout); wait != 0 {
 			waitTime = wait
@@ -213,7 +213,7 @@ func (cs *Coscheduling) Permit(ctx context.Context, state *framework.CycleState,
 			return framework.NewStatus(framework.Wait, ""), waitTime
 		}
 		klog.Infof("Permit error %v", err)
-		return framework.NewStatus(framework.Unschedulable, err.Error()), waitTime
+		return framework.NewStatus(framework.Unschedulable, err.Error()), 0
 	}
 
 	klog.V(5).Infof("Pod requires pgName %v", fullName)


### PR DESCRIPTION
Update coscheduling codes with two changes, make the codes easier to read.

change 1: 
Update `UnschedulableAndUnresolvable` to `Unschedulable`. `UnschedulableAndUnresolvable` is used to avoid preemption, while the changed line is at function ` Permit`,  it cannot trigger preemption at all.

The description about `UnschedulableAndUnresolvable` in codes
```
	// UnschedulableAndUnresolvable is used when a (pre-)filter plugin finds a pod unschedulable and
	// preemption would not change anything. ......
```

change 2: 
Update the `waitTime` to `0` if the returned status is not `Wait`, the `waitTime` will only be handled when the return status is `Wait`, or it will be ingored. Returning a `waitTime` may confuse the one who reads the codes.

The related codes to handle returned status:
```
func (f *frameworkImpl) RunPermitPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (status *framework.Status) {
	.....
	statusCode := framework.Success
	for _, pl := range f.permitPlugins {
		status, timeout := f.runPermitPlugin(ctx, pl, state, pod, nodeName)
		if !status.IsSuccess() {
			if status.IsUnschedulable() {  <<=== for `UnschedulableAndUnresolvable` or `Unschedulable`, timeout value is ingored.
				msg := fmt.Sprintf("rejected pod %q by permit plugin %q: %v", pod.Name, pl.Name(), status.Message())
				klog.V(4).Infof(msg)
				return framework.NewStatus(status.Code(), msg)
			}
	}
```