### PR TITLE
CapacityScheduling: fix usedOverMinWith/usedOverMaxWith/usedOverMin func and add unit test

### DIFF
--- a/pkg/capacityscheduling/elasticquota.go
+++ b/pkg/capacityscheduling/elasticquota.go
@@ -17,8 +17,6 @@ limitations under the License.
 package capacityscheduling
 
 import (
-	"reflect"
-
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -90,30 +88,27 @@ func (e *ElasticQuotaInfo) unreserveResource(request framework.Resource) {
 }
 
 func (e *ElasticQuotaInfo) usedOverMinWith(podRequest *framework.Resource) bool {
-	eqMin := reflect.ValueOf(e).Elem().FieldByName("Min")
-	if eqMin.IsValid() && !eqMin.IsZero() {
-		return cmp2(podRequest, e.Used, e.Min)
-	}
 	// "ElasticQuotaInfo doesn't have Min" means used values exceeded min(0)
-	return true
+	if e.Min == nil {
+		return true
+	}
+	return cmp2(podRequest, e.Used, e.Min)
 }
 
 func (e *ElasticQuotaInfo) usedOverMaxWith(podRequest *framework.Resource) bool {
-	eqMax := reflect.ValueOf(e).Elem().FieldByName("Max")
-	if eqMax.IsValid() && !eqMax.IsZero() {
-		return cmp2(podRequest, e.Used, e.Max)
-	}
 	// "ElasticQuotaInfo doesn't have Max" means there are no limitations(infinite)
-	return false
+	if e.Max == nil {
+		return false
+	}
+	return cmp2(podRequest, e.Used, e.Max)
 }
 
 func (e *ElasticQuotaInfo) usedOverMin() bool {
-	eqMin := reflect.ValueOf(e).Elem().FieldByName("Min")
-	if eqMin.IsValid() && !eqMin.IsZero() {
-		return cmp(e.Used, e.Min)
-	}
 	// "ElasticQuotaInfo doesn't have Min" means used values exceeded min(0)
-	return true
+	if e.Min == nil {
+		return true
+	}
+	return cmp(e.Used, e.Min)
 }
 
 func (e *ElasticQuotaInfo) clone() *ElasticQuotaInfo {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When ElasticQuota's Max or Min isn't set up, usedOverMaxWith or usedOverMinWith returns panic.
So I fixed this bug and added unit tests.

#### Which issue(s) this PR fixes:
Fixes #508 

#### Special notes for your reviewer:
Thank you very much for creating and maintaining this amazing repository.
This is the first time I created PR for this repo.
If I do wrong things, please let me know.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```