### PR TITLE
chart: fix service account name

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: scheduler-plugins-controller
     spec:
-      serviceAccountName: scheduler-plugins-controller
+      serviceAccountName: {{ .Values.controller.name }}
       containers:
       - name: scheduler-plugins-controller
         image: {{ .Values.controller.image }}
@@ -38,7 +38,7 @@ spec:
       labels:
         component: scheduler
     spec:
-      serviceAccountName: scheduler-plugins-scheduler
+      serviceAccountName: {{ .Values.scheduler.name }}
       containers:
       - command:
         - /bin/kube-scheduler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

The scheduler name, and subsequently the scheduler service account name can be configured by a value, but the deployment still referenced a hardcoded service account name. This resulted in the deployment failing whenever the scheduler name was overridden.

https://github.com/kubernetes-sigs/scheduler-plugins/blob/ac60529f9d8f8d444c952352876571d5b99d49d5/manifests/install/charts/as-a-second-scheduler/templates/serviceaccount.yaml#L4

https://github.com/kubernetes-sigs/scheduler-plugins/blob/ac60529f9d8f8d444c952352876571d5b99d49d5/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml#L41

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
