### PR TITLE
Nrt fix ext resources

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -87,6 +87,7 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 
 		// for each requested resource, calculate which NUMA slots are good fits, and then AND with the aggregated bitmask, IOW unset appropriate bit if we can't align resources, or set it
 		// obvious, bits which are not in the NUMA id's range would be unset
+		hasNUMAAffinity := false
 		resourceBitmask := bm.NewEmptyBitMask()
 		for _, numaNode := range numaNodes {
 			numaQuantity, ok := numaNode.Resources[resource]
@@ -94,6 +95,7 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 				continue
 			}
 
+			hasNUMAAffinity = true
 			if !isNUMANodeSuitable(qos, resource, quantity, numaQuantity) {
 				continue
 			}
@@ -101,6 +103,12 @@ func resourcesAvailableInAnyNUMANodes(logKey string, numaNodes NUMANodeList, res
 			resourceBitmask.Add(numaNode.NUMAID)
 			klog.V(6).InfoS("feasible", "logKey", logKey, "node", nodeName, "NUMA", numaNode.NUMAID, "resource", resource)
 		}
+
+		if !hasNUMAAffinity && !v1helper.IsNativeResource(resource) {
+			klog.V(6).InfoS("resource available at node level (no NUMA affinity)", "logKey", logKey, "node", nodeName, "resource", resource)
+			continue
+		}
+
 		bitmask.And(resourceBitmask)
 		if bitmask.IsEmpty() {
 			klog.V(5).InfoS("early verdict", "logKey", logKey, "node", nodeName, "resource", resource, "suitable", "false")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fix handling of resources w/o NUMA affinity. Some resources legitimate lack NUMA affinity. Extended resources
are a great example: https://kubernetes.io/docs/tasks/administer-cluster/extended-resource-node/

#### Which issue(s) this PR fixes:
Fixes #355

#### Special notes for your reviewer:
please do not squash this PR: I'm including unit tests contributed by another community member, and we should preserver their authorship.

