### PR TITLE
update the documents to adapt to 0.21.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ changed.
 
 Scheduler Plugins  | Compiled With k8s Version | Container Image                                      | Arch           |
 -------------------|---------------------------|------------------------------------------------------|----------------|
+v0.21.6            | v1.21.6                   | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6  | AMD64<br>ARM64 |
 v0.20.10           | v1.20.10                  | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.20.10 | AMD64<br>ARM64 |
 v0.19.9            | v1.19.9                   | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.19.9  | AMD64<br>ARM64 |
 v0.19.8            | v1.19.8                   | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.19.8  | AMD64<br>ARM64 |
@@ -58,6 +59,7 @@ v0.18.9            | v1.18.9                   | k8s.gcr.io/scheduler-plugins/ku
 
 Controller | Compiled With k8s Version | Container Image                                  | Arch           |
 -----------|---------------------------|--------------------------------------------------|----------------|
+v0.21.6    | v1.21.6                   | k8s.gcr.io/scheduler-plugins/controller:v0.21.6  | AMD64<br>ARM64 |
 v0.20.10   | v1.20.10                  | k8s.gcr.io/scheduler-plugins/controller:v0.20.10 | AMD64<br>ARM64 |
 v0.19.9    | v1.19.9                   | k8s.gcr.io/scheduler-plugins/controller:v0.19.9  | AMD64<br>ARM64 |
 v0.19.8    | v1.19.8                   | k8s.gcr.io/scheduler-plugins/controller:v0.19.8  | AMD64<br>ARM64 |

--- a/doc/install.md
+++ b/doc/install.md
@@ -3,7 +3,7 @@
 ## Table of Contents
 
 - [Create a Kubernetes Cluster](#create-a-kubernetes-cluster)
-- [Install release v0.20.10 and use Coscheduling](#install-release-v0199-and-use-coscheduling)
+- [Install release v0.21.6 and use Coscheduling](#install-release-v0216-and-use-coscheduling)
     - [As a second scheduler](#as-a-second-scheduler)
     - [As a single scheduler(replacing the vanilla default-scheduler)](#as-a-single-schedulerreplacing-the-vanilla-default-scheduler)
 - [Test Coscheduling](#test-coscheduling)
@@ -14,7 +14,7 @@
 
 Firstly you need to have a Kubernetes cluster, and a `kubectl` command-line tool must be configured to communicate with the cluster.
 
-The Kubernetes version must equal to or greater than **v1.20.0**. To check the version, use `kubectl version --short`.
+The Kubernetes version must equal to or greater than **v1.21.0**. To check the version, use `kubectl version --short`.
 
 If you do not have a cluster yet, create one by using one of the following provision tools:
 
@@ -22,7 +22,7 @@ If you do not have a cluster yet, create one by using one of the following provi
 * [kubeadm](https://kubernetes.io/docs/admin/kubeadm/)
 * [minikube](https://minikube.sigs.k8s.io/)
 
-## Install release v0.20.10 and use Coscheduling
+## Install release v0.21.6 and use Coscheduling
 
 Note: we provide two ways to install the scheduler-plugin artifacts: as a second scheduler
 and as a single scheduler. Their pros and cons are as below:
@@ -181,9 +181,9 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     >     - --kubeconfig=/etc/kubernetes/scheduler.conf
     >     - --leader-elect=true
     19,20c20
-    <     image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.20.10
+    <     image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6
     ---
-    >     image: k8s.gcr.io/kube-scheduler:v1.20.10
+    >     image: k8s.gcr.io/kube-scheduler:v1.21.6
     50,52d49
     <     - mountPath: /etc/kubernetes/sched-cc.yaml
     <       name: sched-cc
@@ -195,14 +195,14 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     <     name: sched-cc
     ```
    
-1. Verify that kube-scheduler pod is running properly with a correct image: `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.20.10`
+1. Verify that kube-scheduler pod is running properly with a correct image: `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6`
 
     ```bash
     $ kubectl get pod -n kube-system | grep kube-scheduler
     kube-scheduler-kind-control-plane            1/1     Running   0          3m27s
  
     $ kubectl get pods -l component=kube-scheduler -n kube-system -o=jsonpath="{.items[0].spec.containers[0].image}{'\n'}"
-    k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.20.10
+    k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6
     ```
 
 ## Test Coscheduling

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -80,5 +80,5 @@ spec:
       serviceAccount: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
-        image: k8s.gcr.io/scheduler-plugins/controller:v0.20.10
+        image: k8s.gcr.io/scheduler-plugins/controller:v0.21.6
         imagePullPolicy: IfNotPresent

--- a/manifests/install/charts/as-a-second-scheduler/Chart.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.9
+version: 0.21.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.19.9
+appVersion: 0.21.6

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -4,12 +4,12 @@
 
 scheduler:
   name: scheduler-plugins-scheduler
-  image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.20.10
+  image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6
   namespace: scheduler-plugins
   replicaCount: 1
 
 controller:
   name: scheduler-plugins-controller
-  image: k8s.gcr.io/scheduler-plugins/controller:v0.20.10
+  image: k8s.gcr.io/scheduler-plugins/controller:v0.21.6
   namespace: scheduler-plugins
   replicaCount: 1


### PR DESCRIPTION
/kind document

This PR updates the documents and helm chart to pin the latest images to v0.21.6.