### PR TITLE
implement strict alignment check for the noderesourcetopology filter plugin

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -73,19 +73,12 @@ func resMatchNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1
 			if !ok && !resourceFoundOnNode(resource, quantity, nodeInfo) && !quantity.IsZero() {
 				continue
 			}
-			// Check for the following:
-			// 1. set numa node as possible node if resource is memory or Hugepages
-			// 2. set numa node as possible node if resource is cpu and it's not guaranteed QoS, since cpu will flow
-			// 3. set numa node as possible node if zero quantity for non existing resource was requested
-			// 4. otherwise check amount of resources
-			if resource == v1.ResourceMemory ||
-				strings.HasPrefix(string(resource), v1.ResourceHugePagesPrefix) ||
-				resource == v1.ResourceCPU && qos != v1.PodQOSGuaranteed ||
-				quantity.IsZero() ||
-				numaQuantity.Cmp(quantity) >= 0 {
-				// possible to align resources on NUMA node
-				resourceBitmask.Add(numaNode.NUMAID)
+
+			if !isNUMANodeSuitable(qos, resource, quantity, numaQuantity) {
+				continue
 			}
+
+			resourceBitmask.Add(numaNode.NUMAID)
 		}
 		bitmask.And(resourceBitmask)
 		if bitmask.IsEmpty() {
@@ -93,6 +86,23 @@ func resMatchNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1
 		}
 	}
 	return bitmask.IsEmpty()
+}
+
+func isNUMANodeSuitable(qos v1.PodQOSClass, resource v1.ResourceName, quantity, numaQuantity resource.Quantity) bool {
+	// Check for the following:
+	// 1. set numa node as possible node if resource is memory or Hugepages
+	// 2. set numa node as possible node if resource is cpu and it's not guaranteed QoS, since cpu will flow
+	// 3. set numa node as possible node if zero quantity for non existing resource was requested
+	// 4. otherwise check amount of resources
+	if resource == v1.ResourceMemory ||
+		strings.HasPrefix(string(resource), v1.ResourceHugePagesPrefix) ||
+		resource == v1.ResourceCPU && qos != v1.PodQOSGuaranteed ||
+		quantity.IsZero() ||
+		numaQuantity.Cmp(quantity) >= 0 {
+		// possible to align resources on NUMA node
+		return true
+	}
+	return false
 }
 
 func singleNUMAPodLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneList, nodeInfo *framework.NodeInfo) *framework.Status {

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -60,7 +60,6 @@ func resMatchNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1
 	// on the NUMA node, bit should be unset
 	bitmask.Fill()
 
-	zeroQuantity := resource.MustParse("0")
 	for resource, quantity := range resources {
 		// for each requested resource, calculate which NUMA slots are good fits, and then AND with the aggregated bitmask, IOW unset appropriate bit if we can't align resources, or set it
 		// obvious, bits which are not in the NUMA id's range would be unset
@@ -71,7 +70,7 @@ func resMatchNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1
 			// if the resource can be found at the node itself, because there are resources which are not NUMA aligned
 			// or not supported by the topology exporter - if resource was not found at both checks - skip (don't set it as available NUMA node).
 			// if the un-found resource has 0 quantity probably this numa node can be considered.
-			if !ok && !resourceFoundOnNode(resource, quantity, nodeInfo) && quantity.Cmp(zeroQuantity) != 0 {
+			if !ok && !resourceFoundOnNode(resource, quantity, nodeInfo) && !quantity.IsZero() {
 				continue
 			}
 			// Check for the following:
@@ -82,7 +81,7 @@ func resMatchNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1
 			if resource == v1.ResourceMemory ||
 				strings.HasPrefix(string(resource), v1.ResourceHugePagesPrefix) ||
 				resource == v1.ResourceCPU && qos != v1.PodQOSGuaranteed ||
-				quantity.Cmp(zeroQuantity) == 0 ||
+				quantity.IsZero() ||
 				numaQuantity.Cmp(quantity) >= 0 {
 				// possible to align resources on NUMA node
 				resourceBitmask.Add(numaNode.NUMAID)

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -90,16 +90,18 @@ func resMatchNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1
 
 func isNUMANodeSuitable(qos v1.PodQOSClass, resource v1.ResourceName, quantity, numaQuantity resource.Quantity) bool {
 	// Check for the following:
-	// 1. set numa node as possible node if resource is memory or Hugepages
-	if resource == v1.ResourceMemory {
-		return true
-	}
-	if strings.HasPrefix(string(resource), v1.ResourceHugePagesPrefix) {
-		return true
-	}
-	// 2. set numa node as possible node if resource is cpu and it's not guaranteed QoS, since cpu will flow
-	if resource == v1.ResourceCPU && qos != v1.PodQOSGuaranteed {
-		return true
+	if qos != v1.PodQOSGuaranteed {
+		// 1. set numa node as possible node if resource is memory or Hugepages
+		if resource == v1.ResourceMemory {
+			return true
+		}
+		if strings.HasPrefix(string(resource), v1.ResourceHugePagesPrefix) {
+			return true
+		}
+		// 2. set numa node as possible node if resource is CPU
+		if resource == v1.ResourceCPU {
+			return true
+		}
 	}
 	// 3. set numa node as possible node if zero quantity for non existing resource was requested
 	if quantity.IsZero() {

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -170,6 +170,22 @@ func TestNodeResourceTopology(t *testing.T) {
 			wantStatus: nil,
 		},
 		{
+			name: "Guaranteed QoS, minimal, pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi")}),
+			node:       nodes[0],
+			wantStatus: nil,
+		},
+		{
+			name: "Guaranteed QoS, minimal, saturating zone, pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    findAvailableResourceByName(nodeTopologies[0].Zones[1].Resources, cpu),
+				v1.ResourceMemory: findAvailableResourceByName(nodeTopologies[0].Zones[1].Resources, memory)}),
+			node:       nodes[0],
+			wantStatus: nil,
+		},
+		{
 			name: "Guaranteed QoS, zero quantity of unavailable resource, pod fit",
 			pod: makePodByResourceList(&v1.ResourceList{
 				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
@@ -260,6 +276,22 @@ func TestNodeResourceTopology(t *testing.T) {
 			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
 		},
 		{
+			name: "Guaranteed QoS Topology Scope, minimal, pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("1Gi")}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Guaranteed QoS TopologyScope, minimal, saturating zone, pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    findAvailableResourceByName(nodeTopologies[3].Zones[0].Resources, cpu),
+				v1.ResourceMemory: findAvailableResourceByName(nodeTopologies[3].Zones[0].Resources, memory)}),
+			node:       nodes[3],
+			wantStatus: nil,
+		},
+		{
 			name: "Guaranteed QoS Topology Scope, pod fit",
 			pod: makePodByResourceListWithManyContainers(&v1.ResourceList{
 				v1.ResourceCPU:             *resource.NewQuantity(1, resource.DecimalSI),
@@ -305,4 +337,13 @@ func TestNodeResourceTopology(t *testing.T) {
 			}
 		})
 	}
+}
+
+func findAvailableResourceByName(resourceInfoList topologyv1alpha1.ResourceInfoList, name string) resource.Quantity {
+	for _, resourceInfo := range resourceInfoList {
+		if resourceInfo.Name == name {
+			return resourceInfo.Available
+		}
+	}
+	return resource.MustParse("0")
 }

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -42,107 +42,108 @@ const (
 )
 
 func TestNodeResourceTopology(t *testing.T) {
-	nodeTopologies := make([]*topologyv1alpha1.NodeResourceTopology, 4)
-	nodeTopologies[0] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "node1"},
-		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
-		Zones: topologyv1alpha1.ZoneList{
-			{
-				Name: "node-0",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "20", "4"),
-					MakeTopologyResInfo(memory, "8Gi", "8Gi"),
-					MakeTopologyResInfo(nicResourceName, "30", "10"),
+	nodeTopologies := []*topologyv1alpha1.NodeResourceTopology{
+		{
+			ObjectMeta:       metav1.ObjectMeta{Name: "node1"},
+			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
+			Zones: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "20", "4"),
+						MakeTopologyResInfo(memory, "8Gi", "8Gi"),
+						MakeTopologyResInfo(nicResourceName, "30", "10"),
+					},
 				},
-			},
-			{
-				Name: "node-1",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "30", "8"),
-					MakeTopologyResInfo(memory, "8Gi", "8Gi"),
-					MakeTopologyResInfo(nicResourceName, "30", "10"),
-				},
-			},
-		},
-	}
-	nodeTopologies[1] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "node2"},
-		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
-		Zones: topologyv1alpha1.ZoneList{
-			{
-				Name: "node-0",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "20", "2"),
-					MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-					MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
-					MakeTopologyResInfo(nicResourceName, "30", "5"),
-				},
-			},
-			{
-				Name: "node-1",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "30", "4"),
-					MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-					MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
-					MakeTopologyResInfo(nicResourceName, "30", "2"),
+				{
+					Name: "node-1",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "30", "8"),
+						MakeTopologyResInfo(memory, "8Gi", "8Gi"),
+						MakeTopologyResInfo(nicResourceName, "30", "10"),
+					},
 				},
 			},
 		},
-	}
-	nodeTopologies[2] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "node3"},
-		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
-		Zones: topologyv1alpha1.ZoneList{
-			{
-				Name: "node-0",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "20", "2"),
-					MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-					MakeTopologyResInfo(nicResourceName, "30", "5"),
+		{
+			ObjectMeta:       metav1.ObjectMeta{Name: "node2"},
+			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
+			Zones: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "20", "2"),
+						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+						MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
+						MakeTopologyResInfo(nicResourceName, "30", "5"),
+					},
 				},
-			},
-			{
-				Name: "node-1",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "30", "4"),
-					MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-					MakeTopologyResInfo(nicResourceName, "30", "2"),
+				{
+					Name: "node-1",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "30", "4"),
+						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+						MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
+						MakeTopologyResInfo(nicResourceName, "30", "2"),
+					},
 				},
 			},
 		},
-	}
-	nodeTopologies[3] = &topologyv1alpha1.NodeResourceTopology{
-		ObjectMeta:       metav1.ObjectMeta{Name: "badly_formed_node"},
-		TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
-		Zones: topologyv1alpha1.ZoneList{
-			{
-				Name: "node-0",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "20", "2"),
-					MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-					MakeTopologyResInfo(nicResourceName, "30", "5"),
+		{
+			ObjectMeta:       metav1.ObjectMeta{Name: "node3"},
+			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
+			Zones: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "20", "2"),
+						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+						MakeTopologyResInfo(nicResourceName, "30", "5"),
+					},
+				},
+				{
+					Name: "node-1",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "30", "4"),
+						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+						MakeTopologyResInfo(nicResourceName, "30", "2"),
+					},
 				},
 			},
-			{
-				Name: "node-75",
-				Type: "Node",
-				Resources: topologyv1alpha1.ResourceInfoList{
-					MakeTopologyResInfo(cpu, "30", "4"),
-					MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-					MakeTopologyResInfo(nicResourceName, "30", "2"),
+		},
+		{
+			ObjectMeta:       metav1.ObjectMeta{Name: "badly_formed_node"},
+			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
+			Zones: topologyv1alpha1.ZoneList{
+				{
+					Name: "node-0",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "20", "2"),
+						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+						MakeTopologyResInfo(nicResourceName, "30", "5"),
+					},
+				},
+				{
+					Name: "node-75",
+					Type: "Node",
+					Resources: topologyv1alpha1.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "30", "4"),
+						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+						MakeTopologyResInfo(nicResourceName, "30", "2"),
+					},
 				},
 			},
 		},
 	}
 
-	nodes := make([]*v1.Node, 4)
+	nodes := make([]*v1.Node, len(nodeTopologies))
 	for i := range nodes {
 		nodeResTopology := nodeTopologies[i]
 		res := makeResourceListFromZones(nodeResTopology.Zones)


### PR DESCRIPTION
Add one of the following kinds:
/kind cleanup

#### What this PR does / why we need it:
The noderesourcetopology filter plugin used to skip memory and hugepages when checking alignment requirements because the reporting of these resources wasn't readily available. That's no longer the case, so we can now implement a stricter alignment check.

#### Which issue(s) this PR fixes:
Fixes #346

#### Special notes for your reviewer:

