### PR TITLE
support self define timeSeconds to escape podNumberChecking in perFilter stage of CoScheduling

### DIFF
--- a/apis/config/types.go
+++ b/apis/config/types.go
@@ -32,6 +32,10 @@ type CoschedulingArgs struct {
 	PermitWaitingTimeSeconds int64
 	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup.
 	DeniedPGExpirationTimeSeconds int64
+	// IgnorePodNumCheckingTimeSeconds describes a time window in seconds, which can help
+	// newly created pods (whose survival time is within this window) quickly pass through
+	// the perFilter stage, where they can skip the pod number check.
+	IgnorePodNumCheckingTimeSeconds int64
 }
 
 // ModeType is a "string" type.

--- a/apis/config/v1beta2/defaults.go
+++ b/apis/config/v1beta2/defaults.go
@@ -26,8 +26,10 @@ import (
 )
 
 var (
-	defaultPermitWaitingTimeSeconds      int64 = 60
-	defaultDeniedPGExpirationTimeSeconds int64 = 20
+	defaultPermitWaitingTimeSeconds        int64 = 60
+	defaultDeniedPGExpirationTimeSeconds   int64 = 20
+	defaultIgnorePodNumCheckingTimeSeconds int64 = 3
+	noIgnorePodNumCheckingTimeSeconds      int64 = 0
 
 	defaultNodeResourcesAllocatableMode = Least
 
@@ -80,6 +82,12 @@ func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	}
 	if obj.DeniedPGExpirationTimeSeconds == nil {
 		obj.DeniedPGExpirationTimeSeconds = &defaultDeniedPGExpirationTimeSeconds
+	}
+	if obj.IgnorePodNumCheckingTimeSeconds == nil {
+		obj.IgnorePodNumCheckingTimeSeconds = &defaultIgnorePodNumCheckingTimeSeconds
+	}
+	if obj.IgnorePodNumCheckingTimeSeconds != nil && *obj.IgnorePodNumCheckingTimeSeconds < 0 {
+		obj.IgnorePodNumCheckingTimeSeconds = &noIgnorePodNumCheckingTimeSeconds
 	}
 }
 

--- a/apis/config/v1beta2/defaults_test.go
+++ b/apis/config/v1beta2/defaults_test.go
@@ -39,19 +39,35 @@ func TestSchedulingDefaults(t *testing.T) {
 			name:   "empty config CoschedulingArgs",
 			config: &CoschedulingArgs{},
 			expect: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(20),
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(20),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(3),
 			},
 		},
 		{
 			name: "set non default CoschedulingArgs",
 			config: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(2),
 			},
 			expect: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(2),
+			},
+		},
+		{
+			name: "set negative IgnorePodNumCheckingTimeSeconds in CoschedulingArgs",
+			config: &CoschedulingArgs{
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(-2),
+			},
+			expect: &CoschedulingArgs{
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(0),
 			},
 		},
 		{

--- a/apis/config/v1beta2/types.go
+++ b/apis/config/v1beta2/types.go
@@ -32,6 +32,11 @@ type CoschedulingArgs struct {
 	PermitWaitingTimeSeconds *int64 `json:"permitWaitingTimeSeconds,omitempty"`
 	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup store.
 	DeniedPGExpirationTimeSeconds *int64 `json:"deniedPGExpirationTimeSeconds,omitempty"`
+
+	// IgnorePodNumCheckingTimeSeconds describes a time window in seconds, which can help
+	// newly created pods (whose survival time is within this window) quickly pass through
+	// the perFilter stage, where they can skip the pod number check.
+	IgnorePodNumCheckingTimeSeconds *int64 `json:"ignorePodNumCheckingTimeSeconds,omitempty"`
 }
 
 // ModeType is a type "string".

--- a/apis/config/v1beta3/defaults.go
+++ b/apis/config/v1beta3/defaults.go
@@ -26,8 +26,10 @@ import (
 )
 
 var (
-	defaultPermitWaitingTimeSeconds      int64 = 60
-	defaultDeniedPGExpirationTimeSeconds int64 = 20
+	defaultPermitWaitingTimeSeconds        int64 = 60
+	defaultDeniedPGExpirationTimeSeconds   int64 = 20
+	defaultIgnorePodNumCheckingTimeSeconds int64 = 3
+	notIgnorePodNumCheckingTimeSeconds     int64 = 0
 
 	defaultNodeResourcesAllocatableMode = Least
 
@@ -80,6 +82,12 @@ func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	}
 	if obj.DeniedPGExpirationTimeSeconds == nil {
 		obj.DeniedPGExpirationTimeSeconds = &defaultDeniedPGExpirationTimeSeconds
+	}
+	if obj.IgnorePodNumCheckingTimeSeconds == nil {
+		obj.IgnorePodNumCheckingTimeSeconds = &defaultIgnorePodNumCheckingTimeSeconds
+	}
+	if obj.IgnorePodNumCheckingTimeSeconds != nil && *obj.IgnorePodNumCheckingTimeSeconds < 0 {
+		obj.IgnorePodNumCheckingTimeSeconds = &notIgnorePodNumCheckingTimeSeconds
 	}
 }
 

--- a/apis/config/v1beta3/defaults_test.go
+++ b/apis/config/v1beta3/defaults_test.go
@@ -39,19 +39,35 @@ func TestSchedulingDefaults(t *testing.T) {
 			name:   "empty config CoschedulingArgs",
 			config: &CoschedulingArgs{},
 			expect: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(20),
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(20),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(3),
 			},
 		},
 		{
 			name: "set non default CoschedulingArgs",
 			config: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(2),
 			},
 			expect: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(2),
+			},
+		},
+		{
+			name: "set negative IgnorePodNumCheckingTimeSeconds in CoschedulingArgs",
+			config: &CoschedulingArgs{
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(-2),
+			},
+			expect: &CoschedulingArgs{
+				PermitWaitingTimeSeconds:        pointer.Int64Ptr(60),
+				DeniedPGExpirationTimeSeconds:   pointer.Int64Ptr(10),
+				IgnorePodNumCheckingTimeSeconds: pointer.Int64Ptr(0),
 			},
 		},
 		{

--- a/apis/config/v1beta3/types.go
+++ b/apis/config/v1beta3/types.go
@@ -33,6 +33,11 @@ type CoschedulingArgs struct {
 
 	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup store.
 	DeniedPGExpirationTimeSeconds *int64 `json:"deniedPGExpirationTimeSeconds,omitempty"`
+
+	// IgnorePodNumCheckingTimeSeconds describes a time window in seconds, which can help
+	// newly created pods (whose survival time is within this window) quickly pass through
+	// the perFilter stage, where they can skip the pod number check.
+	IgnorePodNumCheckingTimeSeconds *int64 `json:"ignorePodNumCheckingTimeSeconds,omitempty"`
 }
 
 // ModeType is a type "string".

--- a/pkg/coscheduling/core/core_test.go
+++ b/pkg/coscheduling/core/core_test.go
@@ -47,6 +47,7 @@ func TestPreFilter(t *testing.T) {
 	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
 	pgInformerFactory.Start(ctx.Done())
 	scheduleTimeout := 10 * time.Second
+	ignorePodNumCheckingTime := 0 * time.Second
 	pg := testutil.MakePG("pg", "ns1", 2, nil, nil)
 	pg1 := testutil.MakePG("pg1", "ns1", 2, nil, nil)
 	pg2 := testutil.MakePG("pg2", "ns1", 2, nil, &corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")})
@@ -159,7 +160,7 @@ func TestPreFilter(t *testing.T) {
 			existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
 			snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 			pgMgr := &PodGroupManager{pgLister: pgLister, lastDeniedPG: tt.lastDeniedPG, permittedPG: newCache(),
-				snapshotSharedLister: snapshot, podLister: podInformer.Lister(), scheduleTimeout: &scheduleTimeout, lastDeniedPGExpirationTime: &scheduleTimeout}
+				snapshotSharedLister: snapshot, podLister: podInformer.Lister(), scheduleTimeout: &scheduleTimeout, lastDeniedPGExpirationTime: &scheduleTimeout, ignorePodNumCheckingTime: &ignorePodNumCheckingTime}
 			informerFactory.Start(ctx.Done())
 			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
 				t.Fatal("WaitForCacheSync failed")

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -72,10 +72,11 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 
 	scheduleTimeDuration := time.Duration(args.PermitWaitingTimeSeconds) * time.Second
 	deniedPGExpirationTime := time.Duration(args.DeniedPGExpirationTimeSeconds) * time.Second
+	ignorePodNumCheckingTime := time.Duration(args.IgnorePodNumCheckingTimeSeconds) * time.Second
 
 	ctx := context.TODO()
 
-	pgMgr := core.NewPodGroupManager(pgClient, handle.SnapshotSharedLister(), &scheduleTimeDuration, &deniedPGExpirationTime, pgInformer, podInformer)
+	pgMgr := core.NewPodGroupManager(pgClient, handle.SnapshotSharedLister(), &scheduleTimeDuration, &deniedPGExpirationTime, &ignorePodNumCheckingTime, pgInformer, podInformer)
 	plugin := &Coscheduling{
 		frameworkHandler: handle,
 		pgMgr:            pgMgr,

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -90,6 +90,7 @@ func TestLess(t *testing.T) {
 	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 	scheudleDuration := 10 * time.Second
 	deniedPGExpirationTime := 3 * time.Second
+	ignorePodNumCheckingTime := 3 * time.Second
 	var lowPriority, highPriority = int32(10), int32(100)
 	ns1, ns2 := "namespace1", "namespace2"
 	for _, tt := range []struct {
@@ -257,7 +258,7 @@ func TestLess(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
+			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, &ignorePodNumCheckingTime, pgInformer, podInformer)
 			coscheduling := &Coscheduling{pgMgr: pgMgr}
 			if got := coscheduling.Less(tt.p1, tt.p2); got != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, got)
@@ -320,9 +321,10 @@ func TestPermit(t *testing.T) {
 	}
 	scheudleDuration := 10 * time.Second
 	deniedPGExpirationTime := 3 * time.Second
+	ignorePodNumCheckingTime := 3 * time.Second
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
+			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, &ignorePodNumCheckingTime, pgInformer, podInformer)
 			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheudleDuration}
 			code, _ := coscheduling.Permit(context.Background(), framework.NewCycleState(), tt.pod, "test")
 			if code.Code() != tt.expected {
@@ -370,6 +372,7 @@ func TestPostFilter(t *testing.T) {
 	groupPodSnapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 	scheduleDuration := 10 * time.Second
 	deniedPGExpirationTime := 3 * time.Second
+	ignorePodNumCheckingTime := 3 * time.Second
 	tests := []struct {
 		name                 string
 		pod                  *v1.Pod
@@ -402,7 +405,7 @@ func TestPostFilter(t *testing.T) {
 				mgrSnapShot = tt.snapshotSharedLister
 			}
 
-			pgMgr := core.NewPodGroupManager(cs, mgrSnapShot, &scheduleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
+			pgMgr := core.NewPodGroupManager(cs, mgrSnapShot, &scheduleDuration, &deniedPGExpirationTime, &ignorePodNumCheckingTime, pgInformer, podInformer)
 			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheduleDuration}
 			_, code := coscheduling.PostFilter(context.Background(), cycleState, tt.pod, nodeStatusMap)
 			if code.Message() == "" != tt.expectedEmptyMsg {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
add  field `IgnorePodNumCheckingTimeSeconds` in CoScheduling, which could help user self define timeSeconds to escape podNumChecking in preFilter stage. If its zero, which means podNumChecking must be performed. Default as 3s.

`IgnorePodNumCheckingTimeSeconds` describes a time window in seconds, which can help newly created pods (whose survival time is within this window) quickly pass through the perFilter stage, where they can skip the pod number check.

NOTE: even if IgnorePodNumCheckingTime is configured, the newly created pod may still fail at perFilter stage, since they may not pass resource restrictions or other checks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #364 

#### Special notes for your reviewer:
@denkensk @Huang-Wei 
