### PR TITLE
Fix controller reconcile PodGroup status

### DIFF
--- a/pkg/controller/podgroup.go
+++ b/pkg/controller/podgroup.go
@@ -243,6 +243,11 @@ func (ctrl *PodGroupController) syncHandler(key string) error {
 		pgCopy.Status.Succeeded = succeeded
 		pgCopy.Status.Running = running
 
+		if len(pods) == 0 {
+			pgCopy.Status.Phase = schedv1alpha1.PodGroupPending
+			break
+		}
+
 		if pgCopy.Status.Scheduled >= pgCopy.Spec.MinMember && pgCopy.Status.Phase == schedv1alpha1.PodGroupScheduling {
 			pgCopy.Status.Phase = schedv1alpha1.PodGroupScheduled
 		}

--- a/pkg/controller/podgroup_test.go
+++ b/pkg/controller/podgroup_test.go
@@ -110,7 +110,7 @@ func Test_Run(t *testing.T) {
 			podNextPhase:      v1.PodSucceeded,
 		},
 		{
-			name:               "Group group should not enqueue, created too long",
+			name:               "Group should not enqueue, created too long",
 			pgName:             "pg8",
 			minMember:          2,
 			podNames:           []string{"pod1", "pod2"},
@@ -120,7 +120,7 @@ func Test_Run(t *testing.T) {
 			podGroupCreateTime: &createTime,
 		},
 		{
-			name:              "Group group min member more than Pod number",
+			name:              "Group min member more than Pod number",
 			pgName:            "pg9",
 			minMember:         3,
 			podNames:          []string{"pod91", "pod92"},
@@ -128,11 +128,25 @@ func Test_Run(t *testing.T) {
 			previousPhase:     v1alpha1.PodGroupPending,
 			desiredGroupPhase: v1alpha1.PodGroupPreScheduling,
 		},
+		{
+			name:              "Group status convert from running to pending",
+			pgName:            "pg10",
+			minMember:         2,
+			podNames:          []string{},
+			podPhase:          v1.PodPending,
+			previousPhase:     v1alpha1.PodGroupRunning,
+			desiredGroupPhase: v1alpha1.PodGroupPending,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ps := makePods(c.podNames, c.pgName, c.podPhase)
-			kubeClient := fake.NewSimpleClientset(ps[0], ps[1])
+			var kubeClient *fake.Clientset
+			if len(c.podNames) == 0 {
+				kubeClient = fake.NewSimpleClientset()
+			} else {
+				ps := makePods(c.podNames, c.pgName, c.podPhase)
+				kubeClient = fake.NewSimpleClientset(ps[0], ps[1])
+			}
 			pg := makePG(c.pgName, 2, c.previousPhase, c.podGroupCreateTime)
 			pgClient := pgfake.NewSimpleClientset(pg)
 


### PR DESCRIPTION
Fix #166 

It will be 3 final state of pod group: Failed, Finished, Pending.

Pending means: 
1. The pod group has been accepted by the system, but scheduler can not allocate enough resources to it.
2. The PodGroup doesn't have any associated Pods or associated Pods scaled down to 0.

Failed means: 
at least one of `spec.minMember` pods is failed.

Finished means:
all of `spec.minMember` pods are successfully.

/cc @Huang-Wei @cwdsuzhou @denkensk 
