### PR TITLE
cherry pick move podgroup key to api in v1.19

### DIFF
--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -18,6 +18,8 @@ package app
 
 import (
 	"context"
+	"os"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/server"
@@ -29,12 +31,11 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
-	"os"
 
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/controller"
 	pgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"
 	pgformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
-	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
 func newConfig(kubeconfig, master string, inCluster bool) (*restclient.Config, error) {
@@ -70,7 +71,7 @@ func Run(s *ServerRunOptions) error {
 	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 0, informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
-		opt.LabelSelector = util.PodGroupLabel
+		opt.LabelSelector = v1alpha1.PodGroupLabel
 	}))
 	podInformer := informerFactory.Core().V1().Pods()
 	ctrl := controller.NewPodGroupController(kubeClient, pgInformer, podInformer, pgClient)

--- a/pkg/apis/scheduling/v1alpha1/types.go
+++ b/pkg/apis/scheduling/v1alpha1/types.go
@@ -107,6 +107,9 @@ const (
 
 	// PodGroupFailed means at least one of `spec.minMember` pods is failed.
 	PodGroupFailed PodGroupPhase = "Failed"
+
+	// PodGroupLabel is the default label of coscheduling
+	PodGroupLabel = "pod-group.scheduling.sigs.k8s.io"
 )
 
 // +genclient

--- a/pkg/apis/scheduling/v1alpha1/types.go
+++ b/pkg/apis/scheduling/v1alpha1/types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling"
 )
 
 // +genclient
@@ -109,7 +110,7 @@ const (
 	PodGroupFailed PodGroupPhase = "Failed"
 
 	// PodGroupLabel is the default label of coscheduling
-	PodGroupLabel = "pod-group.scheduling.sigs.k8s.io"
+	PodGroupLabel = "pod-group." + scheduling.GroupName
 )
 
 // +genclient

--- a/pkg/controller/podgroup.go
+++ b/pkg/controller/podgroup.go
@@ -201,7 +201,7 @@ func (ctrl *PodGroupController) syncHandler(ctx context.Context, pg *schedv1alph
 	}()
 
 	pgCopy := pg.DeepCopy()
-	selector := labels.Set(map[string]string{util.PodGroupLabel: pgCopy.Name}).AsSelector()
+	selector := labels.Set(map[string]string{schedv1alpha1.PodGroupLabel: pgCopy.Name}).AsSelector()
 	pods, err := ctrl.podLister.List(selector)
 	if err != nil {
 		klog.Errorf("List pods for group %v failed: %v", pgCopy.Name, err)

--- a/pkg/controller/podgroup_test.go
+++ b/pkg/controller/podgroup_test.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	pgfake "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/fake"
 	schedinformer "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
-	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
 func Test_Run(t *testing.T) {
@@ -165,7 +164,7 @@ func makePods(podNames []string, pgName string, phase v1.PodPhase) []*v1.Pod {
 	pds := make([]*v1.Pod, 0)
 	for _, name := range podNames {
 		pod := st.MakePod().Namespace("default").Name(name).Obj()
-		pod.Labels = map[string]string{util.PodGroupLabel: pgName}
+		pod.Labels = map[string]string{v1alpha1.PodGroupLabel: pgName}
 		pod.Status.Phase = phase
 		pds = append(pds, pod)
 	}

--- a/pkg/coscheduling/core/core.go
+++ b/pkg/coscheduling/core/core.go
@@ -109,7 +109,7 @@ func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, pod *corev1.Pod) er
 		return err
 	}
 	pods, err := pgMgr.podLister.Pods(pod.Namespace).List(
-		labels.SelectorFromSet(labels.Set{util.PodGroupLabel: util.GetPodGroupLabel(pod)}),
+		labels.SelectorFromSet(labels.Set{v1alpha1.PodGroupLabel: util.GetPodGroupLabel(pod)}),
 	)
 	if err != nil {
 		return fmt.Errorf("podLister list pods failed: %v", err)
@@ -266,7 +266,7 @@ func (pgMgr *PodGroupManager) CalculateAssignedPods(podGroupName, namespace stri
 	for _, nodeInfo := range nodeInfos {
 		for _, podInfo := range nodeInfo.Pods {
 			pod := podInfo.Pod
-			if pod.Labels[util.PodGroupLabel] == podGroupName && pod.Namespace == namespace && pod.Spec.NodeName != "" {
+			if pod.Labels[v1alpha1.PodGroupLabel] == podGroupName && pod.Namespace == namespace && pod.Spec.NodeName != "" {
 				count++
 			}
 		}

--- a/pkg/coscheduling/core/core_test.go
+++ b/pkg/coscheduling/core/core_test.go
@@ -70,82 +70,82 @@ func TestPreFilter(t *testing.T) {
 			name: "pod does not belong to any pg",
 			pod:  st.MakePod().Name("p").UID("p").Namespace("ns1").Obj(),
 			pods: []*corev1.Pod{
-				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
-				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg2").Obj(),
+				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 			},
 			lastDeniedPG:    newCache(),
 			expectedSuccess: true,
 		},
 		{
 			name:            "pg was previously denied",
-			pod:             st.MakePod().Name("p1").UID("p1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:             st.MakePod().Name("p1").UID("p1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			lastDeniedPG:    denyCache,
 			expectedSuccess: false,
 		},
 		{
 			name:            "pod belongs to a non-existing pg",
-			pod:             st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(util.PodGroupLabel, "pg-notexisting").Obj(),
+			pod:             st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg-notexisting").Obj(),
 			lastDeniedPG:    newCache(),
 			expectedSuccess: true,
 		},
 		{
 			name: "pod count less than minMember",
-			pod:  st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:  st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			pods: []*corev1.Pod{
-				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg2").Obj(),
+				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 			},
 			lastDeniedPG:    newCache(),
 			expectedSuccess: false,
 		},
 		{
 			name: "pod count equal minMember",
-			pod:  st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:  st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			pods: []*corev1.Pod{
-				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
-				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			},
 			lastDeniedPG:    newCache(),
 			expectedSuccess: true,
 		},
 		{
 			name: "pod count more minMember",
-			pod:  st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:  st.MakePod().Name("p2").UID("p2").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			pods: []*corev1.Pod{
-				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
-				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
-				st.MakePod().Name("pg3-1").UID("pg3-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg3-1").UID("pg3-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			},
 			lastDeniedPG:    newCache(),
 			expectedSuccess: true,
 		},
 		{
 			name: "cluster resource enough, min Resource",
-			pod: st.MakePod().Name("p2-1").UID("p2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg2").
+			pod: st.MakePod().Name("p2-1").UID("p2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg2").
 				Req(map[corev1.ResourceName]string{corev1.ResourceCPU: "1"}).Obj(),
 			pods: []*corev1.Pod{
-				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(util.PodGroupLabel, "pg2").Obj(),
-				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg2").Obj(),
+				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
+				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 			},
 			lastDeniedPG:    newCache(),
 			expectedSuccess: true,
 		},
 		{
 			name: "cluster resource not enough, min Resource",
-			pod: st.MakePod().Name("p2-1").UID("p2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg3").
+			pod: st.MakePod().Name("p2-1").UID("p2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg3").
 				Req(map[corev1.ResourceName]string{corev1.ResourceCPU: "20"}).Obj(),
 			pods: []*corev1.Pod{
-				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(util.PodGroupLabel, "pg3").Obj(),
-				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg3").Obj(),
+				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg3").Obj(),
+				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg3").Obj(),
 			},
 			lastDeniedPG:    newCache(),
 			expectedSuccess: false,
 		},
 		{
 			name: "cluster resource enough not required",
-			pod:  st.MakePod().Name("p2-1").UID("p2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:  st.MakePod().Name("p2-1").UID("p2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			pods: []*corev1.Pod{
-				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
-				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg1-1").UID("pg1-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pg2-1").UID("pg2-1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			},
 			lastDeniedPG:    newCache(),
 			expectedSuccess: true,
@@ -189,7 +189,7 @@ func TestPermit(t *testing.T) {
 	pgInformer.Informer().GetStore().Add(pg1)
 	pgLister := pgInformer.Lister()
 
-	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{util.PodGroupLabel: "pg1"}, 1, 1)
+	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{v1alpha1.PodGroupLabel: "pg1"}, 1, 1)
 	existingPods[0].Spec.NodeName = allNodes[0].Name
 	existingPods[0].Namespace = "ns1"
 	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
@@ -207,18 +207,18 @@ func TestPermit(t *testing.T) {
 		},
 		{
 			name:  "pod belongs to pg, a non-existing pg",
-			pod:   st.MakePod().Name("p").UID("p").Namespace("ns1").Label(util.PodGroupLabel, "pg-noexist").Obj(),
+			pod:   st.MakePod().Name("p").UID("p").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg-noexist").Obj(),
 			allow: false,
 		},
 		{
 			name:     "pod belongs to a pg that doesn't have enough pods",
-			pod:      st.MakePod().Name("p").UID("p").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:      st.MakePod().Name("p").UID("p").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			snapshot: testutil.NewFakeSharedLister([]*corev1.Pod{}, []*corev1.Node{}),
 			allow:    false,
 		},
 		{
 			name:     "pod belongs to a pg that has enough pods",
-			pod:      st.MakePod().Name("p").UID("p").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:      st.MakePod().Name("p").UID("p").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			snapshot: snapshot,
 			allow:    true,
 		},
@@ -260,19 +260,19 @@ func TestPostBind(t *testing.T) {
 	}{
 		{
 			name:              "pg status convert to scheduled",
-			pod:               st.MakePod().Name("p").UID("p").Namespace("ns1").Label(util.PodGroupLabel, "pg").Obj(),
+			pod:               st.MakePod().Name("p").UID("p").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg").Obj(),
 			desiredGroupPhase: v1alpha1.PodGroupScheduled,
 			desiredScheduled:  1,
 		},
 		{
 			name:              "pg status convert to scheduling",
-			pod:               st.MakePod().Name("p").UID("p").Namespace("ns1").Label(util.PodGroupLabel, "pg1").Obj(),
+			pod:               st.MakePod().Name("p").UID("p").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			desiredGroupPhase: v1alpha1.PodGroupScheduling,
 			desiredScheduled:  1,
 		},
 		{
 			name:              "pg status does not convert, although scheduled pods change",
-			pod:               st.MakePod().Name("p").UID("p").Namespace("ns1").Label(util.PodGroupLabel, "pg2").Obj(),
+			pod:               st.MakePod().Name("p").UID("p").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 			desiredGroupPhase: v1alpha1.PodGroupScheduling,
 			desiredScheduled:  1,
 		},
@@ -307,7 +307,7 @@ func TestCheckClusterResource(t *testing.T) {
 	snapshot := testutil.NewFakeSharedLister(nil, []*corev1.Node{node})
 	nodeInfo, _ := snapshot.NodeInfos().List()
 
-	pod := st.MakePod().Name("t1-p1-3").Req(map[corev1.ResourceName]string{corev1.ResourceMemory: "100"}).Label(util.PodGroupLabel,
+	pod := st.MakePod().Name("t1-p1-3").Req(map[corev1.ResourceName]string{corev1.ResourceMemory: "100"}).Label(v1alpha1.PodGroupLabel,
 		"pg1-1").ZeroTerminationGracePeriod().Obj()
 	snapshotWithAssumedPod := testutil.NewFakeSharedLister([]*corev1.Pod{pod}, []*corev1.Node{node})
 	scheduledNodeInfo, _ := snapshotWithAssumedPod.NodeInfos().List()

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -34,6 +34,7 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 
 	"sigs.k8s.io/scheduler-plugins/pkg/apis/config"
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling/core"
 	pgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"
 	pgformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
@@ -176,7 +177,7 @@ func (cs *Coscheduling) PostFilter(ctx context.Context, state *framework.CycleSt
 	// It's based on an implicit assumption: if the nth Pod failed,
 	// it's inferrable other Pods belonging to the same PodGroup would be very likely to fail.
 	cs.frameworkHandler.IterateOverWaitingPods(func(waitingPod framework.WaitingPod) {
-		if waitingPod.GetPod().Namespace == pod.Namespace && waitingPod.GetPod().Labels[util.PodGroupLabel] == pg.Name {
+		if waitingPod.GetPod().Namespace == pod.Namespace && waitingPod.GetPod().Labels[v1alpha1.PodGroupLabel] == pg.Name {
 			klog.V(3).Infof("PostFilter rejects the pod: %v/%v", pgName, waitingPod.GetPod().Name)
 			waitingPod.Reject(cs.Name())
 		}
@@ -243,7 +244,7 @@ func (cs *Coscheduling) Unreserve(ctx context.Context, state *framework.CycleSta
 		return
 	}
 	cs.frameworkHandler.IterateOverWaitingPods(func(waitingPod framework.WaitingPod) {
-		if waitingPod.GetPod().Namespace == pod.Namespace && waitingPod.GetPod().Labels[util.PodGroupLabel] == pg.Name {
+		if waitingPod.GetPod().Namespace == pod.Namespace && waitingPod.GetPod().Labels[v1alpha1.PodGroupLabel] == pg.Name {
 			klog.V(3).Infof("Unreserve rejects the pod: %v/%v", pgName, waitingPod.GetPod().Name)
 			waitingPod.Reject(cs.Name())
 		}

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -80,7 +80,7 @@ func New(obj runtime.Object, handle framework.FrameworkHandle) (framework.Plugin
 		klog.Fatalf("ParseSelector failed %+v", err)
 	}
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(handle.ClientSet(), 0, informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
-		opt.LabelSelector = util.PodGroupLabel
+		opt.LabelSelector = v1alpha1.PodGroupLabel
 		opt.FieldSelector = fieldSelector.String()
 	}))
 	podInformer := informerFactory.Core().V1().Pods()

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -31,10 +31,10 @@ import (
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 
 	_ "sigs.k8s.io/scheduler-plugins/pkg/apis/config/scheme"
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling/core"
 	fakepgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/fake"
 	pgformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
-	pgutil "sigs.k8s.io/scheduler-plugins/pkg/util"
 	testutil "sigs.k8s.io/scheduler-plugins/test/util"
 )
 
@@ -144,7 +144,7 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority less than p2.priority, p1 belongs to podGroup1",
 			p1: &framework.QueuedPodInfo{
-				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(pgutil.PodGroupLabel, "pg1").Obj(),
+				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			},
 			p2: &framework.QueuedPodInfo{
 				Pod: st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj(),
@@ -154,7 +154,7 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority greater than p2.priority, p1 belongs to podGroup1",
 			p1: &framework.QueuedPodInfo{
-				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg1").Obj(),
+				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			},
 			p2: &framework.QueuedPodInfo{
 				Pod: st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Obj(),
@@ -164,7 +164,7 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to podGroup3",
 			p1: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg3").Obj(),
+				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj(),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
@@ -176,7 +176,7 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to podGroup3",
 			p1: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg3").Obj(),
+				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj(),
 				InitialAttemptTimestamp: times[1],
 			},
 			p2: &framework.QueuedPodInfo{
@@ -189,31 +189,31 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority less than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(pgutil.PodGroupLabel, "pg1").Obj(),
+				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod: st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg2").Obj(),
+				Pod: st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
 			name: "p1.priority greater than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg1").Obj(),
+				Pod: st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod: st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Label(pgutil.PodGroupLabel, "pg2").Obj(),
+				Pod: st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg1").Obj(),
+				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg2").Obj(),
+				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 				InitialAttemptTimestamp: times[1],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -221,11 +221,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to podGroup4 and p2 belongs to podGroup3",
 			p1: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg4").Obj(),
+				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg4").Obj(),
 				InitialAttemptTimestamp: times[1],
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg3").Obj(),
+				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj(),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
@@ -233,11 +233,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority and creation time, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg1").Obj(),
+				Pod:                     st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg2").Obj(),
+				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -249,7 +249,7 @@ func TestLess(t *testing.T) {
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(pgutil.PodGroupLabel, "pg2").Obj(),
+				Pod:                     st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -278,12 +278,12 @@ func TestPermit(t *testing.T) {
 		},
 		{
 			name:     "pods belong to a podGroup, Wait",
-			pod:      st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(pgutil.PodGroupLabel, "pg1").Obj(),
+			pod:      st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
 			expected: framework.Wait,
 		},
 		{
 			name:     "pods belong to a podGroup, Allow",
-			pod:      st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(pgutil.PodGroupLabel, "pg2").Obj(),
+			pod:      st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
 			expected: framework.Success,
 		},
 	}
@@ -334,7 +334,7 @@ func TestPostFilter(t *testing.T) {
 	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
 	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 
-	existingPods, allNodes = testutil.MakeNodesAndPods(map[string]string{pgutil.PodGroupLabel: "pg"}, 10, 30)
+	existingPods, allNodes = testutil.MakeNodesAndPods(map[string]string{v1alpha1.PodGroupLabel: "pg"}, 10, 30)
 	for _, pod := range existingPods {
 		pod.Namespace = "ns1"
 	}
@@ -363,14 +363,14 @@ func TestPostFilter(t *testing.T) {
 		},
 		{
 			name:                 "enough pods assigned, do not reject all",
-			pod:                  st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(pgutil.PodGroupLabel, "pg").Obj(),
+			pod:                  st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg").Obj(),
 			expectedEmptyMsg:     true,
 			snapshotSharedLister: groupPodSnapshot,
 			preFilterSuccess:     true,
 		},
 		{
 			name:             "pod failed at filter phase, reject all pods",
-			pod:              st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(pgutil.PodGroupLabel, "pg").Obj(),
+			pod:              st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg").Obj(),
 			expectedEmptyMsg: false,
 			preFilterSuccess: true,
 		},

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -18,11 +18,6 @@ package util
 
 import "fmt"
 
-const (
-	// PodGroupLabel is the default label of coscheduling
-	PodGroupLabel = "pod-group.scheduling.sigs.k8s.io"
-)
-
 var (
 	// ErrorNotMatched means pod does not match coscheduling
 	ErrorNotMatched = fmt.Errorf("not match coscheduling")

--- a/pkg/util/podgroup.go
+++ b/pkg/util/podgroup.go
@@ -49,7 +49,7 @@ func CreateMergePatch(original, new interface{}) ([]byte, error) {
 
 // GetPodGroupLabel get pod group from pod annotations
 func GetPodGroupLabel(pod *v1.Pod) string {
-	return pod.Labels[PodGroupLabel]
+	return pod.Labels[v1alpha1.PodGroupLabel]
 }
 
 // GetPodGroupFullName get namespaced group name from pod annotations

--- a/test/integration/coscheduling_test.go
+++ b/test/integration/coscheduling_test.go
@@ -45,7 +45,6 @@ import (
 	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling"
 	pgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"
-	coschedulingutil "sigs.k8s.io/scheduler-plugins/pkg/util"
 	"sigs.k8s.io/scheduler-plugins/test/util"
 )
 
@@ -195,19 +194,19 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "equal priority, sequentially pg1 meet min and pg2 not meet min",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t1-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg1-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg1-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t1-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg1-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg1-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t1-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg1-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg1-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t1-p2-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t1-p2-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t1-p2-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t1-p2-4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg1-2").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg1-1", ns.Name, 3, nil, nil),
@@ -219,19 +218,19 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "equal priority, not sequentially pg1 meet min and pg2 not meet min",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t2-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg2-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg2-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t2-p2-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t2-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg2-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg2-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t2-p2-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t2-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg2-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg2-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t2-p2-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t2-p2-4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg2-2").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg2-1", ns.Name, 3, nil, nil),
@@ -243,15 +242,15 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "equal priority, not sequentially pg1 not meet min and 3 regular pods",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t3-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg3-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg3-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t3-p2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
 					midPriority).ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t3-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg3-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg3-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t3-p3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
 					midPriority).ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t3-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg3-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg3-1").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg3-1", ns.Name, 4, nil, nil),
@@ -262,17 +261,17 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "different priority, sequentially pg1 meet min and pg2 meet min",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t4-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg4-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg4-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t4-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg4-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg4-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t4-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg4-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg4-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t4-p2-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					highPriority).Label(coschedulingutil.PodGroupLabel, "pg4-2").ZeroTerminationGracePeriod().Obj(), pause),
+					highPriority).Label(v1alpha1.PodGroupLabel, "pg4-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t4-p2-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					highPriority).Label(coschedulingutil.PodGroupLabel, "pg4-2").ZeroTerminationGracePeriod().Obj(), pause),
+					highPriority).Label(v1alpha1.PodGroupLabel, "pg4-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t4-p2-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					highPriority).Label(coschedulingutil.PodGroupLabel, "pg4-2").ZeroTerminationGracePeriod().Obj(), pause),
+					highPriority).Label(v1alpha1.PodGroupLabel, "pg4-2").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg4-1", ns.Name, 3, nil, nil),
@@ -284,17 +283,17 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "different priority, not sequentially pg1 meet min and pg2 meet min",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t5-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg5-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg5-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t5-p2-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					highPriority).Label(coschedulingutil.PodGroupLabel, "pg5-2").ZeroTerminationGracePeriod().Obj(), pause),
+					highPriority).Label(v1alpha1.PodGroupLabel, "pg5-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t5-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg5-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg5-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t5-p2-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					highPriority).Label(coschedulingutil.PodGroupLabel, "pg5-2").ZeroTerminationGracePeriod().Obj(), pause),
+					highPriority).Label(v1alpha1.PodGroupLabel, "pg5-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t5-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg5-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg5-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t5-p2-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					highPriority).Label(coschedulingutil.PodGroupLabel, "pg5-2").ZeroTerminationGracePeriod().Obj(), pause),
+					highPriority).Label(v1alpha1.PodGroupLabel, "pg5-2").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg5-1", ns.Name, 3, nil, nil),
@@ -306,15 +305,15 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "different priority, not sequentially pg1 meet min and 3 regular pods",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t6-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg6-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg6-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t6-p2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
 					highPriority).ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t6-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg6-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg6-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t6-p3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
 					highPriority).ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t6-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg6-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg6-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t6-p4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
 					highPriority).ZeroTerminationGracePeriod().Obj(), pause),
 			},
@@ -327,27 +326,27 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "equal priority, not sequentially pg1 meet min and p2 p3 not meet min",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p2-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p3-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p2-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p3-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p2-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p3-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p2-4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t7-p3-4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg7-3").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg7-1", ns.Name, 3, nil, nil),
@@ -360,27 +359,27 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "equal priority, not sequentially pg1 meet min and p2 p3 not meet min, pgs have min resources",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p2-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p3-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p2-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p3-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p2-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p3-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p2-4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t8-p3-4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg8-3").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg8-1", ns.Name, 3, nil, &v1.ResourceList{v1.ResourceMemory: resource.MustParse("150")}),
@@ -393,19 +392,19 @@ func TestCoschedulingPlugin(t *testing.T) {
 			name: "equal priority, not sequentially pg1 meet min and pg2 not meet min, pgs have min resources",
 			pods: []*v1.Pod{
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t9-p1-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg9-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg9-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t9-p2-1").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t9-p1-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg9-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg9-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t9-p2-2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t9-p1-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "50"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg9-1").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg9-1").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t9-p2-3").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
 				WithContainer(st.MakePod().Namespace(ns.Name).Name("t9-p2-4").Req(map[v1.ResourceName]string{v1.ResourceMemory: "100"}).Priority(
-					midPriority).Label(coschedulingutil.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
+					midPriority).Label(v1alpha1.PodGroupLabel, "pg9-2").ZeroTerminationGracePeriod().Obj(), pause),
 			},
 			podGroups: []*v1alpha1.PodGroup{
 				util.MakePG("pg9-1", ns.Name, 3, nil, &v1.ResourceList{v1.ResourceMemory: resource.MustParse("150")}),


### PR DESCRIPTION
due to the k8s version import in trainning-operator is v1.19, so I cherry pick it to 1.19 https://github.com/kubernetes-sigs/scheduler-plugins/pull/323
https://github.com/kubeflow/training-operator/blob/c935698e4ba17542c651076aa381efaa09995e9d/go.mod#L14

I will cherry pick to 1.20 and 1.21 later.