### PR TITLE
Automated cherry pick of #604: Documents update for release v0.26.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ changed.
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch           |
 |-------------------|---------------------------|-----------------------------------------------------------|----------------|
+| v0.26.7           | v1.26.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7  | AMD64<br>ARM64 |
 | v0.25.7           | v1.25.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7  | AMD64<br>ARM64 |
 | v0.24.9           | v1.24.9                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9  | AMD64<br>ARM64 |
 | v0.23.10          | v1.23.10                  | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.23.10 | AMD64<br>ARM64 |
@@ -71,6 +72,7 @@ changed.
 
 | Controller | Compiled With k8s Version | Container Image                                       | Arch           |
 |------------|---------------------------|-------------------------------------------------------|----------------|
+| v0.26.7    | v1.26.7                   | registry.k8s.io/scheduler-plugins/controller:v0.26.7  | AMD64<br>ARM64 |
 | v0.25.7    | v1.25.7                   | registry.k8s.io/scheduler-plugins/controller:v0.25.7  | AMD64<br>ARM64 |
 | v0.24.9    | v1.24.9                   | registry.k8s.io/scheduler-plugins/controller:v0.24.9  | AMD64<br>ARM64 |
 | v0.23.10   | v1.23.10                  | registry.k8s.io/scheduler-plugins/controller:v0.23.10 | AMD64<br>ARM64 |

--- a/doc/install.md
+++ b/doc/install.md
@@ -4,7 +4,7 @@
 
 <!-- toc -->
 - [Create a Kubernetes Cluster](#create-a-kubernetes-cluster)
-- [Install release v0.25.7 and use Coscheduling](#install-release-v0257-and-use-coscheduling)
+- [Install release v0.26.7 and use Coscheduling](#install-release-v0267-and-use-coscheduling)
   - [As a second scheduler](#as-a-second-scheduler)
   - [As a single scheduler (replacing the vanilla default-scheduler)](#as-a-single-scheduler-replacing-the-vanilla-default-scheduler)
 - [Test Coscheduling](#test-coscheduling)
@@ -24,7 +24,7 @@ If you do not have a cluster yet, create one by using one of the following provi
 * [kubeadm](https://kubernetes.io/docs/admin/kubeadm/)
 * [minikube](https://minikube.sigs.k8s.io/)
 
-## Install release v0.25.7 and use Coscheduling
+## Install release v0.26.7 and use Coscheduling
 
 Note: we provide two ways to install the scheduler-plugin artifacts: as a second scheduler
 and as a single scheduler. Their pros and cons are as below:
@@ -80,7 +80,7 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
 1. Create `/etc/kubernetes/sched-cc.yaml`
 
     ```yaml
-    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
       # (Optional) Change true to false if you are not running a HA control-plane.
@@ -146,9 +146,9 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     >     - --kubeconfig=/etc/kubernetes/scheduler.conf
     >     - --leader-elect=true
     19,20c20
-    <     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
+    <     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7
     ---
-    >     image: registry.k8s.io/kube-scheduler:v1.25.7
+    >     image: registry.k8s.io/kube-scheduler:v1.26.7
     50,52d49
     <     - mountPath: /etc/kubernetes/sched-cc.yaml
     <       name: sched-cc
@@ -160,14 +160,14 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     <     name: sched-cc
     ```
    
-1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7`
+1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7`
 
     ```bash
     $ kubectl get pod -n kube-system | grep kube-scheduler
     kube-scheduler-kind-control-plane            1/1     Running   0          3m27s
  
     $ kubectl get pods -l component=kube-scheduler -n kube-system -o=jsonpath="{.items[0].spec.containers[0].image}{'\n'}"
-    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
+    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7
     ```
    
     > **⚠️Troubleshooting:** If the kube-scheudler is not up, you may need to restart kubelet service inside the kind control plane (`systemctl restart kubelet.service`)

--- a/manifests/appgroup/deploy-sig-scheduling-controller-and-scheduler.yaml
+++ b/manifests/appgroup/deploy-sig-scheduling-controller-and-scheduler.yaml
@@ -89,7 +89,7 @@ spec:
       serviceAccountName: scheduler-plugins-controller
       containers:
         - name: scheduler-plugins-controller
-          image: registry.k8s.io/scheduler-plugins/controller:v0.25.7
+          image: registry.k8s.io/scheduler-plugins/controller:v0.26.7
           imagePullPolicy: IfNotPresent
 ---
 # Install the scheduler
@@ -113,7 +113,7 @@ spec:
       nodeSelector: # To deploy in master node
         node-role.kubernetes.io/master: ""
       containers:
-        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
+        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7
           command: # For extra info, please add verbose level: e.g., - -v=9
             - /bin/kube-scheduler
             - --authentication-kubeconfig=/etc/kubernetes/scheduler.conf

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -90,5 +90,5 @@ spec:
       serviceAccountName: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
-        image: registry.k8s.io/scheduler-plugins/controller:v0.25.7
+        image: registry.k8s.io/scheduler-plugins/controller:v0.26.7
         imagePullPolicy: IfNotPresent

--- a/manifests/install/charts/as-a-second-scheduler/Chart.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.7
+version: 0.26.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.25.7
+appVersion: 0.26.7

--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -45,11 +45,11 @@ The following table lists the configurable parameters of the as-a-second-schedul
 | Parameter                 | Description                 | Default                                                                                         |
 |---------------------------|-----------------------------|-------------------------------------------------------------------------------------------------|
 | `scheduler.name`          | Scheduler name              | `scheduler-plugins-scheduler`                                                                   |
-| `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7`                                      |
+| `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7`                                      |
 | `scheduler.leaderElect`   | Scheduler leaderElection    | `false`                                                                                         |
 | `scheduler.replicaCount`  | Scheduler replicaCount      | `1`                                                                                             |
 | `controller.name`         | Controller name             | `scheduler-plugins-controller`                                                                  |
-| `controller.image`        | Controller image            | `registry.k8s.io/scheduler-plugins/controller:v0.25.7`                                          |
+| `controller.image`        | Controller image            | `registry.k8s.io/scheduler-plugins/controller:v0.26.7`                                          |
 | `controller.replicaCount` | Controller replicaCount     | `1`                                                                                             |
 | `plugins.enabled`         | Plugins enabled by default  | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
 | `plugins.disabled`        | Plugins disabled by default | `["PrioritySort"]`                                                                              |

--- a/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   scheduler-config.yaml: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: {{ .Values.scheduler.leaderElect }}

--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -66,7 +66,7 @@ rules:
 - apiGroups: ["scheduling.x-k8s.io"]
   resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
-# for network-aware plugins add the following lines (scheduler-plugins v.0.25.7)
+# for network-aware plugins add the following lines (scheduler-plugins v0.26.7)
 #- apiGroups: [ "appgroup.diktyo.x-k8s.io" ]
 #  resources: [ "appgroups" ]
 #  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -4,13 +4,13 @@
 
 scheduler:
   name: scheduler-plugins-scheduler
-  image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
+  image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7
   replicaCount: 1
   leaderElect: false
 
 controller:
   name: scheduler-plugins-controller
-  image: registry.k8s.io/scheduler-plugins/controller:v0.25.7
+  image: registry.k8s.io/scheduler-plugins/controller:v0.26.7
   replicaCount: 1
 
 # LoadVariationRiskBalancing and TargetLoadPacking are not enabled by default

--- a/manifests/networktopology/deploy-sig-scheduling-controller-and-scheduler.yaml
+++ b/manifests/networktopology/deploy-sig-scheduling-controller-and-scheduler.yaml
@@ -89,7 +89,7 @@ spec:
       serviceAccountName: scheduler-plugins-controller
       containers:
         - name: scheduler-plugins-controller
-          image: registry.k8s.io/scheduler-plugins/controller:v0.25.7
+          image: registry.k8s.io/scheduler-plugins/controller:v0.26.7
           imagePullPolicy: IfNotPresent
 ---
 # Install the scheduler
@@ -113,7 +113,7 @@ spec:
       nodeSelector: # To deploy in master node
         node-role.kubernetes.io/master: ""
       containers:
-        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.25.7
+        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.26.7
           command: # For extra info, please add verbose level: e.g., - -v=9
             - /bin/kube-scheduler
             - --authentication-kubeconfig=/etc/kubernetes/scheduler.conf

--- a/pkg/networkaware/README.md
+++ b/pkg/networkaware/README.md
@@ -29,7 +29,7 @@ Further details and examples are described [here](../networkaware/networkoverhea
 Consider the following scheduler config as an example to enable both plugins:
 
 ```yaml
-apiVersion: kubescheduler.config.k8s.io/v1beta3
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false


### PR DESCRIPTION
Cherry pick of #604 on release-1.26.

#604: Documents update for release v0.26.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```