### PR TITLE
noderesourcetopology: fix handling of non-NUMA-affine resources

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -87,6 +87,7 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 
 		// for each requested resource, calculate which NUMA slots are good fits, and then AND with the aggregated bitmask, IOW unset appropriate bit if we can't align resources, or set it
 		// obvious, bits which are not in the NUMA id's range would be unset
+		hasNUMAAffinity := false
 		resourceBitmask := bm.NewEmptyBitMask()
 		for _, numaNode := range numaNodes {
 			numaQuantity, ok := numaNode.Resources[resource]
@@ -94,6 +95,7 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 				continue
 			}
 
+			hasNUMAAffinity = true
 			if !isNUMANodeSuitable(qos, resource, quantity, numaQuantity) {
 				continue
 			}
@@ -101,6 +103,12 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 			resourceBitmask.Add(numaNode.NUMAID)
 			klog.V(6).InfoS("feasible", "logKey", logKey, "node", nodeName, "NUMA", numaNode.NUMAID, "resource", resource)
 		}
+
+		if !hasNUMAAffinity && !v1helper.IsNativeResource(resource) {
+			klog.V(6).InfoS("resource available at node level (no NUMA affinity)", "logKey", logKey, "node", nodeName, "resource", resource)
+			continue
+		}
+
 		bitmask.And(resourceBitmask)
 		if bitmask.IsEmpty() {
 			klog.V(5).InfoS("early verdict", "logKey", logKey, "node", nodeName, "resource", resource, "suitable", "false")

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -40,137 +40,159 @@ const (
 	nicResourceName            = "vendor/nic1"
 	notExistingNICResourceName = "vendor/notexistingnic"
 	containerName              = "container1"
+	nicResourceNameNoNUMA      = "vendor.com/old-nic-model"
 )
 
+type nodeTopologyDesc struct {
+	nrt  *topologyv1alpha1.NodeResourceTopology
+	node v1.ResourceList
+}
+
 func TestNodeResourceTopology(t *testing.T) {
-	nodeTopologies := []*topologyv1alpha1.NodeResourceTopology{
+	nodeTopologyDescs := []nodeTopologyDesc{
 		{
-			ObjectMeta:       metav1.ObjectMeta{Name: "node1"},
-			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
-			Zones: topologyv1alpha1.ZoneList{
-				{
-					Name: "node-0",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "20", "4"),
-						MakeTopologyResInfo(memory, "8Gi", "8Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "10"),
+			nrt: &topologyv1alpha1.NodeResourceTopology{
+				ObjectMeta:       metav1.ObjectMeta{Name: "node1"},
+				TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "20", "4"),
+							MakeTopologyResInfo(memory, "8Gi", "8Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "10"),
+						},
 					},
-				},
-				{
-					Name: "node-1",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "30", "8"),
-						MakeTopologyResInfo(memory, "8Gi", "8Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "10"),
+					{
+						Name: "node-1",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "30", "8"),
+							MakeTopologyResInfo(memory, "8Gi", "8Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "10"),
+						},
 					},
 				},
 			},
 		},
 		{
-			ObjectMeta:       metav1.ObjectMeta{Name: "node2"},
-			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
-			Zones: topologyv1alpha1.ZoneList{
-				{
-					Name: "node-0",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "20", "2"),
-						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-						MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
-						MakeTopologyResInfo(nicResourceName, "30", "5"),
+			nrt: &topologyv1alpha1.NodeResourceTopology{
+				ObjectMeta:       metav1.ObjectMeta{Name: "node2"},
+				TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "20", "2"),
+							MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+							MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
+							MakeTopologyResInfo(nicResourceName, "30", "5"),
+						},
+					},
+					{
+						Name: "node-1",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "30", "4"),
+							MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+							MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
+							MakeTopologyResInfo(nicResourceName, "30", "2"),
+						},
 					},
 				},
-				{
-					Name: "node-1",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "30", "4"),
-						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-						MakeTopologyResInfo(hugepages2Mi, "128Mi", "128Mi"),
-						MakeTopologyResInfo(nicResourceName, "30", "2"),
+			},
+			node: v1.ResourceList{
+				v1.ResourceName(nicResourceNameNoNUMA): resource.MustParse("4"),
+			},
+		},
+		{
+			nrt: &topologyv1alpha1.NodeResourceTopology{
+				ObjectMeta:       metav1.ObjectMeta{Name: "node3"},
+				TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "20", "2"),
+							MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "5"),
+						},
+					},
+					{
+						Name: "node-1",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "30", "4"),
+							MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "2"),
+						},
 					},
 				},
 			},
 		},
 		{
-			ObjectMeta:       metav1.ObjectMeta{Name: "node3"},
-			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
-			Zones: topologyv1alpha1.ZoneList{
-				{
-					Name: "node-0",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "20", "2"),
-						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "5"),
+			nrt: &topologyv1alpha1.NodeResourceTopology{
+				ObjectMeta:       metav1.ObjectMeta{Name: "badly_formed_node"},
+				TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "20", "2"),
+							MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "5"),
+						},
 					},
-				},
-				{
-					Name: "node-1",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "30", "4"),
-						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "2"),
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta:       metav1.ObjectMeta{Name: "badly_formed_node"},
-			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodePodLevel)},
-			Zones: topologyv1alpha1.ZoneList{
-				{
-					Name: "node-0",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "20", "2"),
-						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "5"),
-					},
-				},
-				{
-					Name: "node-75",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "30", "4"),
-						MakeTopologyResInfo(memory, "8Gi", "4Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "2"),
+					{
+						Name: "node-75",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "30", "4"),
+							MakeTopologyResInfo(memory, "8Gi", "4Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "2"),
+						},
 					},
 				},
 			},
 		},
 		{
-			ObjectMeta:       metav1.ObjectMeta{Name: "extended"},
-			TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
-			Zones: topologyv1alpha1.ZoneList{
-				{
-					Name: "node-0",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "20", "4"),
-						MakeTopologyResInfo(memory, "8Gi", "8Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "10"),
+			nrt: &topologyv1alpha1.NodeResourceTopology{
+				ObjectMeta:       metav1.ObjectMeta{Name: "extended"},
+				TopologyPolicies: []string{string(topologyv1alpha1.SingleNUMANodeContainerLevel)},
+				Zones: topologyv1alpha1.ZoneList{
+					{
+						Name: "node-0",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "20", "4"),
+							MakeTopologyResInfo(memory, "8Gi", "8Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "10"),
+						},
+					},
+					{
+						Name: "node-1",
+						Type: "Node",
+						Resources: topologyv1alpha1.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "30", "8"),
+							MakeTopologyResInfo(memory, "8Gi", "8Gi"),
+							MakeTopologyResInfo(nicResourceName, "30", "10"),
+						},
 					},
 				},
-				{
-					Name: "node-1",
-					Type: "Node",
-					Resources: topologyv1alpha1.ResourceInfoList{
-						MakeTopologyResInfo(cpu, "30", "8"),
-						MakeTopologyResInfo(memory, "8Gi", "8Gi"),
-						MakeTopologyResInfo(nicResourceName, "30", "10"),
-					},
-				},
+			},
+			node: v1.ResourceList{
+				v1.ResourceName(extended): resource.MustParse("1"),
 			},
 		},
 	}
 
-	nodes := make([]*v1.Node, len(nodeTopologies))
+	nodes := make([]*v1.Node, len(nodeTopologyDescs))
 	for i := range nodes {
-		nodeResTopology := nodeTopologies[i]
+		nodeResTopology := nodeTopologyDescs[i].nrt
 		res := makeResourceListFromZones(nodeResTopology.Zones)
 		nodes[i] = &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{Name: nodeResTopology.Name},
@@ -180,10 +202,9 @@ func TestNodeResourceTopology(t *testing.T) {
 			},
 		}
 
-		if nodes[i].ObjectMeta.Name == "extended" {
-			extendedResourceQuantity := resource.MustParse("1")
-			nodes[i].Status.Capacity[v1.ResourceName(extended)] = extendedResourceQuantity
-			nodes[i].Status.Allocatable[v1.ResourceName(extended)] = extendedResourceQuantity
+		for resName, resQty := range nodeTopologyDescs[i].node {
+			nodes[i].Status.Capacity[resName] = resQty
+			nodes[i].Status.Allocatable[resName] = resQty
 		}
 	}
 
@@ -221,8 +242,8 @@ func TestNodeResourceTopology(t *testing.T) {
 		{
 			name: "Guaranteed QoS, minimal, saturating zone, pod fit",
 			pod: makePodByResourceList(&v1.ResourceList{
-				v1.ResourceCPU:    findAvailableResourceByName(nodeTopologies[0].Zones[1].Resources, cpu),
-				v1.ResourceMemory: findAvailableResourceByName(nodeTopologies[0].Zones[1].Resources, memory)}),
+				v1.ResourceCPU:    findAvailableResourceByName(nodeTopologyDescs[0].nrt.Zones[1].Resources, cpu),
+				v1.ResourceMemory: findAvailableResourceByName(nodeTopologyDescs[0].nrt.Zones[1].Resources, memory)}),
 			node:       nodes[0],
 			wantStatus: nil,
 		},
@@ -319,8 +340,8 @@ func TestNodeResourceTopology(t *testing.T) {
 		{
 			name: "Guaranteed QoS TopologyScope, minimal, saturating zone, pod fit",
 			pod: makePodByResourceList(&v1.ResourceList{
-				v1.ResourceCPU:    findAvailableResourceByName(nodeTopologies[3].Zones[0].Resources, cpu),
-				v1.ResourceMemory: findAvailableResourceByName(nodeTopologies[3].Zones[0].Resources, memory)}),
+				v1.ResourceCPU:    findAvailableResourceByName(nodeTopologyDescs[3].nrt.Zones[0].Resources, cpu),
+				v1.ResourceMemory: findAvailableResourceByName(nodeTopologyDescs[3].nrt.Zones[0].Resources, memory)}),
 			node:       nodes[3],
 			wantStatus: nil,
 		},
@@ -342,12 +363,22 @@ func TestNodeResourceTopology(t *testing.T) {
 			node:       nodes[3],
 			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
 		},
+		{
+			name: "Guaranteed QoS, hugepages, non-NUMA affine NIC, pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:        *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory:     resource.MustParse("2Gi"),
+				hugepages2Mi:          resource.MustParse("64Mi"),
+				nicResourceNameNoNUMA: *resource.NewQuantity(3, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
 	}
 
 	fakeClient := faketopologyv1alpha1.NewSimpleClientset()
 	fakeInformer := topologyinformers.NewSharedInformerFactory(fakeClient, 0).Topology().V1alpha1().NodeResourceTopologies()
-	for _, obj := range nodeTopologies {
-		fakeInformer.Informer().GetStore().Add(obj)
+	for _, desc := range nodeTopologyDescs {
+		fakeInformer.Informer().GetStore().Add(desc.nrt)
 	}
 	lister := fakeInformer.Lister()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Review and reorganize how we handle non-NUMA-affine resources, aka resource which don't declare NUMA affinity, like old device plugins and extended resources.


#### Which issue(s) this PR fixes:
Fixes #355 

#### Special notes for your reviewer:
please do not squash commits! I'm using unit tests written by another community member, and we need to preserve their authorship.
