### PR TITLE
Automated cherry pick of #477: Clean up manifests for all-in-one installation

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -160,7 +160,7 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     <     name: sched-cc
     ```
    
-1. Verify that kube-scheduler pod is running properly with a correct image: `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.22.6`
+1. Verify that kube-scheduler pod is running properly with a correct image: `k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.24.9`
 
     ```bash
     $ kubectl get pod -n kube-system | grep kube-scheduler

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -77,7 +77,7 @@ spec:
       labels:
         app: scheduler-plugins-controller
     spec:
-      serviceAccount: scheduler-plugins-controller
+      serviceAccountName: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
         image: registry.k8s.io/scheduler-plugins/controller:v0.24.9

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -6,7 +6,7 @@ metadata:
   name: system:kube-scheduler:plugins
 rules:
 - apiGroups: ["scheduling.sigs.k8s.io"]
-  resources: ["podgroups", "elasticquotas"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding
@@ -44,7 +44,7 @@ rules:
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["scheduling.sigs.k8s.io"]
-  resources: ["podgroups", "elasticquotas"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Cherry pick of #477 on release-1.24.

#477: Allow all verbs for podgroup/status and

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```