### PR TITLE
rbac: align permissions with 1.22

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -57,7 +57,7 @@ rules:
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["csinodes", "storageclasses" , "csidrivers" , "csistoragecapacities"]
+  resources: ["csinodes", "storageclasses", "csidrivers", "csistoragecapacities"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["topology.node.k8s.io"]
   resources: ["noderesourcetopologies"]


### PR DESCRIPTION
Looking at the permissions of the clusterrole `system:kube-scheduler` in
1.22, we see

```yaml
- apiGroups:
  - storage.k8s.io
  resources:
  - csinodes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - storage.k8s.io
  resources:
  - csidrivers
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - storage.k8s.io
  resources:
  - csistoragecapacities
  verbs:
  - get
  - list
  - watch
```

This PR aligns the secondary scheduler RBAC permissions to these.

Signed-off-by: Francesco Romani <fromani@redhat.com>