### PR TITLE
doc.go modifications in diktyo.io projects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module sigs.k8s.io/scheduler-plugins
 go 1.19
 
 require (
-	github.com/diktyo-io/appgroup-api v1.0.0-alpha
-	github.com/diktyo-io/networktopology-api v1.0.0-alpha
+	github.com/diktyo-io/appgroup-api v1.0.1-alpha
+	github.com/diktyo-io/networktopology-api v1.0.1-alpha
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -125,10 +125,10 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/diktyo-io/appgroup-api v1.0.0-alpha h1:uN+1y8Rahhs3HoopnCq3jt8r15zbEa8oK3Q+i/HQQkk=
-github.com/diktyo-io/appgroup-api v1.0.0-alpha/go.mod h1:Q0UPLA6aFBogLpiOiA9+7sqnlvPES6ge/PIaQohfR8Y=
-github.com/diktyo-io/networktopology-api v1.0.0-alpha h1:XHMPI4/9wjhlTd91qeFDKhTE5d9oUPtxeLJJCXd89v4=
-github.com/diktyo-io/networktopology-api v1.0.0-alpha/go.mod h1:a9YAoBY96ITcSMUTNPJAljMPpDcig91scxJ1smaAhEg=
+github.com/diktyo-io/appgroup-api v1.0.1-alpha h1:XIl7FrBtkGO9QVLQ61xMu7gbtP1DYMdMdS51ntQiN1k=
+github.com/diktyo-io/appgroup-api v1.0.1-alpha/go.mod h1:Q0UPLA6aFBogLpiOiA9+7sqnlvPES6ge/PIaQohfR8Y=
+github.com/diktyo-io/networktopology-api v1.0.1-alpha h1:yAgUu+h2sSC25Gbv52hsZD453pyDiRhbLUQRIWsmFNI=
+github.com/diktyo-io/networktopology-api v1.0.1-alpha/go.mod h1:a9YAoBY96ITcSMUTNPJAljMPpDcig91scxJ1smaAhEg=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/vendor/github.com/diktyo-io/appgroup-api/pkg/apis/appgroup/v1alpha1/doc.go
+++ b/vendor/github.com/diktyo-io/appgroup-api/pkg/apis/appgroup/v1alpha1/doc.go
@@ -1,6 +1,6 @@
 // +k8s:deepcopy-gen=package
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=appgroup.diktyo.k8s.io
+// +groupName=appgroup.diktyo.x-k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 package v1alpha1 // import "github.com/diktyo-io/appgroup-api/pkg/apis/appgroup/v1alpha1"

--- a/vendor/github.com/diktyo-io/networktopology-api/pkg/apis/networktopology/v1alpha1/doc.go
+++ b/vendor/github.com/diktyo-io/networktopology-api/pkg/apis/networktopology/v1alpha1/doc.go
@@ -1,6 +1,6 @@
 // +k8s:deepcopy-gen=package
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=networktopology.diktyo.k8s.io
+// +groupName=networktopology.diktyo.x-k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 package v1alpha1 // import "github.com/diktyo-io/networktopology-api/pkg/apis/networktopology/v1alpha1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,7 +33,7 @@ github.com/coreos/go-systemd/v22/journal
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/diktyo-io/appgroup-api v1.0.0-alpha
+# github.com/diktyo-io/appgroup-api v1.0.1-alpha
 ## explicit; go 1.16
 github.com/diktyo-io/appgroup-api/pkg/apis/appgroup
 github.com/diktyo-io/appgroup-api/pkg/apis/appgroup/v1alpha1
@@ -47,7 +47,7 @@ github.com/diktyo-io/appgroup-api/pkg/generated/informers/externalversions/appgr
 github.com/diktyo-io/appgroup-api/pkg/generated/informers/externalversions/appgroup/v1alpha1
 github.com/diktyo-io/appgroup-api/pkg/generated/informers/externalversions/internalinterfaces
 github.com/diktyo-io/appgroup-api/pkg/generated/listers/appgroup/v1alpha1
-# github.com/diktyo-io/networktopology-api v1.0.0-alpha
+# github.com/diktyo-io/networktopology-api v1.0.1-alpha
 ## explicit; go 1.16
 github.com/diktyo-io/networktopology-api/pkg/apis/networktopology
 github.com/diktyo-io/networktopology-api/pkg/apis/networktopology/v1alpha1


### PR DESCRIPTION
#### What type of PR is this?

small nit can be found in doc.go from diktyo.io APIs

#### What this PR does / why we need it:

To comply with https://kubernetes.io/docs/reference/labels-annotations-taints/, we should stop using "k8s.io" and "kubernetes.io" in all places of this repo, including:

#### Which issue(s) this PR fixes:

Fixes #526