### PR TITLE
enhancement: improve the helm chart implementation to configure multi plugins

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/Chart.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.6
+version: 0.22.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.21.6
+appVersion: 0.22.6

--- a/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.plugins.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,35 +6,43 @@ metadata:
   namespace: {{ .Values.scheduler.namespace }}
 data:
   scheduler-config.yaml: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta1
+    apiVersion: kubescheduler.config.k8s.io/v1beta2
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: false
     profiles:
+    # Compose all plugins in one profile
     - schedulerName: scheduler-plugins-scheduler
       plugins:
+      # Ensure only the first queueSort plugin is rendered.
+
+ {{- $enabledPlugins := .Values.plugins.enabled -}}
+
+  {{- if and (.Values.global.queueSort) (has (index .Values.global.queueSort 0) $enabledPlugins) }}
         queueSort:
           enabled:
-          - name: Coscheduling
+          - name: {{ index .Values.global.queueSort 0 }}
           disabled:
           - name: "*"
-        preFilter:
+  {{- end }}
+   
+    {{- $hasExtension := true -}}
+    
+      {{- range $extension, $plugins := .Values.global.extensions }}
+       {{- $hasExtension = true -}}
+           {{- range $plugins }}
+             {{- if and $hasExtension (has . $enabledPlugins) }}
+        {{ $extension }}:
           enabled:
-          - name: Coscheduling
-        postFilter:
-          enabled:
-          - name: Coscheduling
-        permit:
-          enabled:
-          - name: Coscheduling
-        reserve:
-          enabled:
-          - name: Coscheduling
-        postBind:
-          enabled:
-          - name: Coscheduling
-      pluginConfig:
-      - name: Coscheduling
-        args:
-          permitWaitingTimeSeconds: 10
-          deniedPGExpirationTimeSeconds: 3
+           {{- $hasExtension = false -}}
+              {{- end}}
+            {{- if has . $enabledPlugins }}
+           - name: {{ title . }} 
+            {{- end}}
+         
+        {{- end }}
+      {{- end }}
+
+ {{- end }}
+
+  {{- /* TODO: wire CRD installation with enabled plugins. */}}

--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
         - --address=0.0.0.0
         - --leader-elect=false
         - --config=/etc/kubernetes/scheduler-config.yaml
-        - --scheduler-name=scheduler-plugins-scheduler
         image: {{ .Values.scheduler.image }}
         livenessProbe:
           httpGet:

--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -3,6 +3,9 @@ kind: ClusterRole
 metadata:
   name: scheduler-plugins-scheduler
 rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["", "events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
@@ -22,10 +25,10 @@ rules:
   verbs: ["get", "update"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["delete", "get", "list", "watch"]
+  verbs: ["delete", "get", "list", "watch", "update"]
 - apiGroups: [""]
   resources: ["bindings", "pods/binding"]
   verbs: ["create"]
@@ -54,8 +57,12 @@ rules:
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["csinodes", "storageclasses"]
+  resources: ["csinodes", "storageclasses" , "csidrivers" , "csistoragecapacities"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["topology.node.k8s.io"]
+  resources: ["noderesourcetopologies"]
+  verbs: ["*"]
+# resources need to be updated with the scheduler plugins used
 - apiGroups: ["scheduling.sigs.k8s.io"]
   resources: ["podgroups", "elasticquotas"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
@@ -81,6 +88,13 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch"]
+- apiGroups: ["topology.node.k8s.io"]
+  resources: ["noderesourcetopologies"]
+  verbs: ["*"]
+# resources need to be updated with the scheduler plugins used
 - apiGroups: ["scheduling.sigs.k8s.io"]
   resources: ["podgroups", "elasticquotas"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
@@ -114,4 +128,3 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.controller.name }}
   namespace: {{ .Values.controller.namespace }}
-

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -1,15 +1,35 @@
+
 # Default values for scheduler-plugins-as-a-second-scheduler.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 scheduler:
   name: scheduler-plugins-scheduler
-  image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6
+  image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.22.6
   namespace: scheduler-plugins
   replicaCount: 1
 
 controller:
   name: scheduler-plugins-controller
-  image: k8s.gcr.io/scheduler-plugins/controller:v0.21.6
+  image: k8s.gcr.io/scheduler-plugins/controller:v0.22.6
   namespace: scheduler-plugins
   replicaCount: 1
+
+# LoadVariationRiskBalancing and TargetLoadPacking are not enabled by default
+# as they need extra RBAC privileges on metrics.k8s.io.
+
+plugins:
+  enabled: ["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]
+
+global:  
+   # queueSort is not indented under extensions 
+   # as it needs to be globally enabled once. 
+  queueSort: ["Coscheduling"]
+  extensions: 
+    preFilter: ["Coscheduling", "CapacityScheduling"] 
+    filter: ["NodeResourceTopologyMatch"] 
+    postFilter: ["Coscheduling", "CapacityScheduling"] 
+    score: ["NodeResourceTopologyMatch", "NodeResourcesAllocatable"] 
+    permit: ["Coscheduling"] 
+    reserve: ["Coscheduling", "CapacityScheduling"] 
+    postBind: ["Coscheduling"]


### PR DESCRIPTION
In this PR:
- Give users the ability to configure to enable plugins as a list.
- Give users the ability to configure to set list of plugins args.
Fixes #321 