### PR TITLE
NodeResourceTopology: Bump NRT API to version v0.0.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.1.2
-	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.10
+	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/paypal/load-watcher v0.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.10 h1:wHS+TOQfFY67wkS1roZ5WVyihnE/IQmVsD0zzKtzHrU=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.10/go.mod h1:yJo22okt35DQhvNw3Hgpaol6/oryET8Y5n1CJb9R5mM=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12 h1:NhXbOjO1st8hIcVpegr3zw/AGG12vs3z//tCDDcfPpE=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/manifests/noderesourcetopology/crd.yaml
+++ b/manifests/noderesourcetopology/crd.yaml
@@ -17,7 +17,7 @@ spec:
     shortNames:
     - node-res-topo
     singular: noderesourcetopology
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/manifests/noderesourcetopology/scheduler-config-v1beta1.yaml
+++ b/manifests/noderesourcetopology/scheduler-config-v1beta1.yaml
@@ -1,0 +1,25 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+clientConnection:
+  # kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+  kubeconfig: "/etc/kubernetes/scheduler.conf"
+profiles:
+- schedulerName: topo-aware-scheduler
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+# optional plugin configs
+  pluginConfig:
+  - name: NodeResourceTopologyMatch
+    args:
+      # kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+      kubeconfigpath: "/etc/kubernetes/scheduler.conf"
+      # other strategies are MostAllocated and BalancedAllocation
+      scoringStrategy:
+        type: "LeastAllocated"

--- a/manifests/noderesourcetopology/scheduler-config.yaml
+++ b/manifests/noderesourcetopology/scheduler-config.yaml
@@ -18,8 +18,6 @@ profiles:
   pluginConfig:
   - name: NodeResourceTopologyMatch
     args:
-      namespaces:
-      - "default"
       # other strategies are MostAllocated and BalancedAllocation
       scoringStrategy:
         type: "LeastAllocated"

--- a/manifests/noderesourcetopology/scheduler-configmap-v1beta1.yaml
+++ b/manifests/noderesourcetopology/scheduler-configmap-v1beta1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: topo-aware-scheduler-config
+  namespace: kube-system
+data:
+  scheduler-config.yaml: |
+      apiVersion: kubescheduler.config.k8s.io/v1beta1
+      kind: KubeSchedulerConfiguration
+      leaderElection:
+        leaderElect: false
+      clientConnection:
+        # kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+        kubeconfig: "/etc/kubernetes/scheduler.conf"
+      profiles:
+        - schedulerName: topo-aware-scheduler
+          plugins:
+            filter:
+              enabled:
+                - name: NodeResourceTopologyMatch
+            score:
+              enabled:
+                - name: NodeResourceTopologyMatch
+          # optional plugin configs
+          pluginConfig:
+          - name: NodeResourceTopologyMatch
+            args:
+              # kubeconfig: "REPLACE_ME_WITH_KUBE_CONFIG_PATH"
+              kubeconfigpath: "/etc/kubernetes/scheduler.conf"
+              scoringStrategy:
+                type: "LeastAllocated"

--- a/manifests/noderesourcetopology/scheduler-configmap.yaml
+++ b/manifests/noderesourcetopology/scheduler-configmap.yaml
@@ -24,7 +24,5 @@ data:
           pluginConfig:
           - name: NodeResourceTopologyMatch
             args:
-              namespaces:
-              - "default"
               scoringStrategy:
                 type: "LeastAllocated"

--- a/manifests/noderesourcetopology/worker-node-A.yaml
+++ b/manifests/noderesourcetopology/worker-node-A.yaml
@@ -3,7 +3,6 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-a
-  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: node-0

--- a/manifests/noderesourcetopology/worker-node-B.yaml
+++ b/manifests/noderesourcetopology/worker-node-B.yaml
@@ -3,7 +3,6 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-b
-  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: node-0

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -142,9 +142,6 @@ type ScoringStrategy struct {
 type NodeResourceTopologyMatchArgs struct {
 	metav1.TypeMeta
 
-	// Namespaces to be considered by NodeResourceTopologyMatch plugin
-	Namespaces []string
-
 	// ScoringStrategy a scoring model that determine how the plugin will score the nodes.
 	ScoringStrategy ScoringStrategy
 }

--- a/pkg/apis/config/v1beta1/defaults.go
+++ b/pkg/apis/config/v1beta1/defaults.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerconfig "k8s.io/kube-scheduler/config/v1"
 
 	pluginConfig "sigs.k8s.io/scheduler-plugins/pkg/apis/config"
@@ -130,9 +129,6 @@ func SetDefaultLoadVariationRiskBalancingArgs(args *LoadVariationRiskBalancingAr
 func SetDefaultsNodeResourceTopologyMatchArgs(obj *NodeResourceTopologyMatchArgs) {
 	if obj.KubeConfigPath == nil {
 		obj.KubeConfigPath = &defaultKubeConfigPath
-	}
-	if len(obj.Namespaces) == 0 {
-		obj.Namespaces = []string{metav1.NamespaceDefault}
 	}
 
 	if obj.ScoringStrategy == nil {

--- a/pkg/apis/config/v1beta1/defaults_test.go
+++ b/pkg/apis/config/v1beta1/defaults_test.go
@@ -141,7 +141,6 @@ func TestSchedulingDefaults(t *testing.T) {
 			config: &NodeResourceTopologyMatchArgs{},
 			expect: &NodeResourceTopologyMatchArgs{
 				KubeConfigPath: pointer.StringPtr("/etc/kubernetes/scheduler.conf"),
-				Namespaces:     []string{"default"},
 				ScoringStrategy: &ScoringStrategy{
 					Type:      LeastAllocated,
 					Resources: defaultResourceSpec,

--- a/pkg/apis/config/v1beta1/types.go
+++ b/pkg/apis/config/v1beta1/types.go
@@ -156,6 +156,5 @@ type NodeResourceTopologyMatchArgs struct {
 
 	KubeConfigPath  *string          `json:"kubeconfigpath,omitempty"`
 	MasterOverride  *string          `json:"masteroverride,omitempty"`
-	Namespaces      []string         `json:"namespaces,omitempty"`
 	ScoringStrategy *ScoringStrategy `json:"scoringStrategy,omitempty"`
 }

--- a/pkg/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1beta1/zz_generated.conversion.go
@@ -221,7 +221,6 @@ func Convert_config_MetricProviderSpec_To_v1beta1_MetricProviderSpec(in *config.
 func autoConvert_v1beta1_NodeResourceTopologyMatchArgs_To_config_NodeResourceTopologyMatchArgs(in *NodeResourceTopologyMatchArgs, out *config.NodeResourceTopologyMatchArgs, s conversion.Scope) error {
 	// WARNING: in.KubeConfigPath requires manual conversion: does not exist in peer-type
 	// WARNING: in.MasterOverride requires manual conversion: does not exist in peer-type
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
 	// WARNING: in.ScoringStrategy requires manual conversion: inconvertible types (*sigs.k8s.io/scheduler-plugins/pkg/apis/config/v1beta1.ScoringStrategy vs sigs.k8s.io/scheduler-plugins/pkg/apis/config.ScoringStrategy)
 	// Added manually
 	out.ScoringStrategy = *(*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
@@ -234,7 +233,6 @@ func Convert_v1beta1_NodeResourceTopologyMatchArgs_To_config_NodeResourceTopolog
 }
 
 func autoConvert_config_NodeResourceTopologyMatchArgs_To_v1beta1_NodeResourceTopologyMatchArgs(in *config.NodeResourceTopologyMatchArgs, out *NodeResourceTopologyMatchArgs, s conversion.Scope) error {
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
 	// WARNING: in.ScoringStrategy requires manual conversion: inconvertible types (*sigs.k8s.io/scheduler-plugins/pkg/apis/config/v1beta1.ScoringStrategy vs sigs.k8s.io/scheduler-plugins/pkg/apis/config.ScoringStrategy)
 	// Added manually
 	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(&in.ScoringStrategy))

--- a/pkg/apis/config/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1beta1/zz_generated.deepcopy.go
@@ -183,11 +183,6 @@ func (in *NodeResourceTopologyMatchArgs) DeepCopyInto(out *NodeResourceTopologyM
 		*out = new(string)
 		**out = **in
 	}
-	if in.Namespaces != nil {
-		in, out := &in.Namespaces, &out.Namespaces
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.ScoringStrategy != nil {
 		in, out := &in.ScoringStrategy, &out.ScoringStrategy
 		*out = new(ScoringStrategy)

--- a/pkg/apis/config/v1beta2/defaults.go
+++ b/pkg/apis/config/v1beta2/defaults.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerconfig "k8s.io/kube-scheduler/config/v1"
 
 	pluginConfig "sigs.k8s.io/scheduler-plugins/pkg/apis/config"
@@ -126,10 +125,6 @@ func SetDefaultLoadVariationRiskBalancingArgs(args *LoadVariationRiskBalancingAr
 
 // SetDefaultsNodeResourceTopologyMatchArgs sets the default parameters for NodeResourceTopologyMatch plugin.
 func SetDefaultsNodeResourceTopologyMatchArgs(obj *NodeResourceTopologyMatchArgs) {
-	if len(obj.Namespaces) == 0 {
-		obj.Namespaces = []string{metav1.NamespaceDefault}
-	}
-
 	if obj.ScoringStrategy == nil {
 		obj.ScoringStrategy = &ScoringStrategy{
 			Type:      LeastAllocated,

--- a/pkg/apis/config/v1beta2/defaults_test.go
+++ b/pkg/apis/config/v1beta2/defaults_test.go
@@ -140,7 +140,6 @@ func TestSchedulingDefaults(t *testing.T) {
 			name:   "empty config NodeResourceTopologyMatchArgs",
 			config: &NodeResourceTopologyMatchArgs{},
 			expect: &NodeResourceTopologyMatchArgs{
-				Namespaces: []string{"default"},
 				ScoringStrategy: &ScoringStrategy{
 					Type:      LeastAllocated,
 					Resources: defaultResourceSpec,

--- a/pkg/apis/config/v1beta2/types.go
+++ b/pkg/apis/config/v1beta2/types.go
@@ -140,6 +140,5 @@ type ScoringStrategy struct {
 type NodeResourceTopologyMatchArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces      []string         `json:"namespaces,omitempty"`
 	ScoringStrategy *ScoringStrategy `json:"scoringStrategy,omitempty"`
 }

--- a/pkg/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/config/v1beta2/zz_generated.conversion.go
@@ -217,7 +217,6 @@ func Convert_config_MetricProviderSpec_To_v1beta2_MetricProviderSpec(in *config.
 }
 
 func autoConvert_v1beta2_NodeResourceTopologyMatchArgs_To_config_NodeResourceTopologyMatchArgs(in *NodeResourceTopologyMatchArgs, out *config.NodeResourceTopologyMatchArgs, s conversion.Scope) error {
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
 	// WARNING: in.ScoringStrategy requires manual conversion: inconvertible types (*sigs.k8s.io/scheduler-plugins/pkg/apis/config/v1beta2.ScoringStrategy vs sigs.k8s.io/scheduler-plugins/pkg/apis/config.ScoringStrategy)
 	// Added manually
 	out.ScoringStrategy = *(*config.ScoringStrategy)(unsafe.Pointer(in.ScoringStrategy))
@@ -230,7 +229,6 @@ func Convert_v1beta2_NodeResourceTopologyMatchArgs_To_config_NodeResourceTopolog
 }
 
 func autoConvert_config_NodeResourceTopologyMatchArgs_To_v1beta2_NodeResourceTopologyMatchArgs(in *config.NodeResourceTopologyMatchArgs, out *NodeResourceTopologyMatchArgs, s conversion.Scope) error {
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
 	// WARNING: in.ScoringStrategy requires manual conversion: inconvertible types (sigs.k8s.io/scheduler-plugins/pkg/apis/config.ScoringStrategy vs *sigs.k8s.io/scheduler-plugins/pkg/apis/config/v1beta2.ScoringStrategy)
 	// Added manually
 	out.ScoringStrategy = (*ScoringStrategy)(unsafe.Pointer(&in.ScoringStrategy))

--- a/pkg/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -133,11 +133,6 @@ func (in *MetricProviderSpec) DeepCopy() *MetricProviderSpec {
 func (in *NodeResourceTopologyMatchArgs) DeepCopyInto(out *NodeResourceTopologyMatchArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.Namespaces != nil {
-		in, out := &in.Namespaces, &out.Namespaces
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.ScoringStrategy != nil {
 		in, out := &in.ScoringStrategy, &out.ScoringStrategy
 		*out = new(ScoringStrategy)

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -98,11 +98,6 @@ func (in *MetricProviderSpec) DeepCopy() *MetricProviderSpec {
 func (in *NodeResourceTopologyMatchArgs) DeepCopyInto(out *NodeResourceTopologyMatchArgs) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.Namespaces != nil {
-		in, out := &in.Namespaces, &out.Namespaces
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	in.ScoringStrategy.DeepCopyInto(&out.ScoringStrategy)
 	return
 }

--- a/pkg/noderesourcetopology/README.md
+++ b/pkg/noderesourcetopology/README.md
@@ -22,7 +22,6 @@ In case the cumulative count of node resource allocatable appear to be the same 
 ### Config
 
 Enable the "NodeResourceTopologyMatch" Filter and Score plugins via SchedulerConfigConfiguration.
-NOTE: Update the config below to specify the namespace(s) in which NodeResourceTopology CR instances are present.
 
 ```yaml
 apiVersion: kubescheduler.config.k8s.io/v1beta2
@@ -44,10 +43,6 @@ profiles:
   pluginConfig:
   - name: NodeResourceTopologyMatch
     args:
-      namespaces:
-      - default
-      - production
-      - test-namespace
       # other strategies are MostAllocatable and BalancedAllocation
       scoringStrategy:
         type: "LeastAllocatable"
@@ -60,7 +55,6 @@ Let us assume we have two nodes in a cluster deployed with sample-device-plugin 
 ![Setup](numa-topology.png)
 
 The hardware topology corresponding to both the nodes is represented by the below CRD instances. These CRD instances are supposed to be created by Node Agents like [Resource Topology Exporter](https://github.com/k8stopologyawareschedwg/resource-topology-exporter) (RTE) or Node feature Discovery (NFD). Please refer to issue [Exposing Hardware Topology through CRDs in NFD](https://github.com/kubernetes-sigs/node-feature-discovery/issues/333) and [Design document](https://docs.google.com/document/d/1Q-4wSu1tzmbOXyGk_2r5_mK6JdXXJA-bOd3cAtBFnwo/edit?ts=5f24171f#) which captures details of enhancing NFD to expose node resource topology through CRDs.
-Noderesourcetopology plugin works with namespaces, in this case each CRD could be namespace specific. The default namespace is used if it was omitted in the plugin's configuration.
 
 ```yaml
 # Worker Node A CRD spec
@@ -68,7 +62,6 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-A
-  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: numa-node-0
@@ -103,7 +96,6 @@ apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: worker-node-B
-  namespace: default
 topologyPolicies: ["SingleNUMANodeContainerLevel"]
 zones:
   - name: numa-node-0

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
@@ -128,7 +128,7 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.Cycle
 	}
 
 	nodeName := nodeInfo.Node().Name
-	nodeTopology := findNodeTopology(nodeName, &tm.nodeResTopologyPlugin)
+	nodeTopology := findNodeTopology(nodeName, tm.lister)
 
 	if nodeTopology == nil {
 		return nil

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -43,7 +43,7 @@ const (
 func TestNodeResourceTopology(t *testing.T) {
 	nodeTopologies := make([]*topologyv1alpha1.NodeResourceTopology, 4)
 	nodeTopologies[0] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "node1", Namespace: "default"},
+		ObjectMeta:       metav1.ObjectMeta{Name: "node1"},
 		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 		Zones: topologyv1alpha1.ZoneList{
 			{
@@ -67,7 +67,7 @@ func TestNodeResourceTopology(t *testing.T) {
 		},
 	}
 	nodeTopologies[1] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "node2", Namespace: "default"},
+		ObjectMeta:       metav1.ObjectMeta{Name: "node2"},
 		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 		Zones: topologyv1alpha1.ZoneList{
 			{
@@ -91,7 +91,7 @@ func TestNodeResourceTopology(t *testing.T) {
 		},
 	}
 	nodeTopologies[2] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "node3", Namespace: "default"},
+		ObjectMeta:       metav1.ObjectMeta{Name: "node3"},
 		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
 		Zones: topologyv1alpha1.ZoneList{
 			{
@@ -115,7 +115,7 @@ func TestNodeResourceTopology(t *testing.T) {
 		},
 	}
 	nodeTopologies[3] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "badly_formed_node", Namespace: "default"},
+		ObjectMeta:       metav1.ObjectMeta{Name: "badly_formed_node"},
 		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
 		Zones: topologyv1alpha1.ZoneList{
 			{
@@ -253,10 +253,7 @@ func TestNodeResourceTopology(t *testing.T) {
 	lister := fakeInformer.Lister()
 
 	tm := TopologyMatch{
-		nodeResTopologyPlugin: nodeResTopologyPlugin{
-			namespaces: []string{metav1.NamespaceDefault},
-			lister:     &lister,
-		},
+		lister:         lister,
 		policyHandlers: newPolicyHandlerMap(),
 	}
 

--- a/pkg/noderesourcetopology/plugin.go
+++ b/pkg/noderesourcetopology/plugin.go
@@ -36,11 +36,6 @@ type NUMANode struct {
 
 type NUMANodeList []NUMANode
 
-type nodeResTopologyPlugin struct {
-	lister     *listerv1alpha1.NodeResourceTopologyLister
-	namespaces []string
-}
-
 type tmScopeHandler struct {
 	filter func(pod *v1.Pod, zones topologyv1alpha1.ZoneList, nodeInfo *framework.NodeInfo) *framework.Status
 	score  func(pod *v1.Pod, zones topologyv1alpha1.ZoneList, scorerFn scoreStrategy, resourceToWeightMap resourceToWeightMap) (int64, *framework.Status)
@@ -64,7 +59,7 @@ type PolicyHandlerMap map[topologyv1alpha1.TopologyManagerPolicy]tmScopeHandler
 
 // TopologyMatch plugin which run simplified version of TopologyManager's admit handler
 type TopologyMatch struct {
-	nodeResTopologyPlugin
+	lister              listerv1alpha1.NodeResourceTopologyLister
 	policyHandlers      PolicyHandlerMap
 	scorerFn            scoreStrategy
 	resourceToWeightMap resourceToWeightMap
@@ -107,10 +102,7 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 	}
 
 	topologyMatch := &TopologyMatch{
-		nodeResTopologyPlugin: nodeResTopologyPlugin{
-			lister:     lister,
-			namespaces: tcfg.Namespaces,
-		},
+		lister:              lister,
 		policyHandlers:      newPolicyHandlerMap(),
 		scorerFn:            scoringFunction,
 		resourceToWeightMap: resToWeightMap,

--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -31,25 +31,17 @@ import (
 	listerv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/listers/topology/v1alpha1"
 )
 
-func findNodeTopology(nodeName string, nodeResTopoPlugin *nodeResTopologyPlugin) *topologyv1alpha1.NodeResourceTopology {
-	klog.V(5).InfoS("Namespaces for nodeResTopoPlugin", "namespaces", nodeResTopoPlugin.namespaces)
-	for _, namespace := range nodeResTopoPlugin.namespaces {
-		klog.V(5).InfoS("Lister for nodeResTopoPlugin", "lister", nodeResTopoPlugin.lister)
-		// NodeTopology couldn't be placed in several namespaces simultaneously
-		lister := nodeResTopoPlugin.lister
-		nodeTopology, err := (*lister).NodeResourceTopologies(namespace).Get(nodeName)
-		if err != nil {
-			klog.V(5).ErrorS(err, "Cannot get NodeTopologies from NodeResourceTopologyNamespaceLister")
-			continue
-		}
-		if nodeTopology != nil {
-			return nodeTopology
-		}
+func findNodeTopology(nodeName string, lister listerv1alpha1.NodeResourceTopologyLister) *topologyv1alpha1.NodeResourceTopology {
+	klog.V(5).InfoS("Lister for nodeResTopoPlugin", "lister", lister)
+	nodeTopology, err := lister.Get(nodeName)
+	if err != nil {
+		klog.V(5).ErrorS(err, "Cannot get NodeTopologies from NodeResourceTopologyLister")
+		return nil
 	}
-	return nil
+	return nodeTopology
 }
 
-func initNodeTopologyInformer(kubeConfig *restclient.Config) (*listerv1alpha1.NodeResourceTopologyLister, error) {
+func initNodeTopologyInformer(kubeConfig *restclient.Config) (listerv1alpha1.NodeResourceTopologyLister, error) {
 	topoClient, err := topoclientset.NewForConfig(kubeConfig)
 	if err != nil {
 		klog.ErrorS(err, "Cannot create clientset for NodeTopologyResource", "kubeConfig", kubeConfig)
@@ -65,7 +57,7 @@ func initNodeTopologyInformer(kubeConfig *restclient.Config) (*listerv1alpha1.No
 	topologyInformerFactory.Start(ctx.Done())
 	topologyInformerFactory.WaitForCacheSync(ctx.Done())
 
-	return &nodeResourceTopologyLister, nil
+	return nodeResourceTopologyLister, nil
 }
 
 func createNUMANodeList(zones topologyv1alpha1.ZoneList) NUMANodeList {

--- a/pkg/noderesourcetopology/score.go
+++ b/pkg/noderesourcetopology/score.go
@@ -22,7 +22,7 @@ import (
 
 	"gonum.org/v1/gonum/stat"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	apiconfig "sigs.k8s.io/scheduler-plugins/pkg/apis/config"
@@ -55,7 +55,7 @@ func (rw resourceToWeightMap) weight(r v1.ResourceName) int64 {
 
 func (tm *TopologyMatch) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	klog.V(5).InfoS("Scoring node", "nodeName", nodeName)
-	nodeTopology := findNodeTopology(nodeName, &tm.nodeResTopologyPlugin)
+	nodeTopology := findNodeTopology(nodeName, tm.lister)
 
 	if nodeTopology == nil {
 		return 0, nil

--- a/pkg/noderesourcetopology/score_test.go
+++ b/pkg/noderesourcetopology/score_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/listers/topology/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -43,7 +43,7 @@ func TestNodeResourceScorePlugin(t *testing.T) {
 	initTest := func() {
 		// noderesourcetopology objects
 		nodeTopologies[0] = &topologyv1alpha1.NodeResourceTopology{
-			ObjectMeta:       metav1.ObjectMeta{Name: "Node1", Namespace: "default"},
+			ObjectMeta:       metav1.ObjectMeta{Name: "Node1"},
 			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 			Zones: topologyv1alpha1.ZoneList{
 				topologyv1alpha1.Zone{
@@ -66,7 +66,7 @@ func TestNodeResourceScorePlugin(t *testing.T) {
 		}
 
 		nodeTopologies[1] = &topologyv1alpha1.NodeResourceTopology{
-			ObjectMeta:       metav1.ObjectMeta{Name: "Node2", Namespace: "default"},
+			ObjectMeta:       metav1.ObjectMeta{Name: "Node2"},
 			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 			Zones: topologyv1alpha1.ZoneList{
 				topologyv1alpha1.Zone{
@@ -87,7 +87,7 @@ func TestNodeResourceScorePlugin(t *testing.T) {
 			},
 		}
 		nodeTopologies[2] = &topologyv1alpha1.NodeResourceTopology{
-			ObjectMeta:       metav1.ObjectMeta{Name: "Node3", Namespace: "default"},
+			ObjectMeta:       metav1.ObjectMeta{Name: "Node3"},
 			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 			Zones: topologyv1alpha1.ZoneList{
 				topologyv1alpha1.Zone{
@@ -196,10 +196,7 @@ func TestNodeResourceScorePlugin(t *testing.T) {
 			}
 
 			tm := &TopologyMatch{
-				nodeResTopologyPlugin: nodeResTopologyPlugin{
-					lister:     &lister,
-					namespaces: []string{metav1.NamespaceDefault},
-				},
+				lister:         lister,
 				policyHandlers: newPolicyHandlerMap(),
 				scorerFn:       scoringFunction,
 			}

--- a/test/integration/noderesourcetopology_test.go
+++ b/test/integration/noderesourcetopology_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -184,7 +184,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			},
 			nodeResourceTopologies: []*topologyv1alpha1.NodeResourceTopology{
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -222,7 +222,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -269,7 +269,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			},
 			nodeResourceTopologies: []*topologyv1alpha1.NodeResourceTopology{
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -297,7 +297,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -334,7 +334,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			},
 			nodeResourceTopologies: []*topologyv1alpha1.NodeResourceTopology{
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -362,7 +362,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2"},
 					TopologyPolicies: []string{"foo"},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -400,7 +400,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			},
 			nodeResourceTopologies: []*topologyv1alpha1.NodeResourceTopology{
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -422,7 +422,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -454,7 +454,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			},
 			nodeResourceTopologies: []*topologyv1alpha1.NodeResourceTopology{
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -476,7 +476,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -508,7 +508,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			},
 			nodeResourceTopologies: []*topologyv1alpha1.NodeResourceTopology{
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-1"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -530,7 +530,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2", Namespace: ns.Name},
+					ObjectMeta:       metav1.ObjectMeta{Name: "fake-node-2"},
 					TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
 					Zones: topologyv1alpha1.ZoneList{
 						topologyv1alpha1.Zone{
@@ -637,7 +637,7 @@ func makeNodeResourceTopologyCRD() *apiextensionsv1.CustomResourceDefinition {
 
 func createNodeResourceTopologies(ctx context.Context, topologyClient *versioned.Clientset, noderesourcetopologies []*topologyv1alpha1.NodeResourceTopology) error {
 	for _, nrt := range noderesourcetopologies {
-		_, err := topologyClient.TopologyV1alpha1().NodeResourceTopologies(nrt.Namespace).Create(ctx, nrt, metav1.CreateOptions{})
+		_, err := topologyClient.TopologyV1alpha1().NodeResourceTopologies().Create(ctx, nrt, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}
@@ -647,7 +647,7 @@ func createNodeResourceTopologies(ctx context.Context, topologyClient *versioned
 
 func cleanupNodeResourceTopologies(ctx context.Context, topologyClient *versioned.Clientset, noderesourcetopologies []*topologyv1alpha1.NodeResourceTopology) {
 	for _, nrt := range noderesourcetopologies {
-		err := topologyClient.TopologyV1alpha1().NodeResourceTopologies(nrt.Namespace).Delete(ctx, nrt.Name, metav1.DeleteOptions{})
+		err := topologyClient.TopologyV1alpha1().NodeResourceTopologies().Delete(ctx, nrt.Name, metav1.DeleteOptions{})
 		if err != nil {
 			klog.ErrorS(err, "Failed to clean up NodeResourceTopology", "nodeResourceTopology", nrt)
 		}
@@ -717,7 +717,6 @@ func makeProfileByPluginArgs(
 
 func makeResourceAllocationScoreArgs(ns string, strategy *scheconfig.ScoringStrategy) *scheconfig.NodeResourceTopologyMatchArgs {
 	return &scheconfig.NodeResourceTopologyMatchArgs{
-		Namespaces:      []string{ns},
 		ScoringStrategy: *strategy,
 	}
 }

--- a/test/integration/noderesourcetopology_test.go
+++ b/test/integration/noderesourcetopology_test.go
@@ -120,7 +120,6 @@ func TestTopologyMatchPlugin(t *testing.T) {
 	cfg.Profiles[0].PluginConfig = append(cfg.Profiles[0].PluginConfig, schedapi.PluginConfig{
 		Name: noderesourcetopology.Name,
 		Args: &scheconfig.NodeResourceTopologyMatchArgs{
-			Namespaces:      []string{ns.Name},
 			ScoringStrategy: scheconfig.ScoringStrategy{Type: scheconfig.MostAllocated},
 		},
 	})


### PR DESCRIPTION
The NodeResourceTopology API has been made cluster
scoped as in the current context a CR corresponds to
a Node and since Node is a cluster scoped resource it
makes sense to make NRT cluster scoped as well.

Ref: https://github.com/k8stopologyawareschedwg/noderesourcetopology-api/pull/18
