### PR TITLE
update the elastic quota immediately after delete victims

### DIFF
--- a/pkg/apis/config/v1beta1/defaults.go
+++ b/pkg/apis/config/v1beta1/defaults.go
@@ -100,9 +100,7 @@ func SetDefaultsNodeResourcesAllocatableArgs(obj *NodeResourcesAllocatableArgs) 
 
 // SetDefaultsCapacitySchedulingArgs sets the default parameters for CapacityScheduling plugin.
 func SetDefaultsCapacitySchedulingArgs(obj *CapacitySchedulingArgs) {
-	if obj.KubeConfigPath == nil {
-		obj.KubeConfigPath = &defaultKubeConfigPath
-	}
+	// TODO(k/k#96427): get KubeConfigPath and KubeMaster from configuration or command args.
 }
 
 // SetDefaultTargetLoadPackingArgs sets the default parameters for TargetLoadPacking plugin

--- a/pkg/capacityscheduling/capacity_scheduling_test.go
+++ b/pkg/capacityscheduling/capacity_scheduling_test.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	gocmp "github.com/google/go-cmp/cmp"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -123,8 +123,26 @@ func TestPreFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var registerPlugins []st.RegisterPluginFunc
+			registeredPlugins := append(
+				registerPlugins,
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			)
+
+			fwk, err := st.NewFramework(
+				registeredPlugins, "",
+				frameworkruntime.WithPodNominator(testutil.NewPodNominator()),
+				frameworkruntime.WithSnapshotSharedLister(testutil.NewFakeSharedLister(make([]*v1.Pod, 0), make([]*v1.Node, 0))),
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			cs := &CapacityScheduling{
 				elasticQuotaInfos: tt.elasticQuotas,
+				fh:                fwk,
 			}
 
 			pods := make([]*v1.Pod, 0)
@@ -291,9 +309,14 @@ func TestFindCandidates(t *testing.T) {
 				t.Errorf("Unexpected preFilterStatus: %v", preFilterStatus)
 			}
 
-			prefilterStatue := computePodResourceRequest(tt.pod)
+			podReq := computePodResourceRequest(tt.pod)
 			elasticQuotaSnapshotState := &ElasticQuotaSnapshotState{
 				elasticQuotaInfos: tt.elasticQuotas,
+			}
+			prefilterStatue := &PreFilterState{
+				podReq:                         *podReq,
+				nominatedPodsReqWithPodReq:     *podReq,
+				nominatedPodsReqInEQWithPodReq: *podReq,
 			}
 			state.Write(preFilterStateKey, prefilterStatue)
 			state.Write(ElasticQuotaSnapshotKey, elasticQuotaSnapshotState)
@@ -319,7 +342,7 @@ func TestFindCandidates(t *testing.T) {
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].Name() < got[j].Name()
 			})
-			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(candidate{})); diff != "" {
+			if diff := gocmp.Diff(tt.want, got, gocmp.AllowUnexported(candidate{})); diff != "" {
 				t.Errorf("Unexpected candidates (-want, +got): %s", diff)
 			}
 		})

--- a/pkg/capacityscheduling/elasticquota.go
+++ b/pkg/capacityscheduling/elasticquota.go
@@ -36,7 +36,7 @@ func (e ElasticQuotaInfos) clone() ElasticQuotaInfos {
 	return elasticQuotas
 }
 
-func (e ElasticQuotaInfos) aggregatedMinOverUsedWithPod(podRequest framework.Resource) bool {
+func (e ElasticQuotaInfos) aggregatedUsedOverMinWith(podRequest framework.Resource) bool {
 	used := framework.NewResource(nil)
 	min := framework.NewResource(nil)
 
@@ -46,7 +46,7 @@ func (e ElasticQuotaInfos) aggregatedMinOverUsedWithPod(podRequest framework.Res
 	}
 
 	used.Add(podRequest.ResourceList())
-	return moreThanMin(*used, *min)
+	return cmp(used, min)
 }
 
 // ElasticQuotaInfo is a wrapper to a ElasticQuota with information.
@@ -86,21 +86,16 @@ func (e *ElasticQuotaInfo) unreserveResource(request framework.Resource) {
 	}
 }
 
-func (e *ElasticQuotaInfo) overUsed(podRequest framework.Resource, resource *framework.Resource) bool {
-	if e.Used.MilliCPU+podRequest.MilliCPU > resource.MilliCPU {
-		return true
-	}
+func (e *ElasticQuotaInfo) usedOverMinWith(podRequest *framework.Resource) bool {
+	return cmp2(podRequest, e.Used, e.Min)
+}
 
-	if e.Used.Memory+podRequest.Memory > resource.Memory {
-		return true
-	}
+func (e *ElasticQuotaInfo) usedOverMaxWith(podRequest *framework.Resource) bool {
+	return cmp2(podRequest, e.Used, e.Max)
+}
 
-	for rName, rQuant := range podRequest.ScalarResources {
-		if rQuant+e.Used.ScalarResources[rName] > resource.ScalarResources[rName] {
-			return true
-		}
-	}
-	return false
+func (e *ElasticQuotaInfo) usedOverMin() bool {
+	return cmp(e.Used, e.Min)
 }
 
 func (e *ElasticQuotaInfo) clone() *ElasticQuotaInfo {
@@ -140,7 +135,7 @@ func (e *ElasticQuotaInfo) addPodIfNotPresent(pod *v1.Pod) error {
 
 	e.pods.Insert(key)
 	podRequest := computePodResourceRequest(pod)
-	e.reserveResource(podRequest.Resource)
+	e.reserveResource(*podRequest)
 
 	return nil
 }
@@ -157,21 +152,26 @@ func (e *ElasticQuotaInfo) deletePodIfPresent(pod *v1.Pod) error {
 
 	e.pods.Delete(key)
 	podRequest := computePodResourceRequest(pod)
-	e.unreserveResource(podRequest.Resource)
+	e.unreserveResource(*podRequest)
 
 	return nil
 }
 
-func moreThanMin(used, min framework.Resource) bool {
-	if used.MilliCPU > min.MilliCPU {
-		return true
-	}
-	if used.Memory > min.Memory {
+func cmp(x, y *framework.Resource) bool {
+	return cmp2(x, &framework.Resource{}, y)
+}
+
+func cmp2(x1, x2, y *framework.Resource) bool {
+	if x1.MilliCPU+x2.MilliCPU > y.MilliCPU {
 		return true
 	}
 
-	for rName, rQuant := range used.ScalarResources {
-		if rQuant > min.ScalarResources[rName] {
+	if x1.Memory+x2.Memory > y.Memory {
+		return true
+	}
+
+	for rName, rQuant := range x1.ScalarResources {
+		if rQuant+x2.ScalarResources[rName] > y.ScalarResources[rName] {
 			return true
 		}
 	}

--- a/pkg/capacityscheduling/elasticquota_test.go
+++ b/pkg/capacityscheduling/elasticquota_test.go
@@ -66,7 +66,7 @@ func TestReserveResource(t *testing.T) {
 			elasticQuotaInfo := tt.before
 			for _, pod := range tt.pods {
 				request := computePodResourceRequest(pod)
-				elasticQuotaInfo.reserveResource(request.Resource)
+				elasticQuotaInfo.reserveResource(*request)
 			}
 
 			if !reflect.DeepEqual(elasticQuotaInfo, tt.expected) {
@@ -118,7 +118,7 @@ func TestUnReserveResource(t *testing.T) {
 			elasticQuotaInfo := tt.before
 			for _, pod := range tt.pods {
 				request := computePodResourceRequest(pod)
-				elasticQuotaInfo.unreserveResource(request.Resource)
+				elasticQuotaInfo.unreserveResource(*request)
 			}
 
 			if !reflect.DeepEqual(elasticQuotaInfo, tt.expected) {


### PR DESCRIPTION
fix #211 

1. Update the elastic quota immediately after delete victims
2. Consider Nominated Pods in prefilter to avoid repeated preemption