### PR TITLE
install: create a RoleBinding for obtain delegated authentication

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -97,4 +97,21 @@ roleRef:
   kind: ClusterRole
   name: scheduler-plugins-controller
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sched-plugins::extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Values.scheduler.namespace }}
+- kind: ServiceAccount
+  name: {{ .Values.controller.name }}
+  namespace: {{ .Values.controller.namespace }}
 


### PR DESCRIPTION
Fixes #271.

This PRs adds a RoleBinding to obtain delegated authentication which is defined in `extension-apiserver-authentication-reader/kube-system`.