### PR TITLE
fix bugs of score calculation formula in TargetLoadPacking Plugin

### DIFF
--- a/kep/61-Trimaran-real-load-aware-scheduling/README.md
+++ b/kep/61-Trimaran-real-load-aware-scheduling/README.md
@@ -110,7 +110,7 @@ Following is the algorithm:
 2. Calculate the current pod's total CPU requests and overhead. Call it B.
 3. Calculate the expected utilization if the pod is scheduled under this node by adding i.e. U = A + B.
 4. If U &lt;= X%, return (100 - X)U/X + X as the score
-5. If X% &lt; U &lt;= 100%, return 50(100 - U)/(100 - X)
+5. If X% &lt; U &lt;= 100%, return X(100 - U)/(100 - X)
 6. If U > 100%, return 0
 
 For example, let’s say we have three nodes X, Y, and Z, with four cores each and utilization 1, 2, and 3 cores respectively. For simplicity, let’s assume our pod to be scheduled has 0 cores CPU requests and overhead. Let X = 50%.

--- a/pkg/trimaran/targetloadpacking/targetloadpacking.go
+++ b/pkg/trimaran/targetloadpacking/targetloadpacking.go
@@ -258,7 +258,7 @@ func (pl *TargetLoadPacking) Score(ctx context.Context, cycleState *framework.Cy
 		if predictedCPUUsage > 100 {
 			return framework.MinNodeScore, framework.NewStatus(framework.Success, "")
 		}
-		penalisedScore := int64(math.Round(50 * (100 - predictedCPUUsage) / (100 - float64(hostTargetUtilizationPercent))))
+		penalisedScore := int64(math.Round(float64(hostTargetUtilizationPercent) * (100 - predictedCPUUsage) / (100 - float64(hostTargetUtilizationPercent))))
 		klog.V(6).InfoS("Penalised score for host", "nodeName", nodeName, "penalisedScore", penalisedScore)
 		return penalisedScore, framework.NewStatus(framework.Success, "")
 	}

--- a/pkg/trimaran/targetloadpacking/targetloadpacking_test.go
+++ b/pkg/trimaran/targetloadpacking/targetloadpacking_test.go
@@ -183,7 +183,7 @@ func TestTargetLoadPackingScoring(t *testing.T) {
 				},
 			},
 			expected: []framework.NodeScore{
-				{Name: "node-1", Score: 42},
+				{Name: "node-1", Score: 33},
 			},
 		},
 		{


### PR DESCRIPTION


#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix bugs of score calculation formula in TargetLoadPacking Plugin

#### Special notes for your reviewer:
**Algorithm**

1. Get the utilization of the current node to be scored. Call it A.
2. Calculate the current pod's total CPU requests and overhead. Call it B.
3. Calculate the expected utilization if the pod is scheduled under this node by adding i.e. U = A + B.
4. If U &lt;= X%, return (100 - X)U/X + X as the score
5. If X% &lt; U &lt;= 100%, return 50(100 - U)/(100 - X)
6. If U > 100%, return 0

> Point 4, the value range of (100 - X)U/X + X is (X ~ 100)
Point 5, the value range of 50(100 - U)/(100 - X) is (0 ~ 50)
When X<50, the scores of points 4 and 5 overlap.
When X<50, the score for point 5 should be a little smaller. The value range should be (0 ~ X)

**E.g**
X=20
Utilization of each node:

````
Ua = 1
Ub = 5
Uc = 25
Ud = 50
Ue = 99
````


The score of each node :
Before
````
A → (100 - 20)*1/20 + 20 = 24
B → (100 - 20)*5/20 + 20 = 40
C → 50 * (100 - 25)/(100 - 10) = 42
D → 50 * (100 - 50)/(100 - 20) = 31
E → 50 * (100 - 90)/(100 - 20) = 6
````

Now
````
A → (100 - 20)*1/20 + 20 = 24
B → (100 - 20)*5/20 + 20 = 40
C → 20 * (100 - 25)/(100 - 20) = 19
D → 20 * (100 - 50)/(100 - 20) = 13
E → 20 * (100 - 90)/(100 - 20) = 3
````

