### PR TITLE
fix etcd install hint info.

### DIFF
--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is convenience to download and install etcd in third_party.
+# Mostly just used by CI.
+# Usage: `hack/install-etcd.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::etcd::install

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,9 +16,13 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.0}
+ETCD_VERSION=${ETCD_VERSION:-3.5.7}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
+# This is intentionally not called ETCD_LOG_LEVEL:
+# etcd checks that and compains when it is set in addition
+# to the command line argument, even when both have the same value.
+ETCD_LOGLEVEL=${ETCD_LOGLEVEL:-warn}
 export KUBE_INTEGRATION_ETCD_URL="http://${ETCD_HOST}:${ETCD_PORT}"
 
 kube::etcd::validate() {
@@ -29,25 +33,39 @@ kube::etcd::validate() {
     exit 1
   }
 
-  # validate if etcd is running and $ETCD_PORT is in use
-  if ps -ef | grep "etcd " | grep ${ETCD_PORT} &> /dev/null; then
+  # validate etcd port is free
+  local port_check_command
+  if command -v ss &> /dev/null && ss -Version | grep 'iproute2' &> /dev/null; then
+    port_check_command="ss"
+  elif command -v netstat &>/dev/null; then
+    port_check_command="netstat"
+  else
+    kube::log::usage "unable to identify if etcd is bound to port ${ETCD_PORT}. unable to find ss or netstat utilities."
+    exit 1
+  fi
+  if ${port_check_command} -nat | grep "LISTEN" | grep "[\.:]${ETCD_PORT:?}" >/dev/null 2>&1; then
     kube::log::usage "unable to start etcd as port ${ETCD_PORT} is in use. please stop the process listening on this port and retry."
+    kube::log::usage "$(netstat -nat | grep "[\.:]${ETCD_PORT:?} .*LISTEN")"
     exit 1
   fi
 
   # need set the env of "ETCD_UNSUPPORTED_ARCH" on unstable arch.
   arch=$(uname -m)
-  if [[ $arch =~ aarch* ]]; then
-	  export ETCD_UNSUPPORTED_ARCH=arm64
-  elif [[ $arch =~ arm* ]]; then
+  if [[ $arch =~ arm* ]]; then
 	  export ETCD_UNSUPPORTED_ARCH=arm
   fi
   # validate installed version is at least equal to minimum
   version=$(etcd --version | grep Version | head -n 1 | cut -d " " -f 3)
   if [[ $(kube::etcd::version "${ETCD_VERSION}") -gt $(kube::etcd::version "${version}") ]]; then
+   export PATH=${KUBE_ROOT}/third_party/etcd:${PATH}
+   hash etcd
+   echo "${PATH}"
+   version=$(etcd --version | grep Version | head -n 1 | cut -d " " -f 3)
+   if [[ $(kube::etcd::version "${ETCD_VERSION}") -gt $(kube::etcd::version "${version}") ]]; then
     kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
-    kube::log::info "You can use 'hack/install-etcd.sh' to install."
+    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
     exit 1
+   fi
   fi
 }
 
@@ -66,8 +84,8 @@ kube::etcd::start() {
   else
     ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
   fi
-  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=debug > \"${ETCD_LOGFILE}\" 2>/dev/null"
-  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level=debug 2> "${ETCD_LOGFILE}" >/dev/null &
+  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=${ETCD_LOGLEVEL} 2> \"${ETCD_LOGFILE}\" >/dev/null"
+  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level="${ETCD_LOGLEVEL}" 2> "${ETCD_LOGFILE}" >/dev/null &
   ETCD_PID=$!
 
   echo "Waiting for etcd to come up."
@@ -75,7 +93,39 @@ kube::etcd::start() {
   curl -fs -X POST "${KUBE_INTEGRATION_ETCD_URL}/v3/kv/put" -d '{"key": "X3Rlc3Q=", "value": ""}'
 }
 
+kube::etcd::start_scraping() {
+  if [[ -d "${ARTIFACTS:-}" ]]; then
+    ETCD_SCRAPE_DIR="${ARTIFACTS}/etcd-scrapes"
+  else
+    ETCD_SCRAPE_DIR=$(mktemp -d -t test.XXXXXX)/etcd-scrapes
+  fi
+  kube::log::info "Periodically scraping etcd to ${ETCD_SCRAPE_DIR} ."
+  mkdir -p "${ETCD_SCRAPE_DIR}"
+  (
+    while sleep 30; do
+      kube::etcd::scrape
+    done
+  ) &
+  ETCD_SCRAPE_PID=$!
+}
+
+kube::etcd::scrape() {
+    curl -s -S "${KUBE_INTEGRATION_ETCD_URL}/metrics" > "${ETCD_SCRAPE_DIR}/next" && mv "${ETCD_SCRAPE_DIR}/next" "${ETCD_SCRAPE_DIR}/$(date +%s).scrape"
+}
+
+
 kube::etcd::stop() {
+  if [[ -n "${ETCD_SCRAPE_PID:-}" ]] && [[ -n "${ETCD_SCRAPE_DIR:-}" ]] ; then
+    kill "${ETCD_SCRAPE_PID}" &>/dev/null || :
+    wait "${ETCD_SCRAPE_PID}" &>/dev/null || :
+    kube::etcd::scrape || :
+    (
+      # shellcheck disable=SC2015
+      cd "${ETCD_SCRAPE_DIR}"/.. && \
+      tar czf etcd-scrapes.tgz etcd-scrapes && \
+      rm -rf etcd-scrapes || :
+    )
+  fi
   if [[ -n "${ETCD_PID-}" ]]; then
     kill "${ETCD_PID}" &>/dev/null || :
     wait "${ETCD_PID}" &>/dev/null || :
@@ -100,7 +150,8 @@ kube::etcd::install() {
 
     os=$(kube::util::host_os)
     arch=$(kube::util::host_arch)
-
+    mkdir -p ${KUBE_ROOT}/third_party
+    cd "${KUBE_ROOT}/third_party" || return 1
     if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
       kube::log::info "etcd v${ETCD_VERSION} already installed. To use:"
       kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""
@@ -108,19 +159,21 @@ kube::etcd::install() {
     fi
 
     if [[ ${os} == "darwin" ]]; then
-      download_file="etcd-v${ETCD_VERSION}-darwin-amd64.zip"
-      url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
+      download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.zip"
+      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
       kube::util::download_file "${url}" "${download_file}"
       unzip -o "${download_file}"
-      ln -fns "etcd-v${ETCD_VERSION}-darwin-amd64" etcd
+      ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
       rm "${download_file}"
-    else
-      url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-${arch}.tar.gz"
-      download_file="etcd-v${ETCD_VERSION}-linux-${arch}.tar.gz"
+    elif [[ ${os} == "linux" ]]; then
+      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
+      download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
       kube::util::download_file "${url}" "${download_file}"
       tar xzf "${download_file}"
-      ln -fns "etcd-v${ETCD_VERSION}-linux-${arch}" etcd
+      ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
       rm "${download_file}"
+    else
+      kube::log::info "${os} is NOT supported."
     fi
     kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
     kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
```hack/install-etcd.sh``` have not found anywhere. Rebase it to the new install function ```hack/lib/etcd.sh kube::etcd::install```.

#### Which issue(s) this PR fixes:
Fixes #

```release-note

```
