### PR TITLE
Cherry-pick coscheduling: remove lastDeniedPG cache and lastDeniedPGExpirationTime

### DIFF
--- a/apis/config/scheme/scheme_test.go
+++ b/apis/config/scheme/scheme_test.go
@@ -103,8 +103,7 @@ profiles:
 						{
 							Name: coscheduling.Name,
 							Args: &config.CoschedulingArgs{
-								PermitWaitingTimeSeconds:      10,
-								DeniedPGExpirationTimeSeconds: 3,
+								PermitWaitingTimeSeconds: 10,
 							},
 						},
 						{
@@ -214,8 +213,7 @@ profiles:
 						{
 							Name: coscheduling.Name,
 							Args: &config.CoschedulingArgs{
-								PermitWaitingTimeSeconds:      60,
-								DeniedPGExpirationTimeSeconds: 20,
+								PermitWaitingTimeSeconds: 60,
 							},
 						},
 						{
@@ -356,8 +354,7 @@ func TestCodecsEncodePluginConfig(t *testing.T) {
 							{
 								Name: coscheduling.Name,
 								Args: &config.CoschedulingArgs{
-									PermitWaitingTimeSeconds:      10,
-									DeniedPGExpirationTimeSeconds: 3,
+									PermitWaitingTimeSeconds: 10,
 								},
 							},
 							{
@@ -430,7 +427,6 @@ profiles:
 - pluginConfig:
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1beta2
-      deniedPGExpirationTimeSeconds: 3
       kind: CoschedulingArgs
       permitWaitingTimeSeconds: 10
     name: Coscheduling

--- a/apis/config/types.go
+++ b/apis/config/types.go
@@ -30,8 +30,6 @@ type CoschedulingArgs struct {
 
 	// PermitWaitingTimeSeconds is the waiting timeout in seconds.
 	PermitWaitingTimeSeconds int64
-	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup.
-	DeniedPGExpirationTimeSeconds int64
 }
 
 // ModeType is a "string" type.

--- a/apis/config/v1beta2/zz_generated.conversion.go
+++ b/apis/config/v1beta2/zz_generated.conversion.go
@@ -127,9 +127,6 @@ func autoConvert_v1beta2_CoschedulingArgs_To_config_CoschedulingArgs(in *Cosched
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_Pointer_int64_To_int64(&in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds, s); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -140,9 +137,6 @@ func Convert_v1beta2_CoschedulingArgs_To_config_CoschedulingArgs(in *Coschedulin
 
 func autoConvert_config_CoschedulingArgs_To_v1beta2_CoschedulingArgs(in *config.CoschedulingArgs, out *CoschedulingArgs, s conversion.Scope) error {
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
-		return err
-	}
-	if err := v1.Convert_int64_To_Pointer_int64(&in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds, s); err != nil {
 		return err
 	}
 	return nil

--- a/apis/config/v1beta3/defaults.go
+++ b/apis/config/v1beta3/defaults.go
@@ -26,8 +26,7 @@ import (
 )
 
 var (
-	defaultPermitWaitingTimeSeconds      int64 = 60
-	defaultDeniedPGExpirationTimeSeconds int64 = 20
+	defaultPermitWaitingTimeSeconds int64 = 60
 
 	defaultNodeResourcesAllocatableMode = Least
 
@@ -77,9 +76,6 @@ var (
 func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	if obj.PermitWaitingTimeSeconds == nil {
 		obj.PermitWaitingTimeSeconds = &defaultPermitWaitingTimeSeconds
-	}
-	if obj.DeniedPGExpirationTimeSeconds == nil {
-		obj.DeniedPGExpirationTimeSeconds = &defaultDeniedPGExpirationTimeSeconds
 	}
 }
 

--- a/apis/config/v1beta3/defaults_test.go
+++ b/apis/config/v1beta3/defaults_test.go
@@ -39,19 +39,16 @@ func TestSchedulingDefaults(t *testing.T) {
 			name:   "empty config CoschedulingArgs",
 			config: &CoschedulingArgs{},
 			expect: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(20),
+				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
 			},
 		},
 		{
 			name: "set non default CoschedulingArgs",
 			config: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
 			},
 			expect: &CoschedulingArgs{
-				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
-				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
 			},
 		},
 		{

--- a/apis/config/v1beta3/types.go
+++ b/apis/config/v1beta3/types.go
@@ -30,9 +30,6 @@ type CoschedulingArgs struct {
 
 	// PermitWaitingTimeSeconds is the waiting timeout in seconds.
 	PermitWaitingTimeSeconds *int64 `json:"permitWaitingTimeSeconds,omitempty"`
-
-	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup store.
-	DeniedPGExpirationTimeSeconds *int64 `json:"deniedPGExpirationTimeSeconds,omitempty"`
 }
 
 // ModeType is a type "string".

--- a/apis/config/v1beta3/zz_generated.conversion.go
+++ b/apis/config/v1beta3/zz_generated.conversion.go
@@ -127,9 +127,6 @@ func autoConvert_v1beta3_CoschedulingArgs_To_config_CoschedulingArgs(in *Cosched
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_Pointer_int64_To_int64(&in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds, s); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -140,9 +137,6 @@ func Convert_v1beta3_CoschedulingArgs_To_config_CoschedulingArgs(in *Coschedulin
 
 func autoConvert_config_CoschedulingArgs_To_v1beta3_CoschedulingArgs(in *config.CoschedulingArgs, out *CoschedulingArgs, s conversion.Scope) error {
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
-		return err
-	}
-	if err := v1.Convert_int64_To_Pointer_int64(&in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds, s); err != nil {
 		return err
 	}
 	return nil

--- a/apis/config/v1beta3/zz_generated.deepcopy.go
+++ b/apis/config/v1beta3/zz_generated.deepcopy.go
@@ -36,11 +36,6 @@ func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 		*out = new(int64)
 		**out = **in
 	}
-	if in.DeniedPGExpirationTimeSeconds != nil {
-		in, out := &in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds
-		*out = new(int64)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -88,8 +88,7 @@ func TestLess(t *testing.T) {
 
 	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
 	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
-	scheudleDuration := 10 * time.Second
-	deniedPGExpirationTime := 3 * time.Second
+	scheduleDuration := 10 * time.Second
 	var lowPriority, highPriority = int32(10), int32(100)
 	ns1, ns2 := "namespace1", "namespace2"
 	for _, tt := range []struct {
@@ -257,7 +256,7 @@ func TestLess(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
+			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheduleDuration, pgInformer, podInformer)
 			coscheduling := &Coscheduling{pgMgr: pgMgr}
 			if got := coscheduling.Less(tt.p1, tt.p2); got != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, got)
@@ -318,12 +317,11 @@ func TestPermit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	scheudleDuration := 10 * time.Second
-	deniedPGExpirationTime := 3 * time.Second
+	scheduleDuration := 10 * time.Second
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheudleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
-			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheudleDuration}
+			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheduleDuration, pgInformer, podInformer)
+			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheduleDuration}
 			code, _ := coscheduling.Permit(context.Background(), framework.NewCycleState(), tt.pod, "test")
 			if code.Code() != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, code.Code())
@@ -369,7 +367,6 @@ func TestPostFilter(t *testing.T) {
 	}
 	groupPodSnapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 	scheduleDuration := 10 * time.Second
-	deniedPGExpirationTime := 3 * time.Second
 	tests := []struct {
 		name                 string
 		pod                  *v1.Pod
@@ -402,7 +399,7 @@ func TestPostFilter(t *testing.T) {
 				mgrSnapShot = tt.snapshotSharedLister
 			}
 
-			pgMgr := core.NewPodGroupManager(cs, mgrSnapShot, &scheduleDuration, &deniedPGExpirationTime, pgInformer, podInformer)
+			pgMgr := core.NewPodGroupManager(cs, mgrSnapShot, &scheduleDuration, pgInformer, podInformer)
 			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheduleDuration}
 			_, code := coscheduling.PostFilter(context.Background(), cycleState, tt.pod, nodeStatusMap)
 			if code.Message() == "" != tt.expectedEmptyMsg {


### PR DESCRIPTION
#### What type of PR is this?

/kind cherry-pick

#### What this PR does / why we need it:

Cherry-pick #408 coscheduling: remove lastDeniedPG cache and lastDeniedPGExpirationTime

```release-note
coscheduling: remove DeniedPGExpirationTimeSeconds field from CoschedulingArgs in v1beta3 API and remove lastDeniedPG, lastDeniedPGExpirationTime

Action required: users of coscheduling plugin need to be aware of the API change when using `v1beta3` scheduler config profile.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

