### PR TITLE
noderesourcetopology: revamp the score logging

### DIFF
--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -18,6 +18,7 @@ package noderesourcetopology
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -191,4 +192,18 @@ func newPolicyHandlerMap() PolicyHandlerMap {
 		topologyv1alpha1.SingleNUMANodePodLevel:       newPodScopedHandler(),
 		topologyv1alpha1.SingleNUMANodeContainerLevel: newContainerScopedHandler(),
 	}
+}
+
+func logNRT(desc string, nrtObj *topologyv1alpha1.NodeResourceTopology) {
+	if !klog.V(6).Enabled() {
+		// avoid the expensive marshal operation
+		return
+	}
+
+	ntrJson, err := json.MarshalIndent(nrtObj, "", " ")
+	if err != nil {
+		klog.V(6).ErrorS(err, "failed to marshal noderesourcetopology object")
+		return
+	}
+	klog.V(6).Info(desc, "noderesourcetopology", string(ntrJson))
 }


### PR DESCRIPTION
This PR is inspired by https://github.com/kubernetes-sigs/scheduler-plugins/pull/354 (but not depend on it)

The goal is to expose more information about how the scoring descion  are made by the plugin.
It also try to make the complex data structure of the NRT object more easier to read in the log.
Finally, we change all logs messages to begin with small letter, to keep consistent convention with the filter logs.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improve the logging in the noderesourcetopology score plugin,  aiming to better clarify the decision points in the code, and make the logs more readable.

#### Which issue(s) this PR fixes:
N/A


#### Special notes for your reviewer:
N/A
