### PR TITLE
add podGroup backoff time for coscheduling

### DIFF
--- a/apis/config/scheme/scheme_test.go
+++ b/apis/config/scheme/scheme_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
 
 	"sigs.k8s.io/scheduler-plugins/apis/config"
-	"sigs.k8s.io/scheduler-plugins/apis/config/v1"
+	v1 "sigs.k8s.io/scheduler-plugins/apis/config/v1"
 	"sigs.k8s.io/scheduler-plugins/apis/config/v1beta2"
 	"sigs.k8s.io/scheduler-plugins/apis/config/v1beta3"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling"
@@ -66,6 +66,7 @@ profiles:
   - name: Coscheduling
     args:
       permitWaitingTimeSeconds: 10
+      podGroupBackoffSeconds: 0
       deniedPGExpirationTimeSeconds: 3
   - name: NodeResourcesAllocatable
     args:
@@ -472,6 +473,7 @@ kind: KubeSchedulerConfiguration
 profiles:
 - schedulerName: scheduler-plugins
   pluginConfig:
+  - name: Coscheduling # Test argument defaulting logic
   - name: TopologicalSort
     args:
       namespaces:
@@ -488,6 +490,12 @@ profiles:
 					SchedulerName: "scheduler-plugins",
 					Plugins:       defaults.PluginsV1,
 					PluginConfig: []schedconfig.PluginConfig{
+						{
+							Name: coscheduling.Name,
+							Args: &config.CoschedulingArgs{
+								PermitWaitingTimeSeconds: 60,
+							},
+						},
 						{
 							Name: topologicalsort.Name,
 							Args: &config.TopologicalSortArgs{
@@ -728,6 +736,7 @@ profiles:
       apiVersion: kubescheduler.config.k8s.io/v1beta2
       kind: CoschedulingArgs
       permitWaitingTimeSeconds: 10
+      podGroupBackoffSeconds: 0
     name: Coscheduling
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1beta2
@@ -781,6 +790,7 @@ profiles:
 								Name: coscheduling.Name,
 								Args: &config.CoschedulingArgs{
 									PermitWaitingTimeSeconds: 10,
+									PodGroupBackoffSeconds:   20,
 								},
 							},
 							{
@@ -868,6 +878,7 @@ profiles:
       apiVersion: kubescheduler.config.k8s.io/v1beta3
       kind: CoschedulingArgs
       permitWaitingTimeSeconds: 10
+      podGroupBackoffSeconds: 20
     name: Coscheduling
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1beta3
@@ -1022,6 +1033,7 @@ profiles:
       apiVersion: kubescheduler.config.k8s.io/v1
       kind: CoschedulingArgs
       permitWaitingTimeSeconds: 10
+      podGroupBackoffSeconds: 0
     name: Coscheduling
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1

--- a/apis/config/types.go
+++ b/apis/config/types.go
@@ -30,6 +30,8 @@ type CoschedulingArgs struct {
 
 	// PermitWaitingTimeSeconds is the waiting timeout in seconds.
 	PermitWaitingTimeSeconds int64
+	// PodGroupBackoffSeconds is the backoff time in seconds before a pod group can be scheduled again.
+	PodGroupBackoffSeconds int64
 }
 
 // ModeType is a "string" type.

--- a/apis/config/v1/defaults.go
+++ b/apis/config/v1/defaults.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	defaultPermitWaitingTimeSeconds int64 = 60
+	defaultPodGroupBackoffSeconds   int64 = 0
 
 	defaultNodeResourcesAllocatableMode = Least
 
@@ -82,6 +83,9 @@ var (
 func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	if obj.PermitWaitingTimeSeconds == nil {
 		obj.PermitWaitingTimeSeconds = &defaultPermitWaitingTimeSeconds
+	}
+	if obj.PodGroupBackoffSeconds == nil {
+		obj.PodGroupBackoffSeconds = &defaultPodGroupBackoffSeconds
 	}
 }
 

--- a/apis/config/v1/defaults_test.go
+++ b/apis/config/v1/defaults_test.go
@@ -40,15 +40,18 @@ func TestSchedulingDefaults(t *testing.T) {
 			config: &CoschedulingArgs{},
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
+				PodGroupBackoffSeconds:   pointer.Int64Ptr(0),
 			},
 		},
 		{
 			name: "set non default CoschedulingArgs",
 			config: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
+				PodGroupBackoffSeconds:   pointer.Int64Ptr(20),
 			},
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
+				PodGroupBackoffSeconds:   pointer.Int64Ptr(20),
 			},
 		},
 		{

--- a/apis/config/v1/types.go
+++ b/apis/config/v1/types.go
@@ -30,6 +30,8 @@ type CoschedulingArgs struct {
 
 	// PermitWaitingTimeSeconds is the waiting timeout in seconds.
 	PermitWaitingTimeSeconds *int64 `json:"permitWaitingTimeSeconds,omitempty"`
+	// PodGroupBackoffSeconds is the backoff time in seconds before a pod group can be scheduled again.
+	PodGroupBackoffSeconds *int64 `json:"podGroupBackoffSeconds,omitempty"`
 }
 
 // ModeType is a type "string".

--- a/apis/config/v1/zz_generated.conversion.go
+++ b/apis/config/v1/zz_generated.conversion.go
@@ -157,6 +157,9 @@ func autoConvert_v1_CoschedulingArgs_To_config_CoschedulingArgs(in *Coscheduling
 	if err := metav1.Convert_Pointer_int64_To_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_int64_To_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -167,6 +170,9 @@ func Convert_v1_CoschedulingArgs_To_config_CoschedulingArgs(in *CoschedulingArgs
 
 func autoConvert_config_CoschedulingArgs_To_v1_CoschedulingArgs(in *config.CoschedulingArgs, out *CoschedulingArgs, s conversion.Scope) error {
 	if err := metav1.Convert_int64_To_Pointer_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_int64_To_Pointer_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
 		return err
 	}
 	return nil

--- a/apis/config/v1/zz_generated.deepcopy.go
+++ b/apis/config/v1/zz_generated.deepcopy.go
@@ -36,6 +36,11 @@ func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodGroupBackoffSeconds != nil {
+		in, out := &in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/apis/config/v1beta2/defaults.go
+++ b/apis/config/v1beta2/defaults.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	defaultPermitWaitingTimeSeconds      int64 = 60
+	defaultPodGroupBackoffSeconds        int64 = 0
 	defaultDeniedPGExpirationTimeSeconds int64 = 20
 
 	defaultNodeResourcesAllocatableMode = Least
@@ -80,6 +81,9 @@ func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	}
 	if obj.DeniedPGExpirationTimeSeconds == nil {
 		obj.DeniedPGExpirationTimeSeconds = &defaultDeniedPGExpirationTimeSeconds
+	}
+	if obj.PodGroupBackoffSeconds == nil {
+		obj.PodGroupBackoffSeconds = &defaultPodGroupBackoffSeconds
 	}
 }
 

--- a/apis/config/v1beta2/defaults_test.go
+++ b/apis/config/v1beta2/defaults_test.go
@@ -41,6 +41,7 @@ func TestSchedulingDefaults(t *testing.T) {
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
 				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(20),
+				PodGroupBackoffSeconds:        pointer.Int64Ptr(0),
 			},
 		},
 		{
@@ -48,10 +49,12 @@ func TestSchedulingDefaults(t *testing.T) {
 			config: &CoschedulingArgs{
 				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
 				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PodGroupBackoffSeconds:        pointer.Int64Ptr(20),
 			},
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds:      pointer.Int64Ptr(60),
 				DeniedPGExpirationTimeSeconds: pointer.Int64Ptr(10),
+				PodGroupBackoffSeconds:        pointer.Int64Ptr(20),
 			},
 		},
 		{

--- a/apis/config/v1beta2/types.go
+++ b/apis/config/v1beta2/types.go
@@ -30,6 +30,8 @@ type CoschedulingArgs struct {
 
 	// PermitWaitingTimeSeconds is the waiting timeout in seconds.
 	PermitWaitingTimeSeconds *int64 `json:"permitWaitingTimeSeconds,omitempty"`
+	// PodGroupBackoffSeconds is the backoff time in seconds before a pod group can be scheduled again.
+	PodGroupBackoffSeconds *int64 `json:"podGroupBackoffSeconds,omitempty"`
 	// DeniedPGExpirationTimeSeconds is the expiration time of the denied podgroup store.
 	DeniedPGExpirationTimeSeconds *int64 `json:"deniedPGExpirationTimeSeconds,omitempty"`
 }

--- a/apis/config/v1beta2/zz_generated.conversion.go
+++ b/apis/config/v1beta2/zz_generated.conversion.go
@@ -127,12 +127,18 @@ func autoConvert_v1beta2_CoschedulingArgs_To_config_CoschedulingArgs(in *Cosched
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_int64_To_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
+		return err
+	}
 	// WARNING: in.DeniedPGExpirationTimeSeconds requires manual conversion: does not exist in peer-type
 	return nil
 }
 
 func autoConvert_config_CoschedulingArgs_To_v1beta2_CoschedulingArgs(in *config.CoschedulingArgs, out *CoschedulingArgs, s conversion.Scope) error {
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_int64_To_Pointer_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
 		return err
 	}
 	return nil

--- a/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -36,6 +36,11 @@ func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodGroupBackoffSeconds != nil {
+		in, out := &in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.DeniedPGExpirationTimeSeconds != nil {
 		in, out := &in.DeniedPGExpirationTimeSeconds, &out.DeniedPGExpirationTimeSeconds
 		*out = new(int64)

--- a/apis/config/v1beta3/defaults.go
+++ b/apis/config/v1beta3/defaults.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta3
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,9 +28,9 @@ import (
 )
 
 var (
-	defaultPermitWaitingTimeSeconds int64 = 60
-
-	defaultNodeResourcesAllocatableMode = Least
+	defaultPermitWaitingTimeSeconds     int64 = 60
+	defaultPodGroupBackoffSeconds       int64 = 0
+	defaultNodeResourcesAllocatableMode       = Least
 
 	// defaultResourcesToWeightMap is used to set the default resourceToWeight map for CPU and memory
 	// used by the NodeResourcesAllocatable scoring plugin.
@@ -82,6 +83,9 @@ var (
 func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	if obj.PermitWaitingTimeSeconds == nil {
 		obj.PermitWaitingTimeSeconds = &defaultPermitWaitingTimeSeconds
+	}
+	if obj.PodGroupBackoffSeconds == nil {
+		obj.PodGroupBackoffSeconds = &defaultPodGroupBackoffSeconds
 	}
 }
 

--- a/apis/config/v1beta3/defaults_test.go
+++ b/apis/config/v1beta3/defaults_test.go
@@ -40,15 +40,18 @@ func TestSchedulingDefaults(t *testing.T) {
 			config: &CoschedulingArgs{},
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
+				PodGroupBackoffSeconds:   pointer.Int64Ptr(0),
 			},
 		},
 		{
 			name: "set non default CoschedulingArgs",
 			config: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
+				PodGroupBackoffSeconds:   pointer.Int64Ptr(20),
 			},
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
+				PodGroupBackoffSeconds:   pointer.Int64Ptr(20),
 			},
 		},
 		{

--- a/apis/config/v1beta3/types.go
+++ b/apis/config/v1beta3/types.go
@@ -30,6 +30,8 @@ type CoschedulingArgs struct {
 
 	// PermitWaitingTimeSeconds is the waiting timeout in seconds.
 	PermitWaitingTimeSeconds *int64 `json:"permitWaitingTimeSeconds,omitempty"`
+	// PodGroupBackoffSeconds is the backoff time in seconds before a pod group can be scheduled again.
+	PodGroupBackoffSeconds *int64 `json:"podGroupBackoffSeconds,omitempty"`
 }
 
 // ModeType is a type "string".

--- a/apis/config/v1beta3/zz_generated.conversion.go
+++ b/apis/config/v1beta3/zz_generated.conversion.go
@@ -157,6 +157,9 @@ func autoConvert_v1beta3_CoschedulingArgs_To_config_CoschedulingArgs(in *Cosched
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_int64_To_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -167,6 +170,9 @@ func Convert_v1beta3_CoschedulingArgs_To_config_CoschedulingArgs(in *Coschedulin
 
 func autoConvert_config_CoschedulingArgs_To_v1beta3_CoschedulingArgs(in *config.CoschedulingArgs, out *CoschedulingArgs, s conversion.Scope) error {
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PermitWaitingTimeSeconds, &out.PermitWaitingTimeSeconds, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_int64_To_Pointer_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
 		return err
 	}
 	return nil

--- a/apis/config/v1beta3/zz_generated.deepcopy.go
+++ b/apis/config/v1beta3/zz_generated.deepcopy.go
@@ -36,6 +36,11 @@ func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodGroupBackoffSeconds != nil {
+		in, out := &in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/coscheduling/core/core_test.go
+++ b/pkg/coscheduling/core/core_test.go
@@ -139,7 +139,7 @@ func TestPreFilter(t *testing.T) {
 			existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
 			snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
 			pgMgr := &PodGroupManager{pgLister: pgLister, permittedPG: newCache(),
-				snapshotSharedLister: snapshot, podLister: podInformer.Lister(), scheduleTimeout: &scheduleTimeout}
+				snapshotSharedLister: snapshot, podLister: podInformer.Lister(), scheduleTimeout: &scheduleTimeout, backedOffPG: gochache.New(10*time.Second, 10*time.Second)}
 			informerFactory.Start(ctx.Done())
 			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
 				t.Fatal("WaitForCacheSync failed")


### PR DESCRIPTION
Adding a backoff in co-scheduling (https://github.com/kubernetes-sigs/scheduler-plugins/issues/429#issuecomment-1254515086) helps to avoid infinite scheduling loop.

```release-note
Add a new coscheduling plugin argument `podGroupBackoffSeconds` to configure backoff timer for failed PodGroup. User needs to explicitly specify a positive integer to enable this feature.
```