### PR TITLE
cleanup: remove ioutil for new go version

### DIFF
--- a/vendor/github.com/fsnotify/fsnotify/kqueue.go
+++ b/vendor/github.com/fsnotify/fsnotify/kqueue.go
@@ -10,7 +10,6 @@ package fsnotify
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -390,7 +389,7 @@ func newCreateEvent(name string) Event {
 // watchDirectoryFiles to mimic inotify when adding a watch on a directory
 func (w *Watcher) watchDirectoryFiles(dirPath string) error {
 	// Get all files
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		return err
 	}
@@ -416,7 +415,7 @@ func (w *Watcher) watchDirectoryFiles(dirPath string) error {
 // create event for files created in a watched directory.
 func (w *Watcher) sendDirectoryChangeEvents(dirPath string) {
 	// Get all files
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		select {
 		case w.Errors <- err:


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
The io/ioutil package has been deprated in go 1.16: https://go.dev/doc/go1.16#ioutil
Mybe we should remove it.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
Does this PR introduce a user-facing change?