### PR TITLE
fix bugs of resource calculation in node resource topology

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -98,18 +98,8 @@ func resMatchNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1
 
 func singleNUMAPodLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneList, nodeInfo *framework.NodeInfo) *framework.Status {
 	klog.V(5).InfoS("Pod Level Resource handler")
-	resources := make(v1.ResourceList)
 
-	// We count here in the way TopologyManager is doing it, IOW we put InitContainers
-	// and normal containers in the one scope
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		for resource, quantity := range container.Resources.Requests {
-			if q, ok := resources[resource]; ok {
-				quantity.Add(q)
-			}
-			resources[resource] = quantity
-		}
-	}
+	resources := util.GetPodEffectiveRequest(pod)
 
 	if resMatchNUMANodes(createNUMANodeList(zones), resources, v1qos.GetPodQOS(pod), nodeInfo) {
 		// definitely we can't align container, so we can't align a pod

--- a/pkg/util/resource.go
+++ b/pkg/util/resource.go
@@ -41,3 +41,37 @@ func ResourceList(r *framework.Resource) v1.ResourceList {
 	}
 	return result
 }
+
+// GetPodEffectiveRequest gets the effective request resource of a pod to the origin resource.
+// The Pod's effective request is the higher of:
+// - the sum of all app containers(spec.Containers) request for a resource.
+// - the effective init containers(spec.InitContainers) request for a resource.
+// The effective init containers request is the highest request on all init containers.
+func GetPodEffectiveRequest(pod *v1.Pod) v1.ResourceList {
+	initResources := make(v1.ResourceList)
+	resources := make(v1.ResourceList)
+
+	for _, container := range pod.Spec.InitContainers {
+		for name, quantity := range container.Resources.Requests {
+			if q, ok := initResources[name]; ok && quantity.Cmp(q) <= 0 {
+				continue
+			}
+			initResources[name] = quantity
+		}
+	}
+	for _, container := range pod.Spec.Containers {
+		for name, quantity := range container.Resources.Requests {
+			if q, ok := resources[name]; ok {
+				quantity.Add(q)
+			}
+			resources[name] = quantity
+		}
+	}
+	for name, quantity := range initResources {
+		if q, ok := resources[name]; ok && quantity.Cmp(q) <= 0 {
+			continue
+		}
+		resources[name] = quantity
+	}
+	return resources
+}

--- a/pkg/util/resource_test.go
+++ b/pkg/util/resource_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func makeResourceList(cpu, mem int64) v1.ResourceList {
+	return v1.ResourceList{
+		v1.ResourceCPU:    *resource.NewMilliQuantity(cpu, resource.DecimalSI),
+		v1.ResourceMemory: *resource.NewQuantity(mem, resource.BinarySI),
+	}
+}
+
+func TestGetPodEffectiveRequest(t *testing.T) {
+	tests := []struct {
+		name                 string
+		containerRequest     []v1.ResourceList
+		initContainerRequest []v1.ResourceList
+		want                 v1.ResourceList
+	}{
+		{
+			name: "1 container",
+			containerRequest: []v1.ResourceList{
+				makeResourceList(1, 1),
+			},
+			initContainerRequest: nil,
+			want:                 makeResourceList(1, 1),
+		},
+		{
+			name: "2 containers",
+			containerRequest: []v1.ResourceList{
+				makeResourceList(1, 1),
+				makeResourceList(2, 3),
+			},
+			initContainerRequest: nil,
+			want:                 makeResourceList(3, 4),
+		},
+		{
+			name: "2 containers and 1 init container",
+			containerRequest: []v1.ResourceList{
+				makeResourceList(1, 1),
+				makeResourceList(2, 3),
+			},
+			initContainerRequest: []v1.ResourceList{
+				makeResourceList(1, 1),
+			},
+			want: makeResourceList(3, 4),
+		},
+		{
+			name: "2 containers and 1 init container with large cpu",
+			containerRequest: []v1.ResourceList{
+				makeResourceList(1, 1),
+				makeResourceList(2, 3),
+			},
+			initContainerRequest: []v1.ResourceList{
+				makeResourceList(10, 1),
+			},
+			want: makeResourceList(10, 4),
+		},
+		{
+			name: "2 containers and 2 init containers with large cpu or mem",
+			containerRequest: []v1.ResourceList{
+				makeResourceList(1, 1),
+				makeResourceList(2, 3),
+			},
+			initContainerRequest: []v1.ResourceList{
+				makeResourceList(10, 1),
+				makeResourceList(1, 10),
+			},
+			want: makeResourceList(10, 10),
+		},
+		{
+			name: "2 containers and 2 init containers with only large cpu",
+			containerRequest: []v1.ResourceList{
+				makeResourceList(1, 1),
+				makeResourceList(2, 3),
+			},
+			initContainerRequest: []v1.ResourceList{
+				makeResourceList(10, 1),
+				makeResourceList(1, 1),
+			},
+			want: makeResourceList(10, 4),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &v1.Pod{}
+			for _, request := range tt.containerRequest {
+				pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+					Resources: v1.ResourceRequirements{
+						Requests: request,
+					},
+				})
+			}
+			for _, request := range tt.initContainerRequest {
+				pod.Spec.InitContainers = append(pod.Spec.InitContainers, v1.Container{
+					Resources: v1.ResourceRequirements{
+						Requests: request,
+					},
+				})
+			}
+			if got := GetPodEffectiveRequest(pod); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPodEffectiveRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

According to the [doc](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources), the Pod's effective request is the higher of:

- the sum of all app containers(spec.Containers) request for a resource.
- the effective init containers(spec.InitContainers) request for a resource.

The effective init containers request is the highest request on all init containers.

And that's what the cpumanager of kubelet does when caculating resources. See [here](https://github.com/kubernetes/kubernetes/blob/b1479da6ad7d4afeb5056ce1a17312a39e06a888/pkg/kubelet/cm/cpumanager/policy_static.go#L357-L383).
