### PR TITLE
update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - ahg-g
-  - Huang-Wei
   - denkensk
+  - ffromani
+  - Huang-Wei
 reviewers:
-  - cwdsuzhou
+  - PiotrProkop
   - seanmalloy
-  - yuanchen8911
+  - swatisehgal
+  - Tal-or
+  - zwpaper


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The OWNERS file should reflect the activeness of contributors, so it's subjected to changes as time goes. This is aligned with upstream policy, to keep a project organic and energetic.

Based on the devstats [data](https://k8s.devstats.cncf.io/d/66/developer-activity-counts-by-companies?orgId=1&var-period_name=Last%202%20years&var-metric=contributions&var-repogroup_name=All&var-repo_name=kubernetes-sigs%2Fscheduler-plugins&var-country_name=All&var-companies=All) of past 2 years:

![image](https://user-images.githubusercontent.com/1425903/222602775-2f90c627-b37c-4edb-9c79-386c8425df42.png)

I'd like to first thank @ahg-g @cwdsuzhou @yuanchen8911 for their past contributions.

Meanwhile, I'd like to nominate @ffromani as a new maintainer, in light of his comprehensive knowledge on scheduler  plugins and noderesourcetoplogy.

Also I'd like to nominate  @PiotrProkop @swatisehgal @Tal-or as new reviewers as they've long been top contributors to this project.

Lastly, @zwpaper has shown expertise in ctr-runtime, Helm, and other areas in the past couple of months. I hope @zwpaper can continue the momentum in this future.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
