### PR TITLE
Automated cherry pick of #414: updated docs for v0.23.10 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ changed.
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                      | Arch           |
 |-------------------|---------------------------|------------------------------------------------------|----------------|
+| v0.23.10          | v1.23.10                  | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.23.10 | AMD64<br>ARM64 |
 | v0.22.6           | v1.22.6                   | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.22.6  | AMD64<br>ARM64 |
 | v0.21.6           | v1.21.6                   | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6  | AMD64<br>ARM64 |
 | v0.20.10          | v1.20.10                  | k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.20.10 | AMD64<br>ARM64 |
@@ -65,6 +66,7 @@ changed.
 
 | Controller | Compiled With k8s Version | Container Image                                  | Arch           |
 |------------|---------------------------|--------------------------------------------------|----------------|
+| v0.23.10   | v1.23.10                  | k8s.gcr.io/scheduler-plugins/controller:v0.23.10 | AMD64<br>ARM64 |
 | v0.22.6    | v1.22.6                   | k8s.gcr.io/scheduler-plugins/controller:v0.22.6  | AMD64<br>ARM64 |
 | v0.21.6    | v1.21.6                   | k8s.gcr.io/scheduler-plugins/controller:v0.21.6  | AMD64<br>ARM64 |
 | v0.20.10   | v1.20.10                  | k8s.gcr.io/scheduler-plugins/controller:v0.20.10 | AMD64<br>ARM64 |

--- a/manifests/install/charts/as-a-second-scheduler/Chart.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/Chart.yaml
@@ -15,9 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.6
+version: 0.23.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.22.6
+appVersion: 0.23.10
+

--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -10,7 +10,6 @@ Quick start instructions for the setup and configuration of as-a-second-schedule
 
 ### Installing the chart
 
-
 #### Install chart using Helm v3.0+
 
 ```bash
@@ -32,23 +31,16 @@ scheduler-plugins-scheduler    1/1     1            1           7s
 
 The following table lists the configurable parameters of the as-a-second-scheduler chart and their default values.
 
-| Parameter                               | Description                                                                                                                               | Default                                                 |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `scheduler.name`                        | Scheduler name                                                                                                                            | `scheduler-plugins-scheduler`                           |
-| `scheduler.image`                       | Scheduler image                                                                                                                           | `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.22.6`   |
-| `scheduler.namespace`                   | Default scheduler-plugins namespace                                                                                                                       | `scheduler-plugins`                                     |
-| `scheduler.replicaCount`                | scheduler-plugins replicas                                                                                                                    | `1`                                                     |
-| `controller.name`                       | Controller name                                                                                                                           | `scheduler-plugins-controller`                          |
-| `controller.image`                      | Controller image                                                                                                                          | `k8s.gcr.io/scheduler-plugins/controller:v0.22.6`       |
-| `controller.namespace`                  | Controller namespace                                                                                                                      | `scheduler-plugins`                                     |    
-| `controller.replicaCount`               | Controller replicaCount                                                                                                                   | `1`                                                     |
-| `plugins.enabled`                       | All Plugins are enabled by default. Plugins enabled                                                                                                                           | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
-| `global.queueSort`                      | The default `queueSort` Plugin, needs to be enabled once                                                                                       | `["Coscheduling"]`                                      |
-| `global.extensions.preFilter`           | `preFilter` extension config. This is be used if the `preFilter` plugin is enabled.                                                                                                               | `["Coscheduling", "CapacityScheduling"]`                |
-| `global.extensions.filter`              | `filter` extension config. This is be used if the `filter` plugin is enabled.                                                                                                                  | `["NodeResourceTopologyMatch"]`                         |
-| `global.extensions.postFilter`          | `postFilter` extension config. This is be used if the `postFilter` plugin is enabled.                                                                                                              | `["Coscheduling", "CapacityScheduling"]`                |
-| `global.extensions.score`               | `score` extension config. This is be used if the `score` plugin is enabled.                                                                                                                   | `["NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
-| `global.extensions.permit`              | `permit` extension config. This is be used if the `permit` plugin is enabled.                                                                                                                  | `["Coscheduling"]`                                      |
-| `global.extensions.reserve`             | `reserve` extension config. This is be used if the `reserve` plugin is enabled.                                                                                                                 | `["Coscheduling", "CapacityScheduling"]`                |
-| `global.extensions.postBind`            | `postBind` extension config. This is be used if the `postBind` plugin is enabled.                                                                                                                | `["Coscheduling"]`                                      |
+| Parameter                               | Description                   | Default                                                                                         |
+| --------------------------------------- |-------------------------------|-------------------------------------------------------------------------------------------------|
+| `scheduler.name`                        | Scheduler name                | `scheduler-plugins-scheduler`                                                                   |
+| `scheduler.image`                       | Scheduler image               | `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.23.10`                                          |
+| `scheduler.namespace`                   | Scheduler namespace           | `scheduler-plugins`                                                                             |
+| `scheduler.replicaCount`                | Scheduler replicaCount        | `1`                                                                                             |
+| `controller.name`                       | Controller name               | `scheduler-plugins-controller`                                                                  |
+| `controller.image`                      | Controller image              | `k8s.gcr.io/scheduler-plugins/controller:v0.23.10`                                              |
+| `controller.namespace`                  | Controller namespace          | `scheduler-plugins`                                                                             |
+| `controller.replicaCount`               | Controller replicaCount       | `1`                                                                                             |
+| `plugins.enabled`                       | Plugins enabled by default    | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
+| `plugins.enabled`                       | Plugins disabled by default   | `["PrioritySort"]`                                                                              |
 

--- a/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
@@ -6,43 +6,24 @@ metadata:
   namespace: {{ .Values.scheduler.namespace }}
 data:
   scheduler-config.yaml: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:
-      leaderElect: false
+      leaderElect: {{ .Values.scheduler.leaderElect }}
     profiles:
     # Compose all plugins in one profile
-    - schedulerName: scheduler-plugins-scheduler
+    - schedulerName: {{ .Values.scheduler.name }}
       plugins:
-      # Ensure only the first queueSort plugin is rendered.
-
- {{- $enabledPlugins := .Values.plugins.enabled -}}
-
-  {{- if and (.Values.global.queueSort) (has (index .Values.global.queueSort 0) $enabledPlugins) }}
-        queueSort:
+        multiPoint:
           enabled:
-          - name: {{ index .Values.global.queueSort 0 }}
+          {{- range $.Values.plugins.enabled }}
+          - name: {{ title . }}
+          {{- end }}
           disabled:
-          - name: "*"
-  {{- end }}
-   
-    {{- $hasExtension := true -}}
-    
-      {{- range $extension, $plugins := .Values.global.extensions }}
-       {{- $hasExtension = true -}}
-           {{- range $plugins }}
-             {{- if and $hasExtension (has . $enabledPlugins) }}
-        {{ $extension }}:
-          enabled:
-           {{- $hasExtension = false -}}
-              {{- end}}
-            {{- if has . $enabledPlugins }}
-           - name: {{ title . }} 
-            {{- end}}
-         
-        {{- end }}
-      {{- end }}
-
- {{- end }}
+          {{- range $.Values.plugins.disabled }}
+          - name: {{ title . }}
+          {{- end }}
 
   {{- /* TODO: wire CRD installation with enabled plugins. */}}
+{{- end }}
+

--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: scheduler-plugins-controller
     spec:
-      serviceAccount: scheduler-plugins-controller
+      serviceAccountName: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
         image: {{ .Values.controller.image }}
@@ -42,20 +42,20 @@ spec:
       containers:
       - command:
         - /bin/kube-scheduler
-        - --address=0.0.0.0
-        - --leader-elect=false
         - --config=/etc/kubernetes/scheduler-config.yaml
         image: {{ .Values.scheduler.image }}
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10251
+            port: 10259
+            scheme: HTTPS
           initialDelaySeconds: 15
         name: scheduler-plugins-scheduler
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 10251
+            port: 10259
+            scheme: HTTPS
         resources:
           requests:
             cpu: '0.1'
@@ -71,3 +71,4 @@ spec:
       - name: scheduler-config
         configMap:
           name: scheduler-config
+

--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -128,3 +128,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.controller.name }}
   namespace: {{ .Values.controller.namespace }}
+

--- a/manifests/install/charts/as-a-second-scheduler/templates/serviceaccount.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/serviceaccount.yaml
@@ -14,3 +14,4 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.controller.name }}
   namespace: {{ .Values.controller.namespace }}
+

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -5,13 +5,14 @@
 
 scheduler:
   name: scheduler-plugins-scheduler
-  image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.22.6
+  image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.23.10
   namespace: scheduler-plugins
   replicaCount: 1
+  leaderElect: false
 
 controller:
   name: scheduler-plugins-controller
-  image: k8s.gcr.io/scheduler-plugins/controller:v0.22.6
+  image: k8s.gcr.io/scheduler-plugins/controller:v0.23.10
   namespace: scheduler-plugins
   replicaCount: 1
 
@@ -19,17 +20,6 @@ controller:
 # as they need extra RBAC privileges on metrics.k8s.io.
 
 plugins:
-  enabled: ["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]
+  enabled: ["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch","NodeResourcesAllocatable"]
+  disabled: ["PrioritySort"] # only in-tree plugins need to be defined here
 
-global:  
-   # queueSort is not indented under extensions 
-   # as it needs to be globally enabled once. 
-  queueSort: ["Coscheduling"]
-  extensions: 
-    preFilter: ["Coscheduling", "CapacityScheduling"] 
-    filter: ["NodeResourceTopologyMatch"] 
-    postFilter: ["Coscheduling", "CapacityScheduling"] 
-    score: ["NodeResourceTopologyMatch", "NodeResourcesAllocatable"] 
-    permit: ["Coscheduling"] 
-    reserve: ["Coscheduling", "CapacityScheduling"] 
-    postBind: ["Coscheduling"]


### PR DESCRIPTION
Cherry pick of #414 on release-1.23.

#414: updated docs for v0.23.10 release

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```