### PR TITLE
0.21 chart should go with v1beta1

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.scheduler.namespace }}
 data:
   scheduler-config.yaml: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1beta1
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: false


### PR DESCRIPTION
Fixes #296.

But note that the configmap is more an example to indicate which plugins to enable/disable. We may come up with a better customizable configmap by leveraging the Helm grammar.