### PR TITLE
Fix podgroup controller UT issue

### DIFF
--- a/pkg/controller/podgroup_test.go
+++ b/pkg/controller/podgroup_test.go
@@ -96,7 +96,7 @@ func Test_Run(t *testing.T) {
 			podNames:          []string{"pod1", "pod2"},
 			podPhase:          v1.PodPending,
 			previousPhase:     v1alpha1.PodGroupScheduling,
-			desiredGroupPhase: v1alpha1.PodGroupFailed,
+			desiredGroupPhase: v1alpha1.PodGroupFinished,
 			podNextPhase:      v1.PodSucceeded,
 		},
 		{
@@ -106,7 +106,7 @@ func Test_Run(t *testing.T) {
 			podNames:          []string{"pod1", "pod2"},
 			podPhase:          v1.PodPending,
 			previousPhase:     v1alpha1.PodGroupPending,
-			desiredGroupPhase: v1alpha1.PodGroupPreScheduling,
+			desiredGroupPhase: v1alpha1.PodGroupFinished,
 			podNextPhase:      v1.PodSucceeded,
 		},
 		{
@@ -118,6 +118,15 @@ func Test_Run(t *testing.T) {
 			previousPhase:      v1alpha1.PodGroupPending,
 			desiredGroupPhase:  v1alpha1.PodGroupPending,
 			podGroupCreateTime: &createTime,
+		},
+		{
+			name:              "Group group min member more than Pod number",
+			pgName:            "pg9",
+			minMember:         3,
+			podNames:          []string{"pod91", "pod92"},
+			podPhase:          v1.PodPending,
+			previousPhase:     v1alpha1.PodGroupPending,
+			desiredGroupPhase: v1alpha1.PodGroupPreScheduling,
 		},
 	}
 	for _, c := range cases {
@@ -154,7 +163,7 @@ func Test_Run(t *testing.T) {
 				return true, nil
 			})
 			if err != nil {
-
+				t.Fatal("Unexpected error", err)
 			}
 		})
 	}


### PR DESCRIPTION
Fix podgroup controller UT issue, I found the source code line 157 if err is not nil, would not deal with.
So I try to add some debug log, the result as below
```
--- FAIL: Test_Run (2.02s)
    --- FAIL: Test_Run/Group_status_convert_from_scheduling_to_succeed#01 (0.20s)
        podgroup_test.go:163: pg.Status.Phase not as expect pg6, now the pg.Status.Phase is Finished
    --- FAIL: Test_Run/Group_status_convert_from_pending_to_prescheduling (0.20s)
        podgroup_test.go:163: pg.Status.Phase not as expect pg7, now the pg.Status.Phase is  Finished
```