### PR TITLE
update 'update-codegen.sh' to make it works outside GOPATH

### DIFF
--- a/config/crd/bases/scheduling.sigs.k8s.io_elasticquotas.yaml
+++ b/config/crd/bases/scheduling.sigs.k8s.io_elasticquotas.yaml
@@ -1,11 +1,10 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/52 # edited manually
-    controller-gen.kubebuilder.io/version: v0.6.2
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/52
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: elasticquotas.scheduling.sigs.k8s.io
 spec:
@@ -79,9 +78,5 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    subresources:
+      status: {}

--- a/config/crd/bases/scheduling.sigs.k8s.io_podgroups.yaml
+++ b/config/crd/bases/scheduling.sigs.k8s.io_podgroups.yaml
@@ -1,11 +1,10 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/50 # edited manually
-    controller-gen.kubebuilder.io/version: v0.6.2
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/50
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: podgroups.scheduling.sigs.k8s.io
 spec:
@@ -98,9 +97,5 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    subresources:
+      status: {}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -23,7 +23,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[@]}")/..
 TOOLS_DIR=$(realpath ./hack/tools)
 TOOLS_BIN_DIR="${TOOLS_DIR}/bin"
 GO_INSTALL=$(realpath ./hack/go-install.sh)
-CONTROLLER_GEN_VER=v0.6.2
+CONTROLLER_GEN_VER=v0.11.1
 CONTROLLER_GEN_BIN=controller-gen
 CONTROLLER_GEN=${TOOLS_BIN_DIR}/${CONTROLLER_GEN_BIN}-${CONTROLLER_GEN_VER}
 # Need v1 to support defaults in CRDs, unfortunately limiting us to k8s 1.16+
@@ -39,11 +39,13 @@ bash "${CODEGEN_PKG}"/generate-internal-groups.sh \
   sigs.k8s.io/scheduler-plugins/apis \
   sigs.k8s.io/scheduler-plugins/apis \
   "config:v1,v1beta2,v1beta3" \
+  --trim-path-prefix sigs.k8s.io/scheduler-plugins \
+  --output-base "./" \
   --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate/boilerplate.generatego.txt
 
-
 ${CONTROLLER_GEN} object:headerFile="hack/boilerplate/boilerplate.generatego.txt" \
-paths="./apis/scheduling/..."
+  paths="./apis/scheduling/..."
 
 ${CONTROLLER_GEN} ${CRD_OPTIONS} rbac:roleName=work-manager webhook \
-paths="./apis/scheduling/..." output:crd:artifacts:config=config/crd/bases
+  paths="./apis/scheduling/..." \
+  output:crd:artifacts:config=config/crd/bases


### PR DESCRIPTION
Signed-off-by: Wei Zhang <kweizh@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes-sigs/scheduler-plugins/commit/b5ea0f1f188e37f770868c7a74a9ae91107dd4e1#diff-149dfe7bb29d1191dceae3a52915e750e64b7f87257a5fb309c29d3056e2a95d This commit previously deleted the `generate-group.sh`, but then can not gen clientset, informers and listers. 

this PR:
1. added the `generate-group.sh` back to generate clientset, informers, listers for scheduler-plugins
2. bump controller gen to `v0.11.1` to match https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/hack/verify-crdgen.sh#L30
3. add `output-base` for codegen to make it works outside GOPATH

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

ref: https://github.com/kubernetes-sigs/kwok/pull/226

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
