### PR TITLE
noderesourcetopology: refine best-effort pod early exit logic

### DIFF
--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -232,6 +232,34 @@ func TestNodeResourceTopology(t *testing.T) {
 			wantStatus: nil,
 		},
 		{
+			name: "Best effort QoS requesting devices, Pod Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				nicResourceName: *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Best effort QoS requesting devices, Pod Scope Topology policy; pod doesn't fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				nicResourceName: *resource.NewQuantity(20, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
+		},
+		{
+			name: "Best effort QoS requesting devices, Container Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				nicResourceName: *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Best effort QoS requesting devices, Container Scope Topology policy; pod doesn't fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				nicResourceName: *resource.NewQuantity(20, resource.DecimalSI)}),
+			node:       nodes[0],
+			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
+		},
+		{
 			name: "Guaranteed QoS, minimal, pod fit",
 			pod: makePodByResourceList(&v1.ResourceList{
 				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
@@ -291,6 +319,38 @@ func TestNodeResourceTopology(t *testing.T) {
 				nicResourceName: *resource.NewQuantity(11, resource.DecimalSI)}),
 			node:       nodes[1],
 			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
+		},
+		{
+			name: "Burstable QoS requesting CPU (enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:  *resource.NewQuantity(2, resource.DecimalSI),
+				nicResourceName: *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "BurstableQoS requesting CPU (not enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:  *resource.NewQuantity(20, resource.DecimalSI),
+				nicResourceName: *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting CPU (enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:  *resource.NewQuantity(2, resource.DecimalSI),
+				nicResourceName: *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting CPU (not enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:  *resource.NewQuantity(4, resource.DecimalSI),
+				nicResourceName: *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
 		},
 		{
 			name: "Guaranteed QoS, hugepages, pod doesn't fit",

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -226,6 +226,15 @@ func TestNodeResourceTopology(t *testing.T) {
 			wantStatus: nil,
 		},
 		{
+			name: "Guaranteed QoS, pod with extended resource no devices; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				extended:          resource.MustParse("1")}),
+			node:       nodes[4],
+			wantStatus: nil,
+		},
+		{
 			name:       "Best effort QoS, pod fit",
 			pod:        &v1.Pod{},
 			node:       nodes[0],
@@ -258,6 +267,104 @@ func TestNodeResourceTopology(t *testing.T) {
 				nicResourceName: *resource.NewQuantity(20, resource.DecimalSI)}),
 			node:       nodes[0],
 			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
+		},
+		{
+			name: "Best effort QoS requesting devices and extended resources, Container Scope Topology policy; pod doesn't fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				extended:        resource.MustParse("1"),
+				nicResourceName: *resource.NewQuantity(10, resource.DecimalSI)}),
+			node:       nodes[4],
+			wantStatus: nil,
+		},
+		{
+			name: "Best effort QoS, requesting CPU, memory (enough on NUMA) and devices (not enough), Container Scope Topology policy; pod doesn't fit",
+			pod: makePodWithReqAndLimitByResourceList(
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("3Gi"),
+					nicResourceName:   *resource.NewQuantity(11, resource.DecimalSI)},
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+					nicResourceName:   *resource.NewQuantity(11, resource.DecimalSI)},
+			),
+			node:       nodes[1],
+			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
+		},
+		{
+			name: "Best effort QoS, requesting CPU, memory (enough on NUMA) and devices (not enough), Pod Scope Topology policy; pod doesn't fit",
+			pod: makePodWithReqAndLimitByResourceList(
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+					nicResourceName:   *resource.NewQuantity(6, resource.DecimalSI)},
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+					nicResourceName:   *resource.NewQuantity(6, resource.DecimalSI)},
+			),
+			node:       nodes[2],
+			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
+		},
+		{
+			name: "Best effort QoS requesting CPU, memory (enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodWithReqAndLimitByResourceList(
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+			),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Best effort QoS requesting CPU, memory (not enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodWithReqAndLimitByResourceList(
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(19, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(20, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("6Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+			),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Best effort QoS requesting CPU, memory (enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodWithReqAndLimitByResourceList(
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("3Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+			),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Best effort QoS requesting CPU, memory (not enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodWithReqAndLimitByResourceList(
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(5, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+				&v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(6, resource.DecimalSI),
+					v1.ResourceMemory: resource.MustParse("6Gi"),
+					nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)},
+			),
+			node:       nodes[1],
+			wantStatus: nil,
 		},
 		{
 			name: "Guaranteed QoS, minimal, pod fit",
@@ -313,12 +420,20 @@ func TestNodeResourceTopology(t *testing.T) {
 			wantStatus: nil,
 		},
 		{
-			name: "Burstable QoS, pod doesn't fit",
+			name: "Burstable QoS, requesting CPU and devices (not enough), Container Scope Topology policy; pod doesn't fit",
 			pod: makePodByResourceList(&v1.ResourceList{
 				v1.ResourceCPU:  *resource.NewQuantity(4, resource.DecimalSI),
 				nicResourceName: *resource.NewQuantity(11, resource.DecimalSI)}),
 			node:       nodes[1],
 			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
+		},
+		{
+			name: "Burstable QoS, requesting CPU and devices (not enough), Pod Scope Topology policy; pod doesn't fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:  *resource.NewQuantity(2, resource.DecimalSI),
+				nicResourceName: *resource.NewQuantity(6, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
 		},
 		{
 			name: "Burstable QoS requesting CPU (enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
@@ -350,6 +465,117 @@ func TestNodeResourceTopology(t *testing.T) {
 				v1.ResourceCPU:  *resource.NewQuantity(4, resource.DecimalSI),
 				nicResourceName: *resource.NewQuantity(5, resource.DecimalSI)}),
 			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS, requesting memory (enough on NUMA) and devices (not enough), Container Scope Topology policy; pod doesn't fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				nicResourceName:   *resource.NewQuantity(11, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
+		},
+		{
+			name: "Burstable QoS, requesting memory (enough on NUMA) and devices (not enough), Pod Scope Topology policy; pod doesn't fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				nicResourceName:   *resource.NewQuantity(6, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
+		},
+		{
+			name: "Burstable QoS requesting memory (enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting memory (not enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("5Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting memory (enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting memory (not enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("5Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS, requesting CPU, memory (enough on NUMA) and devices (not enough), Container Scope Topology policy; pod doesn't fit",
+			pod: makePodWithReqByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+				nicResourceName:   *resource.NewQuantity(11, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: framework.NewStatus(framework.Unschedulable, fmt.Sprintf("cannot align container: %s", containerName)),
+		},
+		{
+			name: "Burstable QoS, requesting CPU, memory (enough on NUMA) and devices (not enough), Pod Scope Topology policy; pod doesn't fit",
+			pod: makePodWithReqByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				nicResourceName:   *resource.NewQuantity(6, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: framework.NewStatus(framework.Unschedulable, "cannot align pod: "),
+		},
+		{
+			name: "Burstable QoS requesting CPU, memory (enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodWithReqByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting CPU, memory (not enough on NUMA) and devices, Pod Scope Topology policy; pod fit",
+			pod: makePodWithReqByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(20, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("5Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[2],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting CPU, memory (enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodWithReqByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS requesting CPU, memory (not enough on NUMA) and devices, Container Scope Topology policy; pod fit",
+			pod: makePodWithReqByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(5, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("5Gi"),
+				nicResourceName:   *resource.NewQuantity(5, resource.DecimalSI)}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
+		{
+			name: "Burstable QoS with extended resources, pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				extended:        resource.MustParse("1"),
+				v1.ResourceCPU:  *resource.NewQuantity(4, resource.DecimalSI),
+				nicResourceName: *resource.NewQuantity(3, resource.DecimalSI)}),
+			node:       nodes[4],
 			wantStatus: nil,
 		},
 		{

--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -103,6 +103,35 @@ func makePodByResourceList(resources *v1.ResourceList) *v1.Pod {
 	}
 }
 
+func makePodWithReqByResourceList(resources *v1.ResourceList) *v1.Pod {
+	return &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Requests: *resources,
+					},
+				},
+			},
+		},
+	}
+}
+
+func makePodWithReqAndLimitByResourceList(resourcesReq, resourcesLim *v1.ResourceList) *v1.Pod {
+	return &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Requests: *resourcesReq,
+						Limits:   *resourcesLim,
+					},
+				},
+			},
+		},
+	}
+}
+
 func makeResourceListFromZones(zones topologyv1alpha1.ZoneList) v1.ResourceList {
 	result := make(v1.ResourceList)
 	for _, zone := range zones {


### PR DESCRIPTION
#### What this PR does / why we need it:

In the current implementation for best effort pods, we exit and leave it
the responsibility of scheduling such a pod to other scheduler plugins
which might still result in TopologyAffinityError.

The correct behavior would be to exit return early ONLY if we are 
evaluating best effort pods AND they are not requesting devices 
(non-native resources).

It is important to handle burstable and best effort pods requesting devices
carefully because irrespective of the QoS class of the pod requesting devices,
devices are always exclusively allocated unlike CPU and memory which are
allocated from the shared pool in case of BE/burstable pods.

Check related to whether requested resource can fit on a NUMA node
in case of non-guaranteed pods is already done in `isNUMANodeSuitable`
helper function so we don't need to duplicate that logic.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>

#### What type of PR is this?
/kind bug

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
noderesourcetopology: refine best-effort pod early exit logic
```
<!--