### PR TITLE
Clean up manifests for all-in-one installation

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -160,7 +160,7 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     <     name: sched-cc
     ```
    
-1. Verify that kube-scheduler pod is running properly with a correct image: `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.22.6`
+1. Verify that kube-scheduler pod is running properly with a correct image: `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.24.9`
 
     ```bash
     $ kubectl get pod -n kube-system | grep kube-scheduler

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -77,7 +77,7 @@ spec:
       labels:
         app: scheduler-plugins-controller
     spec:
-      serviceAccount: scheduler-plugins-controller
+      serviceAccountName: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
         image: registry.k8s.io/scheduler-plugins/controller:v0.24.9

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -6,7 +6,7 @@ metadata:
   name: system:kube-scheduler:plugins
 rules:
 - apiGroups: ["scheduling.sigs.k8s.io"]
-  resources: ["podgroups", "elasticquotas"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding
@@ -44,7 +44,7 @@ rules:
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["scheduling.sigs.k8s.io"]
-  resources: ["podgroups", "elasticquotas"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
I cleaned up manifests for all-in-one installation. Also, I fix the installation guide.

1. To avoid the following errors, I added ClusterRole to allow all verbs for  "podgroups/status", "elasticquotas/status".

```shell
E0115 18:05:06.743727       1 podgroup.go:178] "Error syncing pod group" err="podgroups.scheduling.sigs.k8s.io \"tfjob-simple\" is forbidden: User \"system:serviceaccount:scheduler-plugins:scheduler-plugins-controller\" cannot patch resource \"podgroups/status\" in API group \"scheduling.sigs.k8s.io\" in the namespace \"kubeflow\"" podGroup="kubeflow/tfjob-simple"
```

2. I replaced the [deprecated](https://github.com/kubernetes/api/blob/59fcd23597fd090dba6b7e903eb0a8c9e8efb0a6/core/v1/generated.proto#L3600-L3604) serviceAccount field with serviceAccountName field.
3. Fix the image version for the installation guide.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
