### PR TITLE
Add PreemptionToleration to Plugin List in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The kube-scheduler binary includes the below list of plugins. They can be config
 * [Coscheduling](pkg/coscheduling/README.md)
 * [Node Resources](pkg/noderesources/README.md)
 * [Node Resource Topology](pkg/noderesourcetopology/README.md)
+* [Preemption Toleration](pkg/preemptiontoleration/README.md)
 * [Trimaran](pkg/trimaran/README.md)
 
 Additionally the kube-scheduler binary includes the below list of sample plugins. These plugins are not intended for use in production


### PR DESCRIPTION
It just added [Preemption Toleration](pkg/preemptiontoleration/README.md) plugin to the list in README which is merged in #224 .