### PR TITLE
Automated cherry pick of #470: update the controller image in all-in-one.yaml

### DIFF
--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -80,5 +80,5 @@ spec:
       serviceAccount: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
-        image: k8s.gcr.io/scheduler-plugins/controller:v0.22.6
+        image: registry.k8s.io/scheduler-plugins/controller:v0.24.9
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Cherry pick of #470 on release-1.24.

#470: update the controller image in all-in-one.yaml

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```