### PR TITLE
NodeResourceTopology: Make `default` as the default namespace in scheduler config

### DIFF
--- a/manifests/noderesourcetopology/ns.yaml
+++ b/manifests/noderesourcetopology/ns.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: test-namespace # Test namespace

--- a/manifests/noderesourcetopology/scheduler-config.yaml
+++ b/manifests/noderesourcetopology/scheduler-config.yaml
@@ -21,7 +21,7 @@ profiles:
       # kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
       kubeconfigpath: "/etc/kubernetes/scheduler.conf"
       namespaces:
-      - "test-namespace"
+      - "default"
       # other strategies are MostAllocated and BalancedAllocation
       scoringStrategy:
         type: "LeastAllocated"

--- a/manifests/noderesourcetopology/scheduler-configmap.yaml
+++ b/manifests/noderesourcetopology/scheduler-configmap.yaml
@@ -26,6 +26,6 @@ data:
             args:
               kubeconfigpath: "/etc/kubernetes/scheduler.conf"
               namespaces:
-              - "test-namespace"
+              - "default"
               scoringStrategy:
                 type: "LeastAllocated"

--- a/manifests/noderesourcetopology/worker-node-A.yaml
+++ b/manifests/noderesourcetopology/worker-node-A.yaml
@@ -3,7 +3,7 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-a
-  namespace: test-namespace
+  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: node-0

--- a/manifests/noderesourcetopology/worker-node-B.yaml
+++ b/manifests/noderesourcetopology/worker-node-B.yaml
@@ -3,7 +3,7 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-b
-  namespace: test-namespace
+  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: node-0

--- a/pkg/noderesourcetopology/README.md
+++ b/pkg/noderesourcetopology/README.md
@@ -22,6 +22,7 @@ In case the cumulative count of node resource allocatable appear to be the same 
 ### Config
 
 Enable the "NodeResourceTopologyMatch" Filter and Score plugins via SchedulerConfigConfiguration.
+NOTE: Update the config below to specify the namespace(s) in which NodeResourceTopology CR instances are present.
 
 ```yaml
 apiVersion: kubescheduler.config.k8s.io/v1beta1
@@ -68,7 +69,7 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-A
-  namespace: test-namespace
+  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: numa-node-0
@@ -103,7 +104,7 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-B
-  namespace: test-namespace
+  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: numa-node-0
@@ -151,7 +152,6 @@ zones:
          1. Deploy the CRs representative of the hardware topology of the worker-node-A and worker-node-B:
 
             ```bash
-             $ kubectl create -f ns.yaml
              $ kubectl create -f worker-node-A.yaml
              $ kubectl create -f worker-node-B.yaml
             ```


### PR DESCRIPTION
In order to enable Topology aware scheduling in a Kuberetes cluster, we need to
deploy a producer which exposes resource topology information as CRs and the
NodeResourceTopology scheduler plugin.

An upstream producer of the NodeResourceTopology instances is Node Feature Discovery.
The associated PR where this feature is enabled in NFD is here:
https://github.com/kubernetes-sigs/node-feature-discovery/pull/525

The default namespace where NFD deploys CR instances is `default` as can be seen here:
 https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/cmd/nfd-master/main.go#L108
so in order to have a better user experience and to make sure that both
these components work together seamlessly we change the default namespace
in the scheduler plugin config to be the same as in NFD i.e. `default`.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>