### PR TITLE
update rbac to allow all verbs for podgroups/status

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -64,7 +64,7 @@ rules:
   verbs: ["get", "list", "watch"]
 # resources need to be updated with the scheduler plugins used
 - apiGroups: ["scheduling.sigs.k8s.io"]
-  resources: ["podgroups", "elasticquotas"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding
@@ -96,7 +96,7 @@ rules:
   verbs: ["get", "list", "watch"]
 # resources need to be updated with the scheduler plugins used
 - apiGroups: ["scheduling.sigs.k8s.io"]
-  resources: ["podgroups", "elasticquotas"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
When I install scheduler-plugins by `helm install`, I face the following problem:
![image](https://user-images.githubusercontent.com/30817980/210026344-71f92dc2-c12e-4d32-a816-a731e66b69d4.png)

It seems the rabc in chart doesn't requirement the rules for podgroup/status, so I fix it.
FYI:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
![image](https://user-images.githubusercontent.com/30817980/210026397-54586dfb-a587-4c45-8fd5-93a590696ea2.png)
