### PR TITLE
noderesourcetopology: revamp the filter logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/scheduler-plugins
 go 1.17
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/google/go-cmp v0.5.5
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -41,10 +41,16 @@ func singleNUMAContainerLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneLis
 	nodes := createNUMANodeList(zones)
 	qos := v1qos.GetPodQOS(pod)
 
+	// Node() != nil already verified in Filter(), which is the only public entry point
+	logNumaNodes("container handler NUMA resources", nodeInfo.Node().Name, nodes)
+
 	// We count here in the way TopologyManager is doing it, IOW we put InitContainers
 	// and normal containers in the one scope
 	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		if !resourcesAvailableInAnyNUMANodes(nodes, container.Resources.Requests, qos, nodeInfo) {
+		logKey := fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, container.Name)
+		klog.V(6).InfoS("target resources", resourceListToLoggable(logKey, container.Resources.Requests)...)
+
+		if !resourcesAvailableInAnyNUMANodes(logKey, nodes, container.Resources.Requests, qos, nodeInfo) {
 			// definitely we can't align container, so we can't align a pod
 			return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", container.Name))
 		}
@@ -54,11 +60,14 @@ func singleNUMAContainerLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneLis
 
 // resourcesAvailableInAnyNUMANodes checks for sufficient resource, this function
 // requires NUMANodeList with properly populated NUMANode, NUMAID should be in range 0-63
-func resourcesAvailableInAnyNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, qos v1.PodQOSClass, nodeInfo *framework.NodeInfo) bool {
+func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, resources v1.ResourceList, qos v1.PodQOSClass, nodeInfo *framework.NodeInfo) bool {
 	bitmask := bm.NewEmptyBitMask()
 	// set all bits, each bit is a NUMA node, if resources couldn't be aligned
 	// on the NUMA node, bit should be unset
 	bitmask.Fill()
+
+	// Node() != nil already verified in Filter(), which is the only public entry point
+	nodeName := nodeInfo.Node().Name
 
 	for resource, quantity := range resources {
 		// for each requested resource, calculate which NUMA slots are good fits, and then AND with the aggregated bitmask, IOW unset appropriate bit if we can't align resources, or set it
@@ -79,13 +88,17 @@ func resourcesAvailableInAnyNUMANodes(numaNodes NUMANodeList, resources v1.Resou
 			}
 
 			resourceBitmask.Add(numaNode.NUMAID)
+			klog.V(6).InfoS("feasible", "logKey", logKey, "node", nodeName, "NUMA", numaNode.NUMAID, "resource", resource)
 		}
 		bitmask.And(resourceBitmask)
 		if bitmask.IsEmpty() {
+			klog.V(5).InfoS("early verdict", "logKey", logKey, "node", nodeName, "resource", resource, "suitable", "false")
 			return false
 		}
 	}
-	return !bitmask.IsEmpty()
+	ret := !bitmask.IsEmpty()
+	klog.V(5).InfoS("final verdict", "logKey", logKey, "node", nodeName, "suitable", ret)
+	return ret
 }
 
 func isNUMANodeSuitable(qos v1.PodQOSClass, resource v1.ResourceName, quantity, numaQuantity resource.Quantity) bool {
@@ -116,7 +129,14 @@ func singleNUMAPodLevelHandler(pod *v1.Pod, zones topologyv1alpha1.ZoneList, nod
 
 	resources := util.GetPodEffectiveRequest(pod)
 
-	if !resourcesAvailableInAnyNUMANodes(createNUMANodeList(zones), resources, v1qos.GetPodQOS(pod), nodeInfo) {
+	logKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	nodes := createNUMANodeList(zones)
+
+	// Node() != nil already verified in Filter(), which is the only public entry point
+	logNumaNodes("pod handler NUMA resources", nodeInfo.Node().Name, nodes)
+	klog.V(6).InfoS("target resources", resourceListToLoggable(logKey, resources)...)
+
+	if !resourcesAvailableInAnyNUMANodes(logKey, createNUMANodeList(zones), resources, v1qos.GetPodQOS(pod), nodeInfo) {
 		// definitely we can't align container, so we can't align a pod
 		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align pod: %s", pod.Name))
 	}

--- a/pkg/noderesourcetopology/pluginhelpers_test.go
+++ b/pkg/noderesourcetopology/pluginhelpers_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesourcetopology
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestResourceListToLoggable(t *testing.T) {
+	tests := []struct {
+		name      string
+		logKey    string
+		resources corev1.ResourceList
+		expected  string
+	}{
+		{
+			name:      "empty",
+			logKey:    "",
+			resources: corev1.ResourceList{},
+			expected:  ` logKey=""`,
+		},
+		{
+			name:      "only logKey",
+			logKey:    "TEST1",
+			resources: corev1.ResourceList{},
+			expected:  ` logKey="TEST1"`,
+		},
+		{
+			name:   "only CPUs",
+			logKey: "TEST1",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("16"),
+			},
+			expected: ` logKey="TEST1" cpu="16"`,
+		},
+		{
+			name:   "only Memory",
+			logKey: "TEST2",
+			resources: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+			expected: ` logKey="TEST2" memory="16 GiB"`,
+		},
+		{
+			name:   "CPUs and Memory, no logKey",
+			logKey: "",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("24"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+			expected: ` logKey="" cpu="24" memory="16 GiB"`,
+		},
+		{
+			name:   "CPUs and Memory",
+			logKey: "TEST3",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("24"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+			expected: ` logKey="TEST3" cpu="24" memory="16 GiB"`,
+		},
+		{
+			name:   "CPUs, Memory, hugepages-2Mi",
+			logKey: "TEST4",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:                   resource.MustParse("24"),
+				corev1.ResourceMemory:                resource.MustParse("16Gi"),
+				corev1.ResourceName("hugepages-2Mi"): resource.MustParse("1Gi"),
+			},
+			expected: ` logKey="TEST4" cpu="24" hugepages-2Mi="1.0 GiB" memory="16 GiB"`,
+		},
+		{
+			name:   "CPUs, Memory, hugepages-2Mi, hugepages-1Gi",
+			logKey: "TEST4",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:                   resource.MustParse("24"),
+				corev1.ResourceMemory:                resource.MustParse("16Gi"),
+				corev1.ResourceName("hugepages-2Mi"): resource.MustParse("1Gi"),
+				corev1.ResourceName("hugepages-1Gi"): resource.MustParse("2Gi"),
+			},
+			expected: ` logKey="TEST4" cpu="24" hugepages-1Gi="2.0 GiB" hugepages-2Mi="1.0 GiB" memory="16 GiB"`,
+		},
+		{
+			name:   "CPUs, Memory, hugepages-2Mi, devices",
+			logKey: "TEST4",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:                           resource.MustParse("24"),
+				corev1.ResourceMemory:                        resource.MustParse("16Gi"),
+				corev1.ResourceName("hugepages-2Mi"):         resource.MustParse("1Gi"),
+				corev1.ResourceName("example.com/netdevice"): resource.MustParse("16"),
+				corev1.ResourceName("awesome.net/gpu"):       resource.MustParse("4"),
+			},
+			expected: ` logKey="TEST4" awesome.net/gpu="4" cpu="24" example.com/netdevice="16" hugepages-2Mi="1.0 GiB" memory="16 GiB"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			keysAndValues := resourceListToLoggable(tt.logKey, tt.resources)
+			kvListFormat(&buf, keysAndValues...)
+			got := buf.String()
+			if got != tt.expected {
+				t.Errorf("got=%q expected=%q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// taken from klog
+
+const missingValue = "(MISSING)"
+
+func kvListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
+	for i := 0; i < len(keysAndValues); i += 2 {
+		var v interface{}
+		k := keysAndValues[i]
+		if i+1 < len(keysAndValues) {
+			v = keysAndValues[i+1]
+		} else {
+			v = missingValue
+		}
+		b.WriteByte(' ')
+
+		switch v.(type) {
+		case string, error:
+			b.WriteString(fmt.Sprintf("%s=%q", k, v))
+		case []byte:
+			b.WriteString(fmt.Sprintf("%s=%+q", k, v))
+		default:
+			if _, ok := v.(fmt.Stringer); ok {
+				b.WriteString(fmt.Sprintf("%s=%q", k, v))
+			} else {
+				b.WriteString(fmt.Sprintf("%s=%+v", k, v))
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Improve the logging in the noderesourcetopology filter plugin, reducing the logs but making them more dense and aiming to better clarify the decision points in the code.

#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
With these changes applied, the logs now look like
```
I0329 14:59:16.519008       1 scheduling_queue.go:928] "About to try and schedule pod" pod="e2e-test-workload-placement-tmpol-4922/testpod"
I0329 14:59:16.519038       1 scheduler.go:516] "Attempting to schedule pod" pod="e2e-test-workload-placement-tmpol-4922/testpod"
I0329 14:59:16.519702       1 pluginhelpers.go:40] "Lister for nodeResTopoPlugin" lister=&{indexer:0xc000900f90}
I0329 14:59:16.519776       1 filter.go:174] "Found NodeResourceTopology" nodeTopology="nodeB.test.net"
I0329 14:59:16.519795       1 filter.go:129] "Pod Level Resource handler"
I0329 14:59:16.519703       1 pluginhelpers.go:40] "Lister for nodeResTopoPlugin" lister=&{indexer:0xc000900f90}
I0329 14:59:16.519880       1 pluginhelpers.go:83] "extracted NUMA resources" logKey="node-0" cpu="14" memory="15 GiB"
I0329 14:59:16.519900       1 filter.go:174] "Found NodeResourceTopology" nodeTopology="nodeA.test.net"
I0329 14:59:16.519910       1 filter.go:129] "Pod Level Resource handler"
I0329 14:59:16.519914       1 pluginhelpers.go:83] "extracted NUMA resources" logKey="node-1" cpu="10" memory="16 GiB"
I0329 14:59:16.519935       1 pluginhelpers.go:160] "pod handler NUMA resources" logKey="nodeB.test.net/node-0" cpu="14" memory="15 GiB"
I0329 14:59:16.519941       1 pluginhelpers.go:83] "extracted NUMA resources" logKey="node-0" cpu="2" memory="2.0 GiB"
I0329 14:59:16.519952       1 pluginhelpers.go:160] "pod handler NUMA resources" logKey="nodeB.test.net/node-1" cpu="10" memory="16 GiB"
I0329 14:59:16.519970       1 filter.go:149] "target resources" logKey="e2e-test-workload-placement-tmpol-4922/testpod" cpu="14" memory="16 GiB"
I0329 14:59:16.520005       1 filter.go:92] "feasible" logKey="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeB.test.net" NUMA=0 resource="cpu"
I0329 14:59:16.520030       1 filter.go:92] "feasible" logKey="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeB.test.net" NUMA=1 resource="memory"
I0329 14:59:16.519953       1 pluginhelpers.go:83] "extracted NUMA resources" logKey="node-1" cpu="14" memory="20 GiB"
I0329 14:59:16.520059       1 filter.go:96] "early verdict" logKey="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeB.test.net" resource="memory" suitable="false"
I0329 14:59:16.520070       1 pluginhelpers.go:160] "pod handler NUMA resources" logKey="nodeA.test.net/node-0" cpu="2" memory="2.0 GiB"
I0329 14:59:16.520081       1 pluginhelpers.go:160] "pod handler NUMA resources" logKey="nodeA.test.net/node-1" cpu="14" memory="20 GiB"
I0329 14:59:16.520090       1 filter.go:149] "target resources" logKey="e2e-test-workload-placement-tmpol-4922/testpod" cpu="14" memory="16 GiB"
I0329 14:59:16.520107       1 filter.go:92] "feasible" logKey="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeA.test.net" NUMA=1 resource="cpu"
I0329 14:59:16.520116       1 filter.go:92] "feasible" logKey="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeA.test.net" NUMA=1 resource="memory"
I0329 14:59:16.520126       1 filter.go:101] "final verdict" logKey="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeA.test.net" suitable=true
I0329 14:59:16.520397       1 default_binder.go:52] "Attempting to bind pod to node" pod="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeA.test.net"
I0329 14:59:16.536251       1 eventhandlers.go:166] "Delete event for unscheduled pod" pod="e2e-test-workload-placement-tmpol-4922/testpod"
I0329 14:59:16.536305       1 eventhandlers.go:186] "Add event for scheduled pod" pod="e2e-test-workload-placement-tmpol-4922/testpod"
I0329 14:59:16.536754       1 round_trippers.go:454] POST https://172.30.0.1:443/api/v1/namespaces/e2e-test-workload-placement-tmpol-4922/pods/testpod/binding 201 Created in 16 milliseconds
I0329 14:59:16.536907       1 cache.go:384] Finished binding for pod 943a6a56-3e83-44f3-94c7-94081404e3ed. Can be expired.
I0329 14:59:16.536994       1 scheduler.go:672] "Successfully bound pod to node" pod="e2e-test-workload-placement-tmpol-4922/testpod" node="nodeA.test.net" evaluatedNodes=5 feasibleNodes=1
```

```release-note
NONE
```