### PR TITLE
Migrate to structured logging

### DIFF
--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -56,7 +56,8 @@ func Run(s *ServerRunOptions) error {
 	ctx := context.Background()
 	config, err := newConfig(s.KubeConfig, s.MasterUrl, s.InCluster)
 	if err != nil {
-		klog.Fatal(err)
+		klog.ErrorS(err, "Failed to parse config")
+		os.Exit(1)
 	}
 	config.QPS = float32(s.ApiServerQPS)
 	config.Burst = s.ApiServerBurst
@@ -99,7 +100,8 @@ func Run(s *ServerRunOptions) error {
 				Identity: id,
 			})
 		if err != nil {
-			klog.Fatalf("error creating lock: %v", err)
+			klog.ErrorS(err, "Resource lock creation failed")
+			os.Exit(1)
 		}
 
 		leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
@@ -107,7 +109,8 @@ func Run(s *ServerRunOptions) error {
 			Callbacks: leaderelection.LeaderCallbacks{
 				OnStartedLeading: run,
 				OnStoppedLeading: func() {
-					klog.Fatalf("leaderelection lost")
+					klog.ErrorS(err, "Leaderelection lost")
+					os.Exit(1)
 				},
 			},
 			Name: "scheduler-plugins controller",

--- a/test/integration/base.go
+++ b/test/integration/base.go
@@ -37,7 +37,7 @@ func podScheduled(c clientset.Interface, podNamespace, podName string) bool {
 	pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
 		// This could be a connection error so we want to retry.
-		klog.Errorf("klog error %v", err)
+		klog.ErrorS(err, "Failed to get pod", "pod", klog.KRef(podNamespace, podName))
 		return false
 	}
 	if pod.Spec.NodeName == "" {

--- a/test/integration/capacity_scheduling_test.go
+++ b/test/integration/capacity_scheduling_test.go
@@ -654,7 +654,7 @@ func cleanupElasticQuotas(ctx context.Context, client versioned.Interface, elast
 	for _, eq := range elasticQuotas {
 		err := client.SchedulingV1alpha1().ElasticQuotas(eq.Namespace).Delete(ctx, eq.Name, metav1.DeleteOptions{})
 		if err != nil {
-			klog.Errorf("clean up ElasticQuota (%v/%v) error %s", eq.Namespace, eq.Name, err.Error())
+			klog.ErrorS(err, "Failed to clean up ElasticQuota", "elasticQuota", klog.KObj(eq))
 		}
 	}
 }

--- a/test/integration/coscheduling_test.go
+++ b/test/integration/coscheduling_test.go
@@ -424,7 +424,7 @@ func TestCoschedulingPlugin(t *testing.T) {
 			defer testutils.CleanupPods(cs, t, tt.pods)
 			// Create Pods, We will expect them to be scheduled in a reversed order.
 			for i := range tt.pods {
-				klog.Infof("Creating pod %v", tt.pods[i].Name)
+				klog.InfoS("Creating pod ", "podName", tt.pods[i].Name)
 				_, err := cs.CoreV1().Pods(tt.pods[i].Namespace).Create(testCtx.Ctx, tt.pods[i], metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("Failed to create Pod %q: %v", tt.pods[i].Name, err)

--- a/test/integration/elasticquota_controller_test.go
+++ b/test/integration/elasticquota_controller_test.go
@@ -307,7 +307,7 @@ func TestElasticController(t *testing.T) {
 					eq, err := extClient.SchedulingV1alpha1().ElasticQuotas(v.Namespace).Get(context.TODO(), v.Name, metav1.GetOptions{})
 					if err != nil {
 						// This could be a connection error so we want to retry.
-						klog.Errorf("klog error %v", err)
+						klog.ErrorS(err, "Failed to obtain the elasticQuota clientSet")
 						return false, err
 					}
 					if !quota.Equals(eq.Status.Used, v.Status.Used) {
@@ -344,7 +344,7 @@ func TestElasticController(t *testing.T) {
 					eq, err := extClient.SchedulingV1alpha1().ElasticQuotas(v.Namespace).Get(context.TODO(), v.Name, metav1.GetOptions{})
 					if err != nil {
 						// This could be a connection error so we want to retry.
-						klog.Errorf("klog error %v", err)
+						klog.ErrorS(err, "Failed to obtain the elasticQuota clientSet")
 						return false, err
 					}
 					if !quota.Equals(eq.Status.Used, v.Status.Used) {

--- a/test/integration/noderesourcetopology_test.go
+++ b/test/integration/noderesourcetopology_test.go
@@ -758,7 +758,7 @@ func cleanupNodeResourceTopologies(ctx context.Context, topologyClient *topology
 	for _, nrt := range noderesourcetopologies {
 		err := topologyClient.TopologyV1alpha1().NodeResourceTopologies(nrt.Namespace).Delete(ctx, nrt.Name, metav1.DeleteOptions{})
 		if err != nil {
-			klog.Errorf("clean up NodeResourceTopologies (%v/%v) error %s", nrt.Namespace, nrt.Name, err.Error())
+			klog.ErrorS(err, "Failed to clean up NodeResourceTopology", "nodeResourceTopology", nrt)
 		}
 	}
 }

--- a/test/util/aggregator.go
+++ b/test/util/aggregator.go
@@ -162,7 +162,7 @@ func makeAPIService(gv schema.GroupVersion) *v1.APIService {
 	if !ok {
 		// if we aren't found, then we shouldn't register ourselves because it could result in a CRD group version
 		// being permanently stuck in the APIServices list.
-		klog.Infof("Skipping APIService creation for %v", gv)
+		klog.InfoS("Skipping APIService creation", "groupVersion", gv)
 		return nil
 	}
 	return &v1.APIService{


### PR DESCRIPTION
This PR extends: https://github.com/kubernetes-sigs/scheduler-plugins/issues/120

In this PR, [Part I](https://github.com/kubernetes-sigs/scheduler-plugins/issues/120#issuecomment-907432220) is implemented as part of migration to structured logging for scheduler-plugins.