### PR TITLE
add example config for podState plugin

### DIFF
--- a/manifests/podstate/scheduler-config.yaml
+++ b/manifests/podstate/scheduler-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+clientConnection:
+  kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+profiles:
+  - schedulerName: default-scheduler
+    plugins:
+      score:
+        enabled:
+          - name: PodState

--- a/pkg/podstate/README.md
+++ b/pkg/podstate/README.md
@@ -18,3 +18,20 @@ This is a score plugin that takes terminating and nominated Pods into accounts i
 - the nodes that have more terminating Pods will get a higher score as those terminating Pods would be physically removed eventually from nodes
 - the nodes that have more nominated Pods (which carry .status.nominatedNodeName) will get a lower score as the nominated nodes are supposed to accommodate some preemptor pod in a 
 future scheduling cycle.
+
+## Example config:
+
+```yaml
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+clientConnection:
+  kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+profiles:
+- schedulerName: default-scheduler
+  plugins:
+    score:
+      enabled:
+      - name: PodState
+```


### PR DESCRIPTION
Simply adding an example config for podState plugin. I think I've missed adding this config in PR [#103](https://github.com/kubernetes-sigs/scheduler-plugins/pull/103)