### PR TITLE
Add integration test args to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ install-envtest:
 
 .PHONY: integration-test
 integration-test: install-envtest
-	$(INTEGTESTENVVAR) hack/integration-test.sh
+	$(INTEGTESTENVVAR) hack/integration-test.sh $(ARGS)
 
 .PHONY: verify
 verify:

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -32,8 +32,8 @@ runTests() {
   source "${TEMP_DIR}/setup-envtest"
 
   kube::log::status "Running integration test cases"
-  # TODO: make args customizable.
-  go test -timeout=40m -mod=vendor sigs.k8s.io/scheduler-plugins/test/integration/...
+
+  go test -timeout=40m -mod=vendor sigs.k8s.io/scheduler-plugins/test/integration/... ${ARGS:-}
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds support for passing custom arguments to the integration test script through the `Makefile`. Previously, the integration test script only supported running all the tests, which limited the flexibility.

With this change, you can now pass custom arguments to the integration test script by setting the `ARGS` variable when running the integration-test target in the Makefile. For example, you can run the integration tests with the -run flag and a specific test case by running:
`make integration-test ARGS="-run <test-case>"`

If no arguments are provided, the integration test script will run with default arguments as before.

I tested this change by running this command with some arguments and verifying the results.

#### Special notes for your reviewer:
Please review this pull request and let me know if you have any comments or concerns. Thank you!

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
