### PR TITLE
merge verification-related Makefile entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,16 +122,10 @@ autogen: update-vendor
 integration-test: install-etcd autogen
 	hack/integration-test.sh
 
-.PHONY: verify-gofmt
-verify-gofmt:
+.PHONY: verify
+verify: autogen
 	hack/verify-gofmt.sh
-
-.PHONY: verify-crdgen
-verify-crdgen: autogen
 	hack/verify-crdgen.sh
-
-.PHONY: verify-structured-logging
-verify-structured-logging:
 	hack/verify-structured-logging.sh
 
 .PHONY: clean


### PR DESCRIPTION
It's neat to come up with a unified Makefile `verify` entry rather than individual `verify-xyz` entries.