### PR TITLE
Kubelet configuration change without immediate cache updates

### DIFF
--- a/pkg/noderesourcetopology/cache/store.go
+++ b/pkg/noderesourcetopology/cache/store.go
@@ -76,6 +76,13 @@ func (nrs *nrtStore) Update(nrt *topologyv1alpha2.NodeResourceTopology) {
 	klog.V(5).InfoS("nrtcache: updated cached NodeTopology", "node", nrt.Name)
 }
 
+// UpdateAttributesAndTopologyPolicies adds or replace the Node Resource Topology attributes associated to a node. Always do a copy.
+func (nrs *nrtStore) UpdateAttributesAndTopologyPolicies(nrt *topologyv1alpha2.NodeResourceTopology) {
+	nrs.data[nrt.Name].Attributes = nrt.Attributes.DeepCopy()
+	nrs.data[nrt.Name].TopologyPolicies = nrt.TopologyPolicies
+	klog.V(5).InfoS("nrtcache: updated cached NodeTopology Attributes And TopologyPolicies", "node", nrt.Name)
+}
+
 // resourceStore maps the resource requested by pod by pod namespaed name. It is not thread safe and needs to be protected by a lock.
 type resourceStore struct {
 	// key: namespace + "/" name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When obtaining cached NRT data in the filter and score stages, compare the topologyPolicies in the NRT cache with the topologyPolicies of the real-time NRT resources in the environment. If there are differences, update the topologyPolicies in the cache to the latest value. This can obtain the latest topologyPolicies and avoid entering incorrect functions for operations


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #621

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
"NONE" 
```release-note

```
