### PR TITLE
feat: update PodGroup label key

### DIFF
--- a/apis/scheduling/v1alpha1/types.go
+++ b/apis/scheduling/v1alpha1/types.go
@@ -112,7 +112,7 @@ const (
 	PodGroupFailed PodGroupPhase = "Failed"
 
 	// PodGroupLabel is the default label of coscheduling
-	PodGroupLabel = "pod-group." + scheduling.GroupName
+	PodGroupLabel = scheduling.GroupName + "/pod-group"
 )
 
 // PodGroup is a collection of Pod; used for batch workload.

--- a/doc/install.md
+++ b/doc/install.md
@@ -193,7 +193,7 @@ Now, we're able to verify how the coscheduling plugin works.
     $ kubectl apply -f podgroup.yaml
     ```
 
-1. Create a deployment labelled `pod-group.scheduling.x-k8s.io: pg1` to associated with PodGroup
+1. Create a deployment labelled `scheduling.x-k8s.io/pod-group: pg1` to associated with PodGroup
    `pg1` created in the previous step.
 
     ```yaml
@@ -211,7 +211,7 @@ Now, we're able to verify how the coscheduling plugin works.
         metadata:
           labels:
             app: pause
-            pod-group.scheduling.x-k8s.io: pg1
+            scheduling.x-k8s.io/pod-group: pg1
         spec:
           containers:
           - name: pause

--- a/pkg/controllers/podgroup_test.go
+++ b/pkg/controllers/podgroup_test.go
@@ -281,7 +281,6 @@ func setUp(ctx context.Context,
 	objs := []runtime.Object{pg}
 	if len(podNames) != 0 {
 		ps := makePods(podNames, pgName, podPhase, podOwnerReference)
-		// s.AddKnownTypes(clientgoscheme.SchemeGroupVersion, ps)
 		objs = append(objs, ps[0], ps[1])
 	}
 	client := fake.NewFakeClient(objs...)

--- a/pkg/coscheduling/README.md
+++ b/pkg/coscheduling/README.md
@@ -16,7 +16,7 @@ This folder holds the coscheduling plugin implementations based on [Coscheduling
 
 ### PodGroup
 
-We use a special label named `pod-group.scheduling.x-k8s.io` to define a PodGroup. Pods that set this label and use the same value belong to the same PodGroup.
+We use a special label named `scheduling.x-k8s.io/pod-group` to define a PodGroup. Pods that set this label and use the same value belong to the same PodGroup.
 
 ```
 # PodGroup CRD spec
@@ -28,9 +28,9 @@ spec:
   scheduleTimeoutSeconds: 10
   minMember: 3
 ---
-# Add a label `pod-group.scheduling.x-k8s.io` to mark the pod belongs to a group
+# Add a label `scheduling.x-k8s.io/pod-group` to mark the pod belongs to a group
 labels:
-  pod-group.scheduling.x-k8s.io: nginx
+  scheduling.x-k8s.io/pod-group: nginx
 ```
 
 We will calculate the sum of the Running pods and the Waiting pods (assumed but not bind) in scheduler, if the sum is greater than or equal to the minMember, the Waiting pods
@@ -108,7 +108,7 @@ spec:
       name: nginx
       labels:
         app: nginx
-        pod-group.scheduling.x-k8s.io: nginx
+        scheduling.x-k8s.io/pod-group: nginx
     spec:
       containers:
       - name: nginx

--- a/pkg/coscheduling/core/core.go
+++ b/pkg/coscheduling/core/core.go
@@ -111,6 +111,7 @@ func (pgMgr *PodGroupManager) ActivateSiblings(pod *corev1.Pod, state *framework
 		klog.ErrorS(err, "Failed to obtain pods belong to a PodGroup", "podGroup", pgName)
 		return
 	}
+
 	for i := range pods {
 		if pods[i].UID == pod.UID {
 			pods = append(pods[:i], pods[i+1:]...)
@@ -149,6 +150,7 @@ func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, pod *corev1.Pod) er
 	if err != nil {
 		return fmt.Errorf("podLister list pods failed: %w", err)
 	}
+
 	if len(pods) < int(pg.Spec.MinMember) {
 		return fmt.Errorf("pre-filter pod %v cannot find enough sibling pods, "+
 			"current pods number: %v, minMember of group: %v", pod.Name, len(pods), pg.Spec.MinMember)
@@ -290,7 +292,7 @@ func (pgMgr *PodGroupManager) CalculateAssignedPods(podGroupName, namespace stri
 	for _, nodeInfo := range nodeInfos {
 		for _, podInfo := range nodeInfo.Pods {
 			pod := podInfo.Pod
-			if pod.Labels[v1alpha1.PodGroupLabel] == podGroupName && pod.Namespace == namespace && pod.Spec.NodeName != "" {
+			if util.GetPodGroupLabel(pod) == podGroupName && pod.Namespace == namespace && pod.Spec.NodeName != "" {
 				count++
 			}
 		}

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -30,7 +30,6 @@ import (
 
 	"sigs.k8s.io/scheduler-plugins/apis/config"
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling"
-	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling/core"
 	pgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"
 	pgformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
@@ -162,7 +161,7 @@ func (cs *Coscheduling) PostFilter(ctx context.Context, state *framework.CycleSt
 	// It's based on an implicit assumption: if the nth Pod failed,
 	// it's inferrable other Pods belonging to the same PodGroup would be very likely to fail.
 	cs.frameworkHandler.IterateOverWaitingPods(func(waitingPod framework.WaitingPod) {
-		if waitingPod.GetPod().Namespace == pod.Namespace && waitingPod.GetPod().Labels[v1alpha1.PodGroupLabel] == pg.Name {
+		if waitingPod.GetPod().Namespace == pod.Namespace && util.GetPodGroupLabel(waitingPod.GetPod()) == pg.Name {
 			klog.V(3).InfoS("PostFilter rejects the pod", "podGroup", klog.KObj(pg), "pod", klog.KObj(waitingPod.GetPod()))
 			waitingPod.Reject(cs.Name(), "optimistic rejection in PostFilter")
 		}
@@ -224,7 +223,7 @@ func (cs *Coscheduling) Unreserve(ctx context.Context, state *framework.CycleSta
 		return
 	}
 	cs.frameworkHandler.IterateOverWaitingPods(func(waitingPod framework.WaitingPod) {
-		if waitingPod.GetPod().Namespace == pod.Namespace && waitingPod.GetPod().Labels[v1alpha1.PodGroupLabel] == pg.Name {
+		if waitingPod.GetPod().Namespace == pod.Namespace && util.GetPodGroupLabel(waitingPod.GetPod()) == pg.Name {
 			klog.V(3).InfoS("Unreserve rejects", "pod", klog.KObj(waitingPod.GetPod()), "podGroup", klog.KObj(pg))
 			waitingPod.Reject(cs.Name(), "rejection in Unreserve")
 		}

--- a/pkg/util/podgroup.go
+++ b/pkg/util/podgroup.go
@@ -47,12 +47,12 @@ func CreateMergePatch(original, new interface{}) ([]byte, error) {
 	return patch, nil
 }
 
-// GetPodGroupLabel get pod group from pod annotations
+// GetPodGroupLabel get pod group name from pod labels
 func GetPodGroupLabel(pod *v1.Pod) string {
 	return pod.Labels[v1alpha1.PodGroupLabel]
 }
 
-// GetPodGroupFullName get namespaced group name from pod annotations
+// GetPodGroupFullName get namespaced group name from pod labels
 func GetPodGroupFullName(pod *v1.Pod) string {
 	pgName := GetPodGroupLabel(pod)
 	if len(pgName) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes-sigs/scheduler-plugins/issues/440

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
using new pod label key `scheduling.x-k8s.io/pod-group` to define a PodGroup. 
```
