### PR TITLE
nodetopologymatch: bump deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0
-	github.com/k8stopologyawareschedwg/podfingerprint v0.1.2
+	github.com/k8stopologyawareschedwg/podfingerprint v0.2.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/paypal/load-watcher v0.2.2
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
-	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0
+	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/paypal/load-watcher v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0 h1:2uCRJbv+A+fmaUaO0wLZ8oYd6cLE1dRzBQcFNxggH3s=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
-github.com/k8stopologyawareschedwg/podfingerprint v0.1.2 h1:Db5KLJjPg2mKaCoeEliMlea+JMyDMWdbNPXnWbPNDyM=
-github.com/k8stopologyawareschedwg/podfingerprint v0.1.2/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.0 h1:3Wc58WPBqG0yry0noEARZIAljBOU7TQZDg1L7dQTyw0=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.0/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0 h1:2uCRJbv+A+fmaUaO0wLZ8oYd6cLE1dRzBQcFNxggH3s=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1 h1:BI3L7hNqRvXtB42FO4NI/0ZjDDVRPOMBDFLShhFtf28=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.0 h1:3Wc58WPBqG0yry0noEARZIAljBOU7TQZDg1L7dQTyw0=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.0/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/noderesourcetopology/cache/store.go
+++ b/pkg/noderesourcetopology/cache/store.go
@@ -213,7 +213,7 @@ func checkPodFingerprintForNode(logID string, indexer NodeIndexer, nodeName, pfp
 		return err
 	}
 
-	var st podfingerprint.Status
+	st := podfingerprint.MakeStatus(nodeName)
 	pfp := podfingerprint.NewTracingFingerprint(len(objs), &st)
 	for _, obj := range objs {
 		pfp.Add(obj.Namespace, obj.Name)

--- a/pkg/noderesourcetopology/cache/store.go
+++ b/pkg/noderesourcetopology/cache/store.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	topologyv1alpha2attr "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute"
 
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/stringify"
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
@@ -195,8 +196,8 @@ func (cnt counter) Len() int {
 // podFingerprintForNodeTopology extracts without recomputing the pods fingerprint from
 // the provided Node Resource Topology object.
 func podFingerprintForNodeTopology(nrt *topologyv1alpha2.NodeResourceTopology) string {
-	if attrValue, ok := findAttribute(nrt.Attributes, podfingerprint.Attribute); ok {
-		return attrValue
+	if attr, ok := topologyv1alpha2attr.Get(nrt.Attributes, podfingerprint.Attribute); ok {
+		return attr.Value
 	}
 	if nrt.Annotations != nil {
 		return nrt.Annotations[podfingerprint.Annotation]
@@ -224,13 +225,4 @@ func checkPodFingerprintForNode(logID string, indexer NodeIndexer, nodeName, pfp
 	klog.V(6).InfoS("nrtcache: podset fingerprint debug", "logID", logID, "node", nodeName, "status", st.Repr())
 
 	return pfp.Check(pfpExpected)
-}
-
-func findAttribute(attrs topologyv1alpha2.AttributeList, name string) (string, bool) {
-	for _, attr := range attrs {
-		if attr.Name == name {
-			return attr.Value, true
-		}
-	}
-	return "", false
 }

--- a/test/integration/noderesourcetopology_cache_test.go
+++ b/test/integration/noderesourcetopology_cache_test.go
@@ -680,7 +680,7 @@ func podMatchesExpectedNode(podNamespace, podName, nodeName, expectedNode string
 }
 
 func mkPFP(nodeName string, pods ...*corev1.Pod) string {
-	var st podfingerprint.Status
+	st := podfingerprint.MakeStatus(nodeName)
 	fp := podfingerprint.NewTracingFingerprint(len(pods), &st)
 	for _, pod := range pods {
 		fp.AddPod(pod)

--- a/vendor/github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute/attribute.go
+++ b/vendor/github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute/attribute.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attribute
+
+import (
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+)
+
+// Get looks for attribute by its name in the provided AtributeList.
+// If found, returns the value of the attribute and an explicit boolean value equals true
+// Otherwise, returns the zero value and explicit boolean value equals false.
+// In case there are duplicates in the attribute list, returns the first attribute from the left
+// found in iteration order, iterating on the attribute list treating it as a golang slice.
+func Get(attributes v1alpha2.AttributeList, name string) (v1alpha2.AttributeInfo, bool) {
+	attr := findAttrByName(attributes, name)
+	if attr == nil {
+		return v1alpha2.AttributeInfo{}, false
+	}
+	return *attr, true
+}
+
+// Insert updates or adds an attribute to the provided AttributeList, preserving the existing order.
+// The attribute name must be non-zero, the value can be zero.
+// If the attribute is already present, its value is overridden with the given one; otherwise
+// adds a new attribute preserving as much as possible the current ordering between attributes.
+// Returns the updated AttributeList.
+func Insert(attributes v1alpha2.AttributeList, attr v1alpha2.AttributeInfo) v1alpha2.AttributeList {
+	if attr.Name == "" {
+		return attributes
+	}
+	attrs := attributes.DeepCopy()
+	existingAttr := findAttrByName(attrs, attr.Name)
+	if existingAttr == nil {
+		return append(attrs, attr)
+	}
+	existingAttr.Value = attr.Value
+	return attrs
+}
+
+// Merge joins `updated` into `existing`, preserving as much as possible the current ordering between attributes.
+// Returns the merged attribute list, which includes the union of the elements from `existing` and `updated`.
+// If an element is present in both lists, takes the value present in `updated`.
+func Merge(existing, updated v1alpha2.AttributeList) v1alpha2.AttributeList {
+	ret := existing.DeepCopy()
+	delta := v1alpha2.AttributeList{}
+	for _, attr := range updated {
+		if existingAttr := findAttrByName(ret, attr.Name); existingAttr != nil {
+			existingAttr.Value = attr.Value
+		} else {
+			delta = append(delta, attr)
+		}
+	}
+	return append(ret, delta...)
+}
+
+// DeleteAll removes from the given AttributeList all the elements whose name matches the given `name`.
+// Returns a new AttributeList with all the attributes removed, preserving as much as possible the current
+// ordering between attributes.
+func DeleteAll(attributes v1alpha2.AttributeList, name string) v1alpha2.AttributeList {
+	ret := make(v1alpha2.AttributeList, 0, len(attributes))
+	for _, attr := range attributes {
+		if attr.Name == name {
+			continue
+		}
+		ret = append(ret, attr)
+	}
+	return ret
+}
+
+func findAttrByName(attributes v1alpha2.AttributeList, name string) *v1alpha2.AttributeInfo {
+	for idx := range attributes {
+		attr := &attributes[idx]
+		if attr.Name == name {
+			return attr
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
@@ -65,6 +65,13 @@ type Status struct {
 	FingerprintExpected string           `json:"fingerprintExpected,omitempty"`
 	FingerprintComputed string           `json:"fingerprintComputed,omitempty"`
 	Pods                []NamespacedName `json:"pods,omitempty"`
+	NodeName            string           `json:"nodeName,omitempty"`
+}
+
+func MakeStatus(nodeName string) Status {
+	return Status{
+		NodeName: nodeName,
+	}
 }
 
 func (st *Status) Start(numPods int) {
@@ -90,6 +97,7 @@ func (st *Status) Check(expected string) {
 func (st Status) Repr() string {
 	var sb strings.Builder
 
+	sb.WriteString(fmt.Sprintf("> processing node %q\n", st.NodeName))
 	sb.WriteString(fmt.Sprintf("> processing %d pods\n", len(st.Pods)))
 	for _, pod := range st.Pods {
 		sb.WriteString("+ " + pod.Namespace + "/" + pod.Name + "\n")
@@ -101,6 +109,18 @@ func (st Status) Repr() string {
 	}
 
 	return sb.String()
+}
+
+func (st Status) Clone() Status {
+	pods := make([]NamespacedName, len(st.Pods))
+	copy(pods, st.Pods)
+	ret := Status{
+		FingerprintExpected: st.FingerprintExpected,
+		FingerprintComputed: st.FingerprintComputed,
+		Pods:                pods,
+		NodeName:            st.NodeName,
+	}
+	return ret
 }
 
 type TracingFingerprint struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -204,7 +204,7 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/inform
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions/topology/v1alpha2
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/listers/topology/v1alpha1
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/listers/topology/v1alpha2
-# github.com/k8stopologyawareschedwg/podfingerprint v0.1.2
+# github.com/k8stopologyawareschedwg/podfingerprint v0.2.0
 ## explicit; go 1.17
 github.com/k8stopologyawareschedwg/podfingerprint
 # github.com/mailru/easyjson v0.7.6

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,11 +185,12 @@ github.com/jpillora/backoff
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0
+# github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1
 ## explicit; go 1.16
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2
+github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/fake
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/scheme


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Bump dependencies used by the nodetopologymatch plugin, catching up with simplifications provided by upstream libraries

#### Which issue(s) this PR fixes:
Fixes #N/A

#### Special notes for your reviewer:
Gather minor cleanups we discussed during past reviews. No expected impact in behavior

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
