### PR TITLE
Automated cherry pick of #202: Adjust the timeout to 40m for scheduler-plugins integration

### DIFF
--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -48,7 +48,7 @@ runTests() {
   kube::log::status "Running integration test cases"
 
   # TODO: make args customizable.
-  go test -mod=vendor sigs.k8s.io/scheduler-plugins/test/integration/...
+  go test -timeout=40m -mod=vendor sigs.k8s.io/scheduler-plugins/test/integration/...
 
   cleanup
 }


### PR DESCRIPTION
Cherry pick of #202 on release-1.19.

#202: Adjust the timeout to 40m for scheduler-plugins integration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.