### PR TITLE
ElasticQuota: add unit test for PostFilter & PodEligibleToPreemptOthers

### DIFF
--- a/pkg/capacityscheduling/capacity_scheduling.go
+++ b/pkg/capacityscheduling/capacity_scheduling.go
@@ -423,6 +423,7 @@ func (p *preemptor) PodEligibleToPreemptOthers(pod *v1.Pod, nominatedNodeStatus 
 		if preemptorWithEQ {
 			moreThanMinWithPreemptor := preemptorEQInfo.usedOverMinWith(&preFilterState.nominatedPodsReqInEQWithPodReq)
 			for _, p := range nodeInfo.Pods {
+				// Checking terminating pods
 				if p.Pod.DeletionTimestamp != nil {
 					eqInfo, withEQ := elasticQuotaSnapshotState.elasticQuotaInfos[p.Pod.Namespace]
 					if !withEQ {

--- a/pkg/capacityscheduling/capacity_scheduling_test.go
+++ b/pkg/capacityscheduling/capacity_scheduling_test.go
@@ -38,6 +38,7 @@ import (
 	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -127,6 +128,16 @@ func TestPreFilter(t *testing.T) {
 				framework.Unschedulable,
 			},
 		},
+		{
+			name: "without elasticQuotaInfo",
+			podInfos: []podInfo{
+				{podName: "ns2-p1", podNamespace: "ns2", memReq: 500},
+			},
+			elasticQuotas: map[string]*ElasticQuotaInfo{},
+			expected: []framework.Code{
+				framework.Success,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -163,6 +174,203 @@ func TestPreFilter(t *testing.T) {
 				if _, got := cs.PreFilter(context.TODO(), state, pods[i]); got.Code() != tt.expected[i] {
 					t.Errorf("expected %v, got %v : %v", tt.expected[i], got.Code(), got.Message())
 				}
+			}
+		})
+	}
+}
+
+func TestPostFilter(t *testing.T) {
+	res := map[v1.ResourceName]string{v1.ResourceMemory: "150"}
+	tests := []struct {
+		name                  string
+		pod                   *v1.Pod
+		pods                  []*v1.Pod
+		nodes                 []*v1.Node
+		filteredNodesStatuses framework.NodeToStatusMap
+		elasticQuotas         map[string]*ElasticQuotaInfo
+		wantResult            *framework.PostFilterResult
+		wantStatus            *framework.Status
+	}{
+		{
+			name: "in-namespace preemption",
+			pod:  makePod("t1-p1", "ns1", 50, 0, 0, highPriority, "t1-p1", ""),
+			pods: []*v1.Pod{
+				makePod("t1-p2", "ns1", 50, 0, 0, midPriority, "t1-p2", "node-a"),
+				makePod("t1-p3", "ns2", 50, 0, 0, midPriority, "t1-p3", "node-a"),
+				makePod("t1-p4", "ns2", 50, 0, 0, midPriority, "t1-p4", "node-a"),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			filteredNodesStatuses: framework.NodeToStatusMap{
+				"node-a": framework.NewStatus(framework.Unschedulable),
+			},
+			elasticQuotas: map[string]*ElasticQuotaInfo{
+				"ns1": {
+					Namespace: "ns1",
+					Max: &framework.Resource{
+						Memory: 200,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 50,
+					},
+				},
+				"ns2": {
+					Namespace: "ns2",
+					Max: &framework.Resource{
+						Memory: 200,
+					},
+					Min: &framework.Resource{
+						Memory: 200,
+					},
+					Used: &framework.Resource{
+						Memory: 100,
+					},
+				},
+			},
+			wantResult: framework.NewPostFilterResultWithNominatedNode("node-a"),
+			wantStatus: framework.NewStatus(framework.Success),
+		},
+		{
+			name: "cross-namespace preemption",
+			pod:  makePod("t1-p1", "ns1", 50, 0, 0, highPriority, "t1-p1", ""),
+			pods: []*v1.Pod{
+				makePod("t1-p2", "ns1", 50, 0, 0, midPriority, "t1-p2", "node-a"),
+				makePod("t1-p3", "ns2", 50, 0, 0, midPriority, "t1-p3", "node-a"),
+				makePod("t1-p4", "ns2", 50, 0, 0, midPriority, "t1-p4", "node-a"),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			filteredNodesStatuses: framework.NodeToStatusMap{
+				"node-a": framework.NewStatus(framework.Unschedulable),
+			},
+			elasticQuotas: map[string]*ElasticQuotaInfo{
+				"ns1": {
+					Namespace: "ns1",
+					Max: &framework.Resource{
+						Memory: 200,
+					},
+					Min: &framework.Resource{
+						Memory: 150,
+					},
+					Used: &framework.Resource{
+						Memory: 50,
+					},
+				},
+				"ns2": {
+					Namespace: "ns2",
+					Max: &framework.Resource{
+						Memory: 200,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 100,
+					},
+				},
+			},
+			wantResult: framework.NewPostFilterResultWithNominatedNode("node-a"),
+			wantStatus: framework.NewStatus(framework.Success),
+		},
+		{
+			name: "Without elasticQuotas",
+			pod:  makePod("t1-p1", "ns1", 50, 0, 0, highPriority, "t1-p1", ""),
+			pods: []*v1.Pod{
+				makePod("t1-p2", "ns1", 50, 0, 0, midPriority, "t1-p2", "node-a"),
+				makePod("t1-p3", "ns2", 50, 0, 0, midPriority, "t1-p3", "node-a"),
+				makePod("t1-p4", "ns2", 50, 0, 0, midPriority, "t1-p4", "node-a"),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			filteredNodesStatuses: framework.NodeToStatusMap{
+				"node-a": framework.NewStatus(framework.Unschedulable),
+			},
+			elasticQuotas: map[string]*ElasticQuotaInfo{},
+			wantResult:    framework.NewPostFilterResultWithNominatedNode("node-a"),
+			wantStatus:    framework.NewStatus(framework.Success),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registeredPlugins := []st.RegisterPluginFunc{
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				st.RegisterPluginAsExtensions(noderesources.Name, func(plArgs apiruntime.Object, fh framework.Handle) (framework.Plugin, error) {
+					return noderesources.NewFit(plArgs, fh, plfeature.Features{})
+				}, "Filter", "PreFilter"),
+			}
+
+			podItems := []v1.Pod{}
+			for _, pod := range tt.pods {
+				podItems = append(podItems, *pod)
+			}
+			cs := clientsetfake.NewSimpleClientset(&v1.PodList{Items: podItems})
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			podInformer := informerFactory.Core().V1().Pods().Informer()
+			podInformer.GetStore().Add(tt.pod)
+			for i := range tt.pods {
+				podInformer.GetStore().Add(tt.pods[i])
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			fwk, err := st.NewFramework(
+				registeredPlugins,
+				"default-scheduler",
+				ctx.Done(),
+				frameworkruntime.WithClientSet(cs),
+				frameworkruntime.WithEventRecorder(&events.FakeRecorder{}),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithPodNominator(testutil.NewPodNominator(informerFactory.Core().V1().Pods().Lister())),
+				frameworkruntime.WithSnapshotSharedLister(testutil.NewFakeSharedLister(tt.pods, tt.nodes)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			state := framework.NewCycleState()
+			_, preFilterStatus := fwk.RunPreFilterPlugins(ctx, state, tt.pod)
+			if !preFilterStatus.IsSuccess() {
+				t.Errorf("Unexpected preFilterStatus: %v", preFilterStatus)
+			}
+
+			podReq := computePodResourceRequest(tt.pod)
+			elasticQuotaSnapshotState := &ElasticQuotaSnapshotState{
+				elasticQuotaInfos: tt.elasticQuotas,
+			}
+			prefilterState := &PreFilterState{
+				podReq:                         *podReq,
+				nominatedPodsReqWithPodReq:     *podReq,
+				nominatedPodsReqInEQWithPodReq: *podReq,
+			}
+			state.Write(preFilterStateKey, prefilterState)
+			state.Write(ElasticQuotaSnapshotKey, elasticQuotaSnapshotState)
+
+			c := &CapacityScheduling{
+				elasticQuotaInfos: tt.elasticQuotas,
+				fh:                fwk,
+				podLister:         informerFactory.Core().V1().Pods().Lister(),
+				pdbLister:         getPDBLister(informerFactory),
+			}
+			gotResult, gotStatus := c.PostFilter(ctx, state, tt.pod, tt.filteredNodesStatuses)
+			if gotStatus.Code() == framework.Error {
+				if diff := gocmp.Diff(tt.wantStatus.Reasons(), gotStatus.Reasons()); diff != "" {
+					t.Errorf("Unexpected status (-want, +got):\n%s", diff)
+				}
+			} else {
+				if diff := gocmp.Diff(tt.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Unexpected status (-want, +got):\n%s", diff)
+				}
+			}
+			if diff := gocmp.Diff(tt.wantResult, gotResult); diff != "" {
+				t.Errorf("Unexpected postFilterResult (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -408,7 +616,7 @@ func TestDryRunPreemption(t *testing.T) {
 	}{
 		{
 			name: "in-namespace preemption",
-			pod:  makePod("t1-p", "ns1", 50, 0, 0, highPriority, "", "t1-p"),
+			pod:  makePod("t1-p", "ns1", 50, 0, 0, highPriority, "t1-p", ""),
 			pods: []*v1.Pod{
 				makePod("t1-p1", "ns1", 50, 0, 0, midPriority, "t1-p1", "node-a"),
 				makePod("t1-p2", "ns2", 50, 0, 0, midPriority, "t1-p2", "node-a"),
@@ -460,7 +668,7 @@ func TestDryRunPreemption(t *testing.T) {
 		},
 		{
 			name: "cross-namespace preemption",
-			pod:  makePod("t1-p", "ns1", 50, 0, 0, highPriority, "", "t1-p"),
+			pod:  makePod("t1-p", "ns1", 50, 0, 0, highPriority, "t1-p", ""),
 			pods: []*v1.Pod{
 				makePod("t1-p1", "ns1", 50, 0, 0, midPriority, "t1-p1", "node-a"),
 				makePod("t1-p2", "ns2", 50, 0, 0, highPriority, "t1-p2", "node-a"),
@@ -550,12 +758,12 @@ func TestDryRunPreemption(t *testing.T) {
 			elasticQuotaSnapshotState := &ElasticQuotaSnapshotState{
 				elasticQuotaInfos: tt.elasticQuotas,
 			}
-			prefilterStatue := &PreFilterState{
+			prefilterState := &PreFilterState{
 				podReq:                         *podReq,
 				nominatedPodsReqWithPodReq:     *podReq,
 				nominatedPodsReqInEQWithPodReq: *podReq,
 			}
-			state.Write(preFilterStateKey, prefilterStatue)
+			state.Write(preFilterStateKey, prefilterState)
 			state.Write(ElasticQuotaSnapshotKey, elasticQuotaSnapshotState)
 
 			pe := preemption.Evaluator{
@@ -597,6 +805,222 @@ func TestDryRunPreemption(t *testing.T) {
 				if diff := gocmp.Diff(c.Name(), got[i].Name()); diff != "" {
 					t.Errorf("Unexpected victims at index %v (-want, +got): %s", i, diff)
 				}
+			}
+		})
+	}
+}
+
+func TestPodEligibleToPreemptOthers(t *testing.T) {
+	res := map[v1.ResourceName]string{v1.ResourceMemory: "150"}
+	tests := []struct {
+		name                string
+		pod                 *v1.Pod
+		pods                []*v1.Pod
+		nodes               []*v1.Node
+		nominatedNodeStatus *framework.Status
+		elasticQuotas       map[string]*ElasticQuotaInfo
+		expected            bool
+	}{
+		{
+			name: "Pod with PreemptNever preemption policy",
+			pod:  st.MakePod().Name("t1-p1").UID("t1-p1").Priority(highPriority).PreemptionPolicy(v1.PreemptNever).Obj(),
+			pods: []*v1.Pod{makePod("t1-p0", "ns1", 50, 10, 0, midPriority, "t1-p1", "node-a")},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			nominatedNodeStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, tainttoleration.ErrReasonNotMatch),
+			elasticQuotas: map[string]*ElasticQuotaInfo{
+				"ns1": {
+					Namespace: "ns1",
+					Max: &framework.Resource{
+						Memory: 150,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 0,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Pod with nominated node",
+			pod:  st.MakePod().Name("t1-p1").UID("t1-p1").Priority(highPriority).NominatedNodeName("node-a").Obj(),
+			pods: []*v1.Pod{makePod("t1-p0", "ns1", 50, 10, 0, midPriority, "t1-p1", "node-a")},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			nominatedNodeStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, tainttoleration.ErrReasonNotMatch),
+			elasticQuotas: map[string]*ElasticQuotaInfo{
+				"ns1": {
+					Namespace: "ns1",
+					Max: &framework.Resource{
+						Memory: 150,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 0,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Pod with terminating pod in the same namespace",
+			pod:  st.MakePod().Name("t1-p1").UID("t1-p1").Namespace("ns1").Priority(highPriority).NominatedNodeName("node-a").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("t1-p0").UID("t1-p0").Namespace("ns1").Priority(midPriority).Node("node-a").Terminating().Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			nominatedNodeStatus: nil,
+			elasticQuotas: map[string]*ElasticQuotaInfo{
+				"ns1": {
+					Namespace: "ns1",
+					Max: &framework.Resource{
+						Memory: 150,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 0,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Pod with terminating pod in the different namespace",
+			pod:  st.MakePod().Name("t1-p1").UID("t1-p1").Namespace("ns1").Priority(highPriority).NominatedNodeName("node-a").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("t1-p0").UID("t1-p0").Namespace("ns2").Priority(midPriority).Node("node-a").Terminating().Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			nominatedNodeStatus: nil,
+			elasticQuotas: map[string]*ElasticQuotaInfo{
+				"ns1": {
+					Namespace: "ns1",
+					Max: &framework.Resource{
+						Memory: 150,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 0,
+					},
+				},
+				"ns2": {
+					Namespace: "ns2",
+					Max: &framework.Resource{
+						Memory: 150,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 100,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Pod without ElasticQuotas  and terminating pod exists",
+			pod:  st.MakePod().Name("t1-p1").UID("t1-p1").Namespace("ns1").Priority(highPriority).NominatedNodeName("node-a").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("t1-p0").UID("t1-p0").Namespace("ns2").Priority(midPriority).Node("node-a").Terminating().Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			nominatedNodeStatus: nil,
+			elasticQuotas:       map[string]*ElasticQuotaInfo{},
+			expected:            false,
+		},
+		{
+			name: "Pod with other namespace's ElasticQuotas and terminating pod exists",
+			pod:  st.MakePod().Name("t1-p1").UID("t1-p1").Namespace("ns1").Priority(highPriority).NominatedNodeName("node-a").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("t1-p0").UID("t1-p0").Namespace("ns2").Priority(midPriority).Node("node-a").Terminating().Obj(),
+			},
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Capacity(res).Obj(),
+			},
+			nominatedNodeStatus: nil,
+			elasticQuotas: map[string]*ElasticQuotaInfo{
+				"ns2": {
+					Namespace: "ns2",
+					Max: &framework.Resource{
+						Memory: 150,
+					},
+					Min: &framework.Resource{
+						Memory: 50,
+					},
+					Used: &framework.Resource{
+						Memory: 100,
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registeredPlugins := []st.RegisterPluginFunc{
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				st.RegisterPluginAsExtensions(noderesources.Name, func(plArgs apiruntime.Object, fh framework.Handle) (framework.Plugin, error) {
+					return noderesources.NewFit(plArgs, fh, plfeature.Features{})
+				}, "Filter", "PreFilter"),
+			}
+			cs := clientsetfake.NewSimpleClientset()
+			ctx := context.Background()
+
+			fwk, err := st.NewFramework(
+				registeredPlugins,
+				"default-scheduler",
+				ctx.Done(),
+				frameworkruntime.WithClientSet(cs),
+				frameworkruntime.WithEventRecorder(&events.FakeRecorder{}),
+				frameworkruntime.WithPodNominator(testutil.NewPodNominator(nil)),
+				frameworkruntime.WithSnapshotSharedLister(testutil.NewFakeSharedLister(tt.pods, tt.nodes)),
+				frameworkruntime.WithInformerFactory(informers.NewSharedInformerFactory(cs, 0)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			state := framework.NewCycleState()
+			_, preFilterStatus := fwk.RunPreFilterPlugins(ctx, state, tt.pod)
+			if !preFilterStatus.IsSuccess() {
+				t.Errorf("Unexpected preFilterStatus: %v", preFilterStatus)
+			}
+
+			podReq := computePodResourceRequest(tt.pod)
+			elasticQuotaSnapshotState := &ElasticQuotaSnapshotState{
+				elasticQuotaInfos: tt.elasticQuotas,
+			}
+			prefilterState := &PreFilterState{
+				podReq:                         *podReq,
+				nominatedPodsReqWithPodReq:     *podReq,
+				nominatedPodsReqInEQWithPodReq: *podReq,
+			}
+			state.Write(preFilterStateKey, prefilterState)
+			state.Write(ElasticQuotaSnapshotKey, elasticQuotaSnapshotState)
+
+			p := preemptor{fh: fwk, state: state}
+			if got, _ := p.PodEligibleToPreemptOthers(tt.pod, tt.nominatedNodeStatus); got != tt.expected {
+				t.Errorf("expected %t, got %t for pod: %s", tt.expected, got, tt.pod.Name)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Added unit tests for PostFilter & PodEligibleToPreemptOthers in ElasticQuota.
I referred to the code of [default_preemption_test.go](https://github.com/kubernetes/kubernetes/blob/1af56548af167d836eff33a5f57552fa417cbc0b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
Thank you for reviewing this PR.
Please let me know if I have made any mistakes or if there are any improvements that could be made.
Your comments and feedback are appreciated.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
