### PR TITLE
Trimaran: bug fixes for unpopulated watcher metrics

### DIFF
--- a/pkg/apis/config/scheme/scheme_test.go
+++ b/pkg/apis/config/scheme/scheme_test.go
@@ -189,7 +189,7 @@ profiles:
 								DefaultRequestsMultiplier: "1.5",
 								WatcherAddress:            "",
 								MetricProvider: config.MetricProviderSpec{
-									Type:    "",
+									Type:    config.KubernetesMetricsServer,
 									Address: "",
 									Token:   "",
 								},

--- a/pkg/apis/config/v1beta1/defaults.go
+++ b/pkg/apis/config/v1beta1/defaults.go
@@ -115,22 +115,14 @@ func SetDefaultTargetLoadPackingArgs(args *TargetLoadPackingArgs) {
 	if args.TargetUtilization == nil || *args.TargetUtilization <= 0 {
 		args.TargetUtilization = &DefaultTargetUtilizationPercent
 	}
-	metricProviderType := string(args.MetricProvider.Type)
-	validMetricProviderType := metricProviderType == string(pluginConfig.KubernetesMetricsServer) ||
-		metricProviderType == string(pluginConfig.Prometheus) ||
-		metricProviderType == string(pluginConfig.SignalFx)
-	if args.WatcherAddress == nil && !validMetricProviderType {
+	if args.WatcherAddress == nil && args.MetricProvider.Type == "" {
 		args.MetricProvider.Type = MetricProviderType(DefaultMetricProviderType)
 	}
 }
 
 // SetDefaultLoadVariationRiskBalancingArgs sets the default parameters for LoadVariationRiskBalancing plugin
 func SetDefaultLoadVariationRiskBalancingArgs(args *LoadVariationRiskBalancingArgs) {
-	metricProviderType := string(args.MetricProvider.Type)
-	validMetricProviderType := metricProviderType == string(pluginConfig.KubernetesMetricsServer) ||
-		metricProviderType == string(pluginConfig.Prometheus) ||
-		metricProviderType == string(pluginConfig.SignalFx)
-	if args.WatcherAddress == nil && !validMetricProviderType {
+	if args.WatcherAddress == nil && args.MetricProvider.Type == "" {
 		args.MetricProvider.Type = MetricProviderType(DefaultMetricProviderType)
 	}
 	if args.SafeVarianceMargin == nil || *args.SafeVarianceMargin < 0 {

--- a/pkg/apis/config/v1beta1/defaults.go
+++ b/pkg/apis/config/v1beta1/defaults.go
@@ -115,6 +115,13 @@ func SetDefaultTargetLoadPackingArgs(args *TargetLoadPackingArgs) {
 	if args.TargetUtilization == nil || *args.TargetUtilization <= 0 {
 		args.TargetUtilization = &DefaultTargetUtilizationPercent
 	}
+	metricProviderType := string(args.MetricProvider.Type)
+	validMetricProviderType := metricProviderType == string(pluginConfig.KubernetesMetricsServer) ||
+		metricProviderType == string(pluginConfig.Prometheus) ||
+		metricProviderType == string(pluginConfig.SignalFx)
+	if args.WatcherAddress == nil && !validMetricProviderType {
+		args.MetricProvider.Type = MetricProviderType(DefaultMetricProviderType)
+	}
 }
 
 // SetDefaultLoadVariationRiskBalancingArgs sets the default parameters for LoadVariationRiskBalancing plugin

--- a/pkg/apis/config/v1beta1/defaults_test.go
+++ b/pkg/apis/config/v1beta1/defaults_test.go
@@ -87,6 +87,9 @@ func TestSchedulingDefaults(t *testing.T) {
 					strconv.FormatInt(DefaultRequestsMilliCores, 10) + "m")},
 				DefaultRequestsMultiplier: pointer.StringPtr("1.5"),
 				TargetUtilization:         pointer.Int64Ptr(40),
+				MetricProvider: MetricProviderSpec{
+					Type: "KubernetesMetricsServer",
+				},
 			},
 		},
 		{
@@ -95,11 +98,13 @@ func TestSchedulingDefaults(t *testing.T) {
 				DefaultRequests:           v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m")},
 				DefaultRequestsMultiplier: pointer.StringPtr("2.5"),
 				TargetUtilization:         pointer.Int64Ptr(50),
+				WatcherAddress:            pointer.StringPtr("http://localhost:2020"),
 			},
 			expect: &TargetLoadPackingArgs{
 				DefaultRequests:           v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m")},
 				DefaultRequestsMultiplier: pointer.StringPtr("2.5"),
 				TargetUtilization:         pointer.Int64Ptr(50),
+				WatcherAddress:            pointer.StringPtr("http://localhost:2020"),
 			},
 		},
 		{

--- a/pkg/trimaran/loadvariationriskbalancing/collector.go
+++ b/pkg/trimaran/loadvariationriskbalancing/collector.go
@@ -107,6 +107,11 @@ func (collector *Collector) getAllMetrics() *watcher.WatcherMetrics {
 // getNodeMetrics : get metrics for a node from watcher
 func (collector *Collector) getNodeMetrics(nodeName string) []watcher.Metric {
 	allMetrics := collector.getAllMetrics()
+	// This happens if metrics were never populated since scheduler started
+	if allMetrics.Data.NodeMetricsMap == nil {
+		klog.ErrorS(nil, "Metrics not available from watcher, assigning 0 score to node", "nodeName", nodeName);
+		return nil;
+	}
 	// Check if node is new (no metrics yet) or metrics are unavailable due to 404 or 500
 	if _, ok := allMetrics.Data.NodeMetricsMap[nodeName]; !ok {
 		klog.ErrorS(nil, "Unable to find metrics for node", "nodeName", nodeName)

--- a/pkg/trimaran/loadvariationriskbalancing/collector.go
+++ b/pkg/trimaran/loadvariationriskbalancing/collector.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog/v2"
 
 	pluginConfig "sigs.k8s.io/scheduler-plugins/pkg/apis/config"
-	"sigs.k8s.io/scheduler-plugins/pkg/apis/config/v1beta1"
 )
 
 const (
@@ -57,8 +56,10 @@ type Collector struct {
 // newCollector : create an instance of a data collector
 func newCollector(obj runtime.Object) (*Collector, error) {
 	// get the plugin arguments
-	args := getArgs(obj)
-
+	args, err := getArgs(obj)
+	if err != nil {
+		return nil, err
+	}
 	klog.V(4).InfoS("Using LoadVariationRiskBalancingArgs", "type", args.MetricProvider.Type, "address", args.MetricProvider.Address, "margin", args.SafeVarianceMargin, "sensitivity", args.SafeVarianceSensitivity, "watcher", args.WatcherAddress)
 
 	var client loadwatcherapi.Client
@@ -79,7 +80,7 @@ func newCollector(obj runtime.Object) (*Collector, error) {
 	}
 
 	// populate metrics before returning
-	err := collector.updateMetrics()
+	err = collector.updateMetrics()
 	if err != nil {
 		klog.ErrorS(err, "Unable to populate metrics initially")
 	}
@@ -109,8 +110,8 @@ func (collector *Collector) getNodeMetrics(nodeName string) []watcher.Metric {
 	allMetrics := collector.getAllMetrics()
 	// This happens if metrics were never populated since scheduler started
 	if allMetrics.Data.NodeMetricsMap == nil {
-		klog.ErrorS(nil, "Metrics not available from watcher, assigning 0 score to node", "nodeName", nodeName);
-		return nil;
+		klog.ErrorS(nil, "Metrics not available from watcher")
+		return nil
 	}
 	// Check if node is new (no metrics yet) or metrics are unavailable due to 404 or 500
 	if _, ok := allMetrics.Data.NodeMetricsMap[nodeName]; !ok {
@@ -121,21 +122,22 @@ func (collector *Collector) getNodeMetrics(nodeName string) []watcher.Metric {
 }
 
 // getArgs : get configured args
-func getArgs(obj runtime.Object) *pluginConfig.LoadVariationRiskBalancingArgs {
+func getArgs(obj runtime.Object) (*pluginConfig.LoadVariationRiskBalancingArgs, error) {
 	// cast object into plugin arguments object
 	args, ok := obj.(*pluginConfig.LoadVariationRiskBalancingArgs)
 	if !ok {
-		klog.ErrorS(nil, "PluginArgs is not of type LoadVariationRiskBalancingArgs, using defaults", "argsType", fmt.Sprintf("%T", obj))
-		args = &pluginConfig.LoadVariationRiskBalancingArgs{
-			MetricProvider: pluginConfig.MetricProviderSpec{
-				Type: v1beta1.DefaultMetricProviderType,
-			},
-			SafeVarianceMargin:      v1beta1.DefaultSafeVarianceMargin,
-			SafeVarianceSensitivity: v1beta1.DefaultSafeVarianceSensitivity,
-		}
-		return args
+		return nil, fmt.Errorf("want args to be of type LoadVariationRiskBalancingArgs, got %T", obj)
 	}
-	return args
+	if args.WatcherAddress == "" {
+		metricProviderType := string(args.MetricProvider.Type)
+		validMetricProviderType := metricProviderType == string(pluginConfig.KubernetesMetricsServer) ||
+			metricProviderType == string(pluginConfig.Prometheus) ||
+			metricProviderType == string(pluginConfig.SignalFx)
+		if !validMetricProviderType {
+			return nil, fmt.Errorf("invalid MetricProvider.Type, got %T", args.MetricProvider.Type)
+		}
+	}
+	return args, nil
 }
 
 // updateMetrics : request to load watcher to update all metrics


### PR DESCRIPTION
This PR fixes bugs in Trimaran plugins when metrics from watcher are never populated in Trimaran watcher cache since the scheduler started. This could happen due to misconfigurations (incorrect) provider address, token etc., and if no metrics provider is running.

Also adds missing default handling for TargetLoadPackingArgs