### PR TITLE
Automated cherry pick of #541: Documents update for release v0.25.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ changed.
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch           |
 |-------------------|---------------------------|-----------------------------------------------------------|----------------|
+| v0.25.7           | v1.25.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7  | AMD64<br>ARM64 |
 | v0.24.9           | v1.24.9                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9  | AMD64<br>ARM64 |
 | v0.23.10          | v1.23.10                  | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.23.10 | AMD64<br>ARM64 |
 | v0.22.6           | v1.22.6                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.22.6  | AMD64<br>ARM64 |
@@ -70,6 +71,7 @@ changed.
 
 | Controller | Compiled With k8s Version | Container Image                                       | Arch           |
 |------------|---------------------------|-------------------------------------------------------|----------------|
+| v0.25.7    | v1.25.7                   | registry.k8s.io/scheduler-plugins/controller:v0.25.7  | AMD64<br>ARM64 |
 | v0.24.9    | v1.24.9                   | registry.k8s.io/scheduler-plugins/controller:v0.24.9  | AMD64<br>ARM64 |
 | v0.23.10   | v1.23.10                  | registry.k8s.io/scheduler-plugins/controller:v0.23.10 | AMD64<br>ARM64 |
 | v0.22.6    | v1.22.6                   | registry.k8s.io/scheduler-plugins/controller:v0.22.6  | AMD64<br>ARM64 |

--- a/doc/install.md
+++ b/doc/install.md
@@ -4,7 +4,7 @@
 
 <!-- toc -->
 - [Create a Kubernetes Cluster](#create-a-kubernetes-cluster)
-- [Install release v0.24.9 and use Coscheduling](#install-release-v0249-and-use-coscheduling)
+- [Install release v0.25.7 and use Coscheduling](#install-release-v0257-and-use-coscheduling)
   - [As a second scheduler](#as-a-second-scheduler)
   - [As a single scheduler (replacing the vanilla default-scheduler)](#as-a-single-scheduler-replacing-the-vanilla-default-scheduler)
 - [Test Coscheduling](#test-coscheduling)
@@ -24,7 +24,7 @@ If you do not have a cluster yet, create one by using one of the following provi
 * [kubeadm](https://kubernetes.io/docs/admin/kubeadm/)
 * [minikube](https://minikube.sigs.k8s.io/)
 
-## Install release v0.24.9 and use Coscheduling
+## Install release v0.25.7 and use Coscheduling
 
 Note: we provide two ways to install the scheduler-plugin artifacts: as a second scheduler
 and as a single scheduler. Their pros and cons are as below:
@@ -146,9 +146,9 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     >     - --kubeconfig=/etc/kubernetes/scheduler.conf
     >     - --leader-elect=true
     19,20c20
-    <     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9
+    <     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
     ---
-    >     image: registry.k8s.io/kube-scheduler:v1.24.9
+    >     image: registry.k8s.io/kube-scheduler:v1.25.7
     50,52d49
     <     - mountPath: /etc/kubernetes/sched-cc.yaml
     <       name: sched-cc
@@ -160,14 +160,14 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     <     name: sched-cc
     ```
    
-1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9`
+1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7`
 
     ```bash
     $ kubectl get pod -n kube-system | grep kube-scheduler
     kube-scheduler-kind-control-plane            1/1     Running   0          3m27s
  
     $ kubectl get pods -l component=kube-scheduler -n kube-system -o=jsonpath="{.items[0].spec.containers[0].image}{'\n'}"
-    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9
+    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
     ```
    
     > **⚠️Troubleshooting:** If the kube-scheudler is not up, you may need to restart kubelet service inside the kind control plane (`systemctl restart kubelet.service`)
@@ -238,17 +238,16 @@ Now, we're able to verify how the coscheduling plugin works.
     ```bash
     $ kubectl get pod
     NAME                     READY   STATUS    RESTARTS   AGE
-    pause-58f7d7db67-7sqgp   0/1     Pending   0          9s
-    pause-58f7d7db67-jbmfv   0/1     Pending   0          9s
+    pause-646dbcfb64-4zvt6   0/1     Pending   0          9s
+    pause-646dbcfb64-8kpg4   0/1     Pending   0          9s
    ```
 
-1. Now let's delete the deployment to re-create it with replicas=3, so as to qualify for `minMember`
+1. Now let's scale the deployment up to have 3 replicas, so as to qualify for `minMember`
    (i.e., 3) of the associated PodGroup:
 
     ```bash
-    $ kubectl delete -f deploy.yaml && sed 's/replicas: 2/replicas: 3/' deploy.yaml | kubectl apply -f -
-    deployment.apps "pause" deleted
-    deployment.apps/pause created
+    $ kubectl scale deploy pause --replicas=3
+    deployment.apps/pause scaled
     ```
 
     And wait for a couple of seconds, it's expected to see all Pods get into running state:
@@ -256,9 +255,9 @@ Now, we're able to verify how the coscheduling plugin works.
     ```bash
     $ kubectl get pod
     NAME                     READY   STATUS    RESTARTS   AGE
-    pause-64f5c9ccf4-kprg7   1/1     Running   0          8s
-    pause-64f5c9ccf4-tc8lx   1/1     Running   0          8s
-    pause-64f5c9ccf4-xrgkw   1/1     Running   0          8s
+    pause-646dbcfb64-4zvt6   1/1     Running   0          42s
+    pause-646dbcfb64-8kpg4   1/1     Running   0          42s
+    pause-646dbcfb64-npzcf   1/1     Running   0          8s
     ```
 
 1. You can also get the PodGroup's spec via:

--- a/manifests/install/charts/as-a-second-scheduler/Chart.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.24.9
+version: 0.25.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.24.9
+appVersion: 0.25.7

--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -45,11 +45,11 @@ The following table lists the configurable parameters of the as-a-second-schedul
 | Parameter                 | Description                 | Default                                                                                         |
 |---------------------------|-----------------------------|-------------------------------------------------------------------------------------------------|
 | `scheduler.name`          | Scheduler name              | `scheduler-plugins-scheduler`                                                                   |
-| `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9`                                      |
+| `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7`                                      |
 | `scheduler.leaderElect`   | Scheduler leaderElection    | `false`                                                                                         |
 | `scheduler.replicaCount`  | Scheduler replicaCount      | `1`                                                                                             |
 | `controller.name`         | Controller name             | `scheduler-plugins-controller`                                                                  |
-| `controller.image`        | Controller image            | `registry.k8s.io/scheduler-plugins/controller:v0.24.9`                                          |
+| `controller.image`        | Controller image            | `registry.k8s.io/scheduler-plugins/controller:v0.25.7`                                          |
 | `controller.replicaCount` | Controller replicaCount     | `1`                                                                                             |
 | `plugins.enabled`         | Plugins enabled by default  | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
 | `plugins.disabled`        | Plugins disabled by default | `["PrioritySort"]`                                                                              |

--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -66,11 +66,11 @@ rules:
 - apiGroups: ["scheduling.x-k8s.io"]
   resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
-# for network-aware plugins add the following lines (scheduler-plugins v.0.24.9)
-#- apiGroups: [ "appgroup.diktyo.k8s.io" ]
+# for network-aware plugins add the following lines (scheduler-plugins v.0.25.7)
+#- apiGroups: [ "appgroup.diktyo.x-k8s.io" ]
 #  resources: [ "appgroups" ]
 #  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
-#- apiGroups: [ "networktopology.diktyo.k8s.io" ]
+#- apiGroups: [ "networktopology.diktyo.x-k8s.io" ]
 #  resources: [ "networktopologies" ]
 #  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
 ---

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -4,13 +4,13 @@
 
 scheduler:
   name: scheduler-plugins-scheduler
-  image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9
+  image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
   replicaCount: 1
   leaderElect: false
 
 controller:
   name: scheduler-plugins-controller
-  image: registry.k8s.io/scheduler-plugins/controller:v0.24.9
+  image: registry.k8s.io/scheduler-plugins/controller:v0.25.7
   replicaCount: 1
 
 # LoadVariationRiskBalancing and TargetLoadPacking are not enabled by default


### PR DESCRIPTION
Cherry pick of #541 on release-1.25.

#541: Documents update for release v0.25.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```