### PR TITLE
Nominate denkensk as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,8 +3,8 @@
 approvers:
   - ahg-g
   - Huang-Wei
+  - denkensk
 reviewers:
   - cwdsuzhou
-  - denkensk
   - seanmalloy
   - yuanchen8911


### PR DESCRIPTION
@denkensk is an active contributor/reviewer since the creation of this repo. His contributions includes but not limited to:

- authored the design and implementation of initial version of co-scheduling plugin
- reviewed the 2nd edition of co-scheduling plugin
- authored the design and implementation of capacityscheduling plugin
- main reviewers of releasing PRs
- ......

I'd like to nominate him as a new approver.