### PR TITLE
Fix access to null pointer

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -45,7 +45,7 @@ func singleNUMAContainerLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneLis
 	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 		if resMatchNUMANodes(nodes, container.Resources.Requests, qos) {
 			// definitely we can't align container, so we can't align a pod
-			return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("Cannot align container: %s", container.Name))
+			return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", container.Name))
 		}
 	}
 	return nil
@@ -110,7 +110,7 @@ func singleNUMAPodLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneList) *fr
 
 	if resMatchNUMANodes(createNUMANodeList(zones), resources, v1qos.GetPodQOS(pod)) {
 		// definitely we can't align container, so we can't align a pod
-		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("Cannot align pod: %s", pod.Name))
+		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align pod: %s", pod.Name))
 	}
 	return nil
 }
@@ -118,7 +118,7 @@ func singleNUMAPodLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneList) *fr
 // Filter Now only single-numa-node supported
 func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
 	if nodeInfo.Node() == nil {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("Node is nil %s", nodeInfo.Node().Name))
+		return framework.NewStatus(framework.Error, "node not found")
 	}
 	if v1qos.GetPodQOS(pod) == v1.PodQOSBestEffort {
 		return nil

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -196,7 +196,7 @@ func TestNodeResourceTopology(t *testing.T) {
 				v1.ResourceCPU:  *resource.NewQuantity(4, resource.DecimalSI),
 				nicResourceName: *resource.NewQuantity(11, resource.DecimalSI)}),
 			node:       nodes[1],
-			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("Cannot align container: %s", containerName)),
+			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
 		},
 		{
 			name: "Guaranteed QoS, pod doesn't fit",
@@ -205,7 +205,7 @@ func TestNodeResourceTopology(t *testing.T) {
 				v1.ResourceMemory: resource.MustParse("1Gi"),
 				nicResourceName:   *resource.NewQuantity(3, resource.DecimalSI)}),
 			node:       nodes[0],
-			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("Cannot align container: %s", containerName)),
+			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
 		},
 		{
 			name: "Guaranteed QoS, pod fit",
@@ -223,7 +223,7 @@ func TestNodeResourceTopology(t *testing.T) {
 				v1.ResourceMemory:          resource.MustParse("1Gi"),
 				notExistingNICResourceName: *resource.NewQuantity(0, resource.DecimalSI)}, 3),
 			node:       nodes[2],
-			wantStatus: framework.NewStatus(framework.Unschedulable, "Cannot align pod: "),
+			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
 		},
 		{
 			name: "Guaranteed QoS Topology Scope, pod fit",
@@ -241,7 +241,7 @@ func TestNodeResourceTopology(t *testing.T) {
 				v1.ResourceMemory:          resource.MustParse("1Gi"),
 				notExistingNICResourceName: *resource.NewQuantity(0, resource.DecimalSI)}, 3),
 			node:       nodes[3],
-			wantStatus: framework.NewStatus(framework.Unschedulable, "Cannot align pod: "),
+			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
 		},
 	}
 


### PR DESCRIPTION
What this PR does:
- fix access to nil pointer
- lowercase the first letter of reasons for `framework.Status`
   (I think it is better to lowercase the reason string, and the reason is similar to [error strings](https://github.com/golang/go/wiki/CodeReviewComments#error-strings))