### PR TITLE
update etcd script to not depend on ss or netstat

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -29,19 +29,9 @@ kube::etcd::validate() {
     exit 1
   }
 
-  # validate etcd port is free
-  local port_check_command
-  if command -v ss &> /dev/null && ss -Version | grep 'iproute2' &> /dev/null; then
-    port_check_command="ss"
-  elif command -v netstat &>/dev/null; then
-    port_check_command="netstat"
-  else
-    kube::log::usage "unable to identify if etcd is bound to port ${ETCD_PORT}. unable to find ss or netstat utilities."
-    exit 1
-  fi
-  if ${port_check_command} -nat | grep "LISTEN" | grep "[\.:]${ETCD_PORT:?}" >/dev/null 2>&1; then
+  # validate if etcd is running and $ETCD_PORT is in use
+  if ps -ef | grep "etcd " | grep ${ETCD_PORT} &> /dev/null; then
     kube::log::usage "unable to start etcd as port ${ETCD_PORT} is in use. please stop the process listening on this port and retry."
-    kube::log::usage "$(netstat -nat | grep "[\.:]${ETCD_PORT:?} .*LISTEN")"
     exit 1
   fi
 


### PR DESCRIPTION
Recently I [bumped](https://github.com/kubernetes/test-infra/pull/23314) the golang version to 1.16, but unfortunately the official golang 1.16 images removed `ss` utility:

```script
root@wei-dev:~# docker run -it golang:1.16.7 bash
root@8cae4123bab8:/go# which ss

root@wei-dev:~# docker run -it golang:1.15.10 bash
root@085c4ba5d7d9:/go# which ss
/bin/ss
```

that causes the etcd script to fail to verify if the etcd port is in use.

A straightforward solution is to find another CI image, but there is either no well-maintained one, or some prebuild (like gcr.io/k8s-testimages/kubekins-e2e) image is too large.

So I want to tweak the etcd script to not depend on the presence of `ss` or `natstat`.

**Note:** the downside of using `ps` is that it will also detect dockerized `etcd` process, which is not a problem for our CI job, but maybe confusing for developers.

/ref https://github.com/kubernetes-sigs/scheduler-plugins/pull/220#issuecomment-903727697