### PR TITLE
Migrate noderesources and noderesourcetopology directories to structured logging

### DIFF
--- a/pkg/noderesources/allocatable.go
+++ b/pkg/noderesources/allocatable.go
@@ -138,7 +138,7 @@ func score(capacity int64, mode config.ModeType) int64 {
 		return capacity
 	}
 
-	klog.V(10).Infoln("No match for mode: ", mode)
+	klog.V(10).InfoS("No match for mode", "mode", mode)
 	return 0
 }
 

--- a/pkg/noderesources/resource_allocation.go
+++ b/pkg/noderesources/resource_allocation.go
@@ -73,20 +73,16 @@ func (r *resourceAllocationScorer) score(
 	}
 	if klog.V(10).Enabled() {
 		if len(pod.Spec.Volumes) >= 0 && utilfeature.DefaultFeatureGate.Enabled(features.BalanceAttachedNodeVolumes) && nodeInfo.TransientInfo != nil {
-			klog.Infof(
-				"%v -> %v: %v, map of allocatable resources %v, map of requested resources %v , allocatable volumes %d, requested volumes %d, score %d",
-				pod.Name, node.Name, r.Name,
-				allocatable, requested, nodeInfo.TransientInfo.TransNodeInfo.AllocatableVolumesCount,
-				nodeInfo.TransientInfo.TransNodeInfo.RequestedVolumes,
-				score,
-			)
+			klog.InfoS("Resources, volumes and score",
+				"podName", pod.Name, "nodeName", node.Name, "scorer", r.Name,
+				"allocatableResources", allocatable, "requestedResources", requested,
+				"allocatableVolumes", nodeInfo.TransientInfo.TransNodeInfo.AllocatableVolumesCount, "requestedVolumes", nodeInfo.TransientInfo.TransNodeInfo.RequestedVolumes,
+				"score", score)
 		} else {
-			klog.Infof(
-				"%v -> %v: %v, map of allocatable resources %v, map of requested resources %v ,score %d,",
-				pod.Name, node.Name, r.Name,
-				allocatable, requested, score,
-			)
-
+			klog.InfoS("Resources and score",
+				"podName", pod.Name, "nodeName", node.Name, "scorer", r.Name,
+				"allocatableResources", allocatable, "requestedResources", requested,
+				"score", score)
 		}
 	}
 
@@ -110,8 +106,8 @@ func calculateResourceAllocatableRequest(nodeInfo *framework.NodeInfo, pod *v1.P
 		}
 	}
 	if klog.V(10).Enabled() {
-		klog.Infof("requested resource %v not considered for node score calculation",
-			resource,
+		klog.InfoS("Requested resource not considered for node score calculation",
+			"resource", resource,
 		)
 	}
 	return 0, 0

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -34,7 +34,7 @@ import (
 type PolicyHandler func(pod *v1.Pod, zoneMap topologyv1alpha1.ZoneList) *framework.Status
 
 func singleNUMAContainerLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneList) *framework.Status {
-	klog.V(5).Infof("Single NUMA node handler")
+	klog.V(5).InfoS("Single NUMA node handler")
 
 	// prepare NUMANodes list from zoneMap
 	nodes := createNUMANodeList(zones)
@@ -94,7 +94,7 @@ func resMatchNUMANodes(nodes NUMANodeList, resources v1.ResourceList, qos v1.Pod
 }
 
 func singleNUMAPodLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneList) *framework.Status {
-	klog.V(5).Infof("Pod Level Resource handler")
+	klog.V(5).InfoS("Pod Level Resource handler")
 	resources := make(v1.ResourceList)
 
 	// We count here in the way TopologyManager is doing it, IOW we put InitContainers
@@ -131,14 +131,14 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.Cycle
 		return nil
 	}
 
-	klog.V(5).Infof("nodeTopology: %v", nodeTopology)
+	klog.V(5).InfoS("Found NodeResourceTopology", klog.KObj(nodeTopology))
 	for _, policyName := range nodeTopology.TopologyPolicies {
 		if handler, ok := tm.policyHandlers[topologyv1alpha1.TopologyManagerPolicy(policyName)]; ok {
 			if status := handler.filter(pod, nodeTopology.Zones); status != nil {
 				return status
 			}
 		} else {
-			klog.V(5).Infof("Handler for policy %s not found", policyName)
+			klog.V(5).Infof("Policy handler not found", "policy", policyName)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR  migrates noderesources and noderesourcetopology directories to structed logging

Files changed:
pkg/noderesources/allocatable.go
pkg/noderesources/resource_allocation.go
pkg/noderesourcetopology/filter.go

This pr fixes part 5 of https://github.com/kubernetes-sigs/scheduler-plugins/issues/120
