### PR TITLE
nrt: overreserve: minimize the pod listings

### DIFF
--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -31,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
 )
 
@@ -655,39 +653,6 @@ func dumpNRT(nrtObj *topologyv1alpha2.NodeResourceTopology) string {
 		return "marshallingError"
 	}
 	return string(nrtJson)
-}
-
-type fakePodLister struct {
-	pods []*corev1.Pod
-	err  error
-}
-
-type fakePodNamespaceLister struct {
-	parent    *fakePodLister
-	namespace string
-}
-
-func (fpl *fakePodLister) AddPod(pod *corev1.Pod) {
-	fpl.pods = append(fpl.pods, pod)
-}
-
-func (fpl *fakePodLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
-	return fpl.pods, fpl.err
-}
-
-func (fpl *fakePodLister) Pods(namespace string) podlisterv1.PodNamespaceLister {
-	return &fakePodNamespaceLister{
-		parent:    fpl,
-		namespace: namespace,
-	}
-}
-
-func (fpnl *fakePodNamespaceLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
-	return nil, fmt.Errorf("not yet implemented")
-}
-
-func (fpnl *fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
-	return nil, fmt.Errorf("not yet implemented")
 }
 
 func MakeTopologyResInfo(name, capacity, available string) topologyv1alpha2.ResourceInfo {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
In https://github.com/kubernetes-sigs/scheduler-plugins/pull/557 we replaced the custom indexer implementation with the simpler lister implementation.
The relisting works, but does unnecessary work relisting for each node which is processed, which is wasteful: even though client-go is optimized, let's avoid useless work, because we can relist the pods once per resync attempt.

#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
