### PR TITLE
Update load watcher dependency for Trimaran plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.10
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/paypal/load-watcher v0.1.1
+	github.com/paypal/load-watcher v0.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	gonum.org/v1/gonum v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -612,8 +612,8 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
-github.com/paypal/load-watcher v0.1.1 h1:WZxLNYjsBXtfwbjhjl/+Ln4wvD8xU327jFcxyojcey8=
-github.com/paypal/load-watcher v0.1.1/go.mod h1:EpvL9ULcqU4G2T4tc7Es5OP1zgYKQ8FvbSs6tLYnvS4=
+github.com/paypal/load-watcher v0.2.0 h1:uywANA03YvCUj1jKWmFOIDyrTx+16uI2dCwnAFnw81c=
+github.com/paypal/load-watcher v0.2.0/go.mod h1:EpvL9ULcqU4G2T4tc7Es5OP1zgYKQ8FvbSs6tLYnvS4=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=


### PR DESCRIPTION
For new [release](https://github.com/paypal/load-watcher/releases/tag/v0.2.0) of load watcher.
Signed-off-by: Abdul Qadeer <aqadeer@paypal.com>