### PR TITLE
NodeResourceTopology: Return error if no NRT instances found

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
@@ -127,7 +127,11 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.Cycle
 	}
 
 	nodeName := nodeInfo.Node().Name
-	nodeTopology := findNodeTopology(nodeName, &tm.nodeResTopologyPlugin)
+	nodeTopology, err := findNodeTopology(nodeName, &tm.nodeResTopologyPlugin)
+
+	if err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
 
 	if nodeTopology == nil {
 		return nil

--- a/pkg/noderesourcetopology/score.go
+++ b/pkg/noderesourcetopology/score.go
@@ -22,7 +22,7 @@ import (
 
 	"gonum.org/v1/gonum/stat"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	apiconfig "sigs.k8s.io/scheduler-plugins/pkg/apis/config"
@@ -55,7 +55,11 @@ func (rw resourceToWeightMap) weight(r v1.ResourceName) int64 {
 
 func (tm *TopologyMatch) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	klog.V(5).InfoS("Scoring node", "nodeName", nodeName)
-	nodeTopology := findNodeTopology(nodeName, &tm.nodeResTopologyPlugin)
+	nodeTopology, err := findNodeTopology(nodeName, &tm.nodeResTopologyPlugin)
+
+	if err != nil {
+		return 0, framework.NewStatus(framework.Error, err.Error())
+	}
 
 	if nodeTopology == nil {
 		return 0, nil


### PR DESCRIPTION
In case no NRT instances are present in any of the namespaces
specified in the Topology aware Scheduler plugin config, we should
return an error with the information rather than silently admitting
the pod as that pod could end with Topology Affinity Error.

For more context please refer to the slack thread here:
https://kubernetes.slack.com/archives/C01A82FKSQK/p1633514787010400?thread_ts=1628171809.003900&cid=C01A82FKSQK

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>