### PR TITLE
fix: add "imagePullPolicy: IfNotPresent" in helmchart's kube-scheduler image

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
         - /bin/kube-scheduler
         - --config=/etc/kubernetes/scheduler-config.yaml
         image: {{ .Values.scheduler.image }}
+        imagePullPolicy: IfNotPresent        
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind bug

#### What this PR does / why we need it:
With the addition of "imagePullPolicy: IfNotPresent", we can run helm as-a-second-scheduler more easily than before.

When attempting to run helm as-a-second-scheduler in my local environment, I wanted to use "localhost:5000/scheduler-plugins/kube-scheduler:latest" image. However, the deployment failed to pull the local image due to the absence of "imagePullPolicy: IfNotPresent".

It would also be consistent with the scheduler-plugins-controller for kube-scheduler to have "imagePullPolicy: IfNotPresent".

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Thank you for reviewing this PR.
Please let me know if I have made any mistakes or if there are any improvements that could be made.
Your comments and feedback are appreciated.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
