### PR TITLE
Adjust the timeout to 40m for scheduler-plugins integration test

### DIFF
--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -48,7 +48,7 @@ runTests() {
   kube::log::status "Running integration test cases"
 
   # TODO: make args customizable.
-  go test -mod=vendor sigs.k8s.io/scheduler-plugins/test/integration/...
+  go test -timeout=40m -mod=vendor sigs.k8s.io/scheduler-plugins/test/integration/...
 
   cleanup
 }


### PR DESCRIPTION
`go test` default sets a 10m timeout, which is not enough for the integration test.

```
$ go help testflag
...
	-timeout d
	    If a test binary runs longer than duration d, panic.
	    If d is 0, the timeout is disabled.
	    The default is 10 minutes (10m).
```

This PR adjusts the timeout for integration tests to 40m.