### PR TITLE
helm: install chart to ns scheduler-pluings if `-n` is not provided

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scheduler-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}
 data:
   scheduler-config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1beta3

--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -2,7 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Values.controller.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}
   labels:
     app: scheduler-plugins-controller
 spec:
@@ -27,7 +27,7 @@ metadata:
   labels:
     component: scheduler
   name: {{ .Values.scheduler.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}
 spec:
   selector:
     matchLabels:

--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -85,7 +85,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.scheduler.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -113,7 +113,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.controller.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: scheduler-plugins-controller
@@ -131,7 +131,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.scheduler.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}
 - kind: ServiceAccount
   name: {{ .Values.controller.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}

--- a/manifests/install/charts/as-a-second-scheduler/templates/serviceaccount.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/serviceaccount.yaml
@@ -1,11 +1,18 @@
+{{- if eq .Release.Namespace "default" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+---
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.scheduler.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.controller.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ ne .Release.Namespace "default" | ternary .Release.Namespace .Values.namespace }}

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -1,6 +1,7 @@
 # Default values for scheduler-plugins-as-a-second-scheduler.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+namespace: scheduler-plugins
 
 scheduler:
   name: scheduler-plugins-scheduler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

A follow-up of https://github.com/kubernetes-sigs/scheduler-plugins/pull/533#discussion_r1125581851.

With this PR, the command

```
helm install scheduler-plugins manifests/install/charts/as-a-second-scheduler/
```

works as before - the chart will be installed into the default namespace `default-plugins`.

And it also works well with PR #519 to support `-n` command:

```
helm install scheduler-plugins manifests/install/charts/as-a-second-scheduler/ -n foo --create-namespace
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
