### PR TITLE
fix: WaitForCacheSync parameter

### DIFF
--- a/pkg/controller/podgroup.go
+++ b/pkg/controller/podgroup.go
@@ -96,7 +96,7 @@ func (ctrl *PodGroupController) Run(workers int, stopCh <-chan struct{}) {
 	klog.Info("Starting coscheduling")
 	defer klog.Info("Shutting coscheduling")
 
-	if !cache.WaitForCacheSync(stopCh, ctrl.pgListerSynced, ctrl.pgListerSynced) {
+	if !cache.WaitForCacheSync(stopCh, ctrl.pgListerSynced, ctrl.podListerSynced) {
 		klog.Error("Cannot sync caches")
 		return
 	}


### PR DESCRIPTION
- duplicate Synced object (`ctrl.pgListerSynced`)

I think that it might be `pgListerSynced` and `podListerSynced`