### PR TITLE
ensure plugins implement the interface

### DIFF
--- a/pkg/networkaware/topologicalsort/topologicalsort.go
+++ b/pkg/networkaware/topologicalsort/topologicalsort.go
@@ -43,6 +43,8 @@ type TopologicalSort struct {
 	namespaces []string
 }
 
+var _ framework.QueueSortPlugin = &TopologicalSort{}
+
 // Name : returns the name of the plugin.
 func (ts *TopologicalSort) Name() string {
 	return Name

--- a/pkg/trimaran/loadvariationriskbalancing/loadvariationriskbalancing.go
+++ b/pkg/trimaran/loadvariationriskbalancing/loadvariationriskbalancing.go
@@ -49,6 +49,8 @@ type LoadVariationRiskBalancing struct {
 	args         *pluginConfig.LoadVariationRiskBalancingArgs
 }
 
+var _ framework.ScorePlugin = &LoadVariationRiskBalancing{}
+
 // New : create an instance of a LoadVariationRiskBalancing plugin
 func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) {
 	klog.V(4).InfoS("Creating new instance of the LoadVariationRiskBalancing plugin")

--- a/pkg/trimaran/targetloadpacking/targetloadpacking.go
+++ b/pkg/trimaran/targetloadpacking/targetloadpacking.go
@@ -59,6 +59,8 @@ type TargetLoadPacking struct {
 	args         *pluginConfig.TargetLoadPackingArgs
 }
 
+var _ framework.ScorePlugin = &TargetLoadPacking{}
+
 func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) {
 	klog.V(4).InfoS("Creating new instance of the TargetLoadPacking plugin")
 	// cast object into plugin arguments object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Ensure that plugins implement the interface.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
