### PR TITLE
noderesourcetopology: quicker and simpler fail logic for filter when dealing with node-level resources

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -76,6 +76,8 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 			continue
 		}
 
+		isNodeResource := resourceFoundOnNode(resource, quantity, nodeInfo)
+
 		// for each requested resource, calculate which NUMA slots are good fits, and then AND with the aggregated bitmask, IOW unset appropriate bit if we can't align resources, or set it
 		// obvious, bits which are not in the NUMA id's range would be unset
 		resourceBitmask := bm.NewEmptyBitMask()
@@ -84,7 +86,7 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 			// if the requested resource can't be found on the NUMA node, we still need to check
 			// if the resource can be found at the node itself, because there are resources which are not NUMA aligned
 			// or not supported by the topology exporter - if resource was not found at both checks - skip (don't set it as available NUMA node).
-			if !ok && !resourceFoundOnNode(resource, quantity, nodeInfo) {
+			if !ok && !isNodeResource {
 				continue
 			}
 

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -19,11 +19,11 @@ package noderesourcetopology
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	bm "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -108,7 +108,7 @@ func isNUMANodeSuitable(qos v1.PodQOSClass, resource v1.ResourceName, quantity, 
 		if resource == v1.ResourceMemory {
 			return true
 		}
-		if strings.HasPrefix(string(resource), v1.ResourceHugePagesPrefix) {
+		if v1helper.IsHugePageResourceName(resource) {
 			return true
 		}
 		// 2. set numa node as possible node if resource is CPU

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -225,14 +225,6 @@ func TestNodeResourceTopology(t *testing.T) {
 		{
 			name: "Burstable QoS, pod doesn't fit",
 			pod: makePodByResourceList(&v1.ResourceList{
-				v1.ResourceCPU:  *resource.NewQuantity(14, resource.DecimalSI),
-				nicResourceName: *resource.NewQuantity(3, resource.DecimalSI)}),
-			node:       nodes[1],
-			wantStatus: nil, // number of cpu is exceeded, but in case of burstable QoS for cpu resources we rely on fit.go
-		},
-		{
-			name: "Burstable QoS, pod doesn't fit",
-			pod: makePodByResourceList(&v1.ResourceList{
 				v1.ResourceCPU:  *resource.NewQuantity(4, resource.DecimalSI),
 				nicResourceName: *resource.NewQuantity(11, resource.DecimalSI)}),
 			node:       nodes[1],

--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/dustin/go-humanize"
 
@@ -30,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 
 	topologyv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	topoclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
@@ -184,7 +184,7 @@ func needsHumanization(resName string) bool {
 	// memory-related resources may be expressed in KiB/Bytes, which makes
 	// for long numbers, harder to read and compare. To make it easier for
 	// the reader, we express them in a more compact form using go-humanize.
-	return resName == string(v1.ResourceMemory) || strings.HasPrefix(resName, v1.ResourceHugePagesPrefix)
+	return resName == string(v1.ResourceMemory) || v1helper.IsHugePageResourceName(v1.ResourceName(resName))
 }
 
 func newPolicyHandlerMap() PolicyHandlerMap {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
During the implementation of #372 (which wants to fix issue 355) quite a few of possible filter flow flow simplifications emerged. 
The objective is to make the filtering logic fail quicker while also being more linear (and simpler) when dealing with node-level resources. The implementation of #372 will build on top of this simplification.
I am splitting them out here to make it easier to review them in isolation and to help ensure their correctness.

#### Which issue(s) this PR fixes:
Fixes None, but related to 355

#### Special notes for your reviewer:
See #372 for more context
