### PR TITLE
Introduce pluginargs validation for NodeResourceTopologyMatch plugin

### DIFF
--- a/apis/config/validation/validation_pluginargs.go
+++ b/apis/config/validation/validation_pluginargs.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"sigs.k8s.io/scheduler-plugins/apis/config"
+)
+
+var validScoringStrategy = sets.NewString(
+	string(config.MostAllocated),
+	string(config.BalancedAllocation),
+	string(config.LeastAllocated),
+	string(config.LeastNUMANodes),
+)
+
+func ValidateNodeResourceTopologyMatchArgs(path *field.Path, args *config.NodeResourceTopologyMatchArgs) error {
+	var allErrs field.ErrorList
+	scoringStrategyTypePath := path.Child("scoringStrategy.type")
+	if err := validateScoringStrategyType(args.ScoringStrategy.Type, scoringStrategyTypePath); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	return allErrs.ToAggregate()
+}
+
+func validateScoringStrategyType(scoringStrategy config.ScoringStrategyType, path *field.Path) *field.Error {
+	if !validScoringStrategy.Has(string(scoringStrategy)) {
+		return field.Invalid(path, scoringStrategy, "invalid ScoringStrategyType")
+	}
+	return nil
+}

--- a/apis/config/validation/validation_plugingargs_test.go
+++ b/apis/config/validation/validation_plugingargs_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/scheduler-plugins/apis/config"
+)
+
+func TestValidateNodeResourceTopologyMatchArgs(t *testing.T) {
+	testCases := []struct {
+		args        *config.NodeResourceTopologyMatchArgs
+		expectedErr error
+		description string
+	}{
+		{
+			description: "correct config",
+			args: &config.NodeResourceTopologyMatchArgs{
+				ScoringStrategy: config.ScoringStrategy{
+					Type: config.MostAllocated,
+				},
+			},
+		},
+		{
+			description: "incorrect config, wrong ScoringStrategy type",
+			args: &config.NodeResourceTopologyMatchArgs{
+				ScoringStrategy: config.ScoringStrategy{
+					Type: "not existent",
+				},
+			},
+			expectedErr: fmt.Errorf("scoringStrategy.type: Invalid value:"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			err := ValidateNodeResourceTopologyMatchArgs(nil, testCase.args)
+			if testCase.expectedErr != nil {
+				if err == nil {
+					t.Errorf("expected err to equal %v not nil", testCase.expectedErr)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedErr.Error()) {
+					t.Errorf("expected err to contain %s in error message: %s", testCase.expectedErr.Error(), err.Error())
+				}
+			}
+			if testCase.expectedErr == nil && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/noderesourcetopology/plugin.go
+++ b/pkg/noderesourcetopology/plugin.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
+	"sigs.k8s.io/scheduler-plugins/apis/config/validation"
 	nrtcache "sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/cache"
 
 	topologyapi "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology"
@@ -118,6 +119,10 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 	tcfg, ok := args.(*apiconfig.NodeResourceTopologyMatchArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type NodeResourceTopologyMatchArgs, got %T", args)
+	}
+
+	if err := validation.ValidateNodeResourceTopologyMatchArgs(nil, tcfg); err != nil {
+		return nil, err
 	}
 
 	nrtCache, err := initNodeTopologyInformer(tcfg, handle)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Introduce pluginargs validation for NodeResourceTopologyMatch plugin.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #507 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
