### PR TITLE
bump go version to 1.17 in Dockerfiles

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.16.10
+FROM golang:1.17.6
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.16.10
+FROM golang:1.17.6
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

With the recent Go version bump in source code, the Go version in Dockerfile needs to upgraded as well; otherwise, it will throw an error: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-scheduler-plugins-push-images/1492937069842927616

```
go mod tidy: go.mod file indicates go 1.17, but maximum supported version is 1.16
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

