### PR TITLE
Clean up unused variables and functions

### DIFF
--- a/pkg/capacityscheduling/capacity_scheduling.go
+++ b/pkg/capacityscheduling/capacity_scheduling.go
@@ -793,13 +793,6 @@ func getPDBLister(informerFactory informers.SharedInformerFactory) policylisters
 	return informerFactory.Policy().V1().PodDisruptionBudgets().Lister()
 }
 
-func getPodDisruptionBudgets(pdbLister policylisters.PodDisruptionBudgetLister) ([]*policy.PodDisruptionBudget, error) {
-	if pdbLister != nil {
-		return pdbLister.List(labels.Everything())
-	}
-	return nil, nil
-}
-
 // computePodResourceRequest returns a framework.Resource that covers the largest
 // width in each resource dimension. Because init-containers run sequentially, we collect
 // the max in each dimension iteratively. In contrast, we sum the resource vectors for

--- a/pkg/coscheduling/core/core.go
+++ b/pkg/coscheduling/core/core.go
@@ -79,8 +79,6 @@ type PodGroupManager struct {
 	pgLister pglister.PodGroupLister
 	// podLister is pod lister
 	podLister listerv1.PodLister
-	// reserveResourcePercentage is the reserved resource for the max finished group, range (0,100]
-	reserveResourcePercentage int32
 	sync.RWMutex
 }
 

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
@@ -237,13 +236,4 @@ func (cs *Coscheduling) Unreserve(ctx context.Context, state *framework.CycleSta
 func (cs *Coscheduling) PostBind(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeName string) {
 	klog.V(5).InfoS("PostBind", "pod", klog.KObj(pod))
 	cs.pgMgr.PostBind(ctx, pod, nodeName)
-}
-
-// rejectPod rejects pod in cache
-func (cs *Coscheduling) rejectPod(uid types.UID) {
-	waitingPod := cs.frameworkHandler.GetWaitingPod(uid)
-	if waitingPod == nil {
-		return
-	}
-	waitingPod.Reject(Name, "")
 }

--- a/pkg/networkaware/networkoverhead/networkoverhead_test.go
+++ b/pkg/networkaware/networkoverhead/networkoverhead_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/informers"
 	testClientSet "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
@@ -1610,15 +1609,4 @@ func makePodAllocated(selector string, podName string, hostname string, priority
 			},
 		},
 	}
-}
-
-// podScheduled returns true if a node is assigned to the given pod.
-func podScheduled(c *testClientSet.Clientset, podNamespace, podName string) bool {
-	pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
-	if err != nil {
-		// This could be a connection error so we want to retry.
-		klog.ErrorS(err, "Failed to get pod", "pod", klog.KRef(podNamespace, podName))
-		return false
-	}
-	return pod.Spec.NodeName != ""
 }

--- a/pkg/trimaran/loadvariationriskbalancing/analysis_test.go
+++ b/pkg/trimaran/loadvariationriskbalancing/analysis_test.go
@@ -20,54 +20,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/paypal/load-watcher/pkg/watcher"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/scheduler-plugins/pkg/trimaran"
-
-	v1 "k8s.io/api/core/v1"
-	st "k8s.io/kubernetes/pkg/scheduler/testing"
-)
-
-var (
-	metrics = []watcher.Metric{
-		{
-			Name:     "no_name",
-			Type:     watcher.CPU,
-			Operator: "",
-			Value:    40,
-		},
-		{
-			Name:     "cpu_running_avg",
-			Type:     watcher.CPU,
-			Operator: watcher.Average,
-			Value:    40,
-		},
-		{
-			Name:     "cpu_running_std",
-			Type:     watcher.CPU,
-			Operator: watcher.Std,
-			Value:    36,
-		},
-		{
-			Name:     "mem_running_avg",
-			Type:     watcher.Memory,
-			Operator: watcher.Average,
-			Value:    20,
-		},
-		{
-			Name:     "mem_running_std",
-			Type:     watcher.Memory,
-			Operator: watcher.Std,
-			Value:    10,
-		},
-	}
-
-	nodeResources = map[v1.ResourceName]string{
-		v1.ResourceCPU:    "1000m",
-		v1.ResourceMemory: "1Gi",
-	}
-
-	node0 = st.MakeNode().Name("node0").Capacity(nodeResources).Obj()
 )
 
 func TestComputeScore(t *testing.T) {

--- a/pkg/util/podgroup_test.go
+++ b/pkg/util/podgroup_test.go
@@ -22,12 +22,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 )
 
-type test struct {
-	old           interface{}
-	new           interface{}
-	expectedError bool
-}
-
 func TestCreateMergePatch(t *testing.T) {
 	tests := []struct {
 		old      interface{}


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
