### PR TITLE
Add comments for NodeResourceTopologyMatchArgs

### DIFF
--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -134,7 +134,12 @@ type LoadVariationRiskBalancingArgs struct {
 type NodeResourceTopologyMatchArgs struct {
 	metav1.TypeMeta
 
+	// KubeConfigPath is the path of kubeconfig.
 	KubeConfigPath string
+
+	// MasterOverride is the url of api-server
 	MasterOverride string
-	Namespaces     []string
+
+	// Namespaces to be considered by NodeResourceTopologyMatch plugin
+	Namespaces []string
 }


### PR DESCRIPTION
It mostly code cleanup, we missed it in our initial commit, but other plugins have such comments.