### PR TITLE
Find correct cost associated with given NUMA node ID

### DIFF
--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -137,10 +137,10 @@ func nodesAvgDistance(numaNodes NUMANodeList, nodes ...int) float32 {
 
 	for _, node1 := range nodes {
 		for _, node2 := range nodes {
-			cost, ok := numaNodes[node1].Costs[node2]
+			cost, ok := numaNodes[node1].Costs[numaNodes[node2].NUMAID]
 			// we couldn't read Costs assign maxDistanceValue
 			if !ok {
-				klog.Warningf("cannot retrieve Costs information for node %d", node2)
+				klog.Warningf("cannot retrieve Costs information for node ID %d", numaNodes[node1].NUMAID)
 				cost = maxDistanceValue
 			}
 			accu += cost
@@ -176,7 +176,9 @@ func numaNodesRequired(identifier string, qos v1.PodQOSClass, numaNodes NUMANode
 		// we have found suitable combination for given bitmaskLen
 		if suitableCombination != nil {
 			bm := bitmask.NewEmptyBitMask()
-			bm.Add(suitableCombination...)
+			for _, nodeIdx := range suitableCombination {
+				bm.Add(numaNodes[nodeIdx].NUMAID)
+			}
 			return bm, isMinDistance
 		}
 	}

--- a/pkg/noderesourcetopology/least_numa_test.go
+++ b/pkg/noderesourcetopology/least_numa_test.go
@@ -271,6 +271,248 @@ func TestNUMANodesRequired(t *testing.T) {
 			expectedErr:         nil,
 			expectedMinDistance: false,
 		},
+		{
+			description: "8 NUMA node optimal distance, not sorted ids",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10, 1: 20, 2: 40, 3: 30, 4: 20, 5: 30, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 3,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 40, 2: 20, 3: 10, 4: 30, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 5,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 20, 2: 50, 3: 20, 4: 50, 5: 10, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 7,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 50, 2: 30, 3: 50, 4: 20, 5: 40, 6: 30, 7: 10,
+					},
+				},
+				{
+					NUMAID: 1,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 10, 2: 30, 3: 40, 4: 50, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 50, 1: 40, 2: 20, 3: 40, 4: 30, 5: 50, 6: 10, 7: 30,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 30, 2: 10, 3: 20, 4: 40, 5: 50, 6: 20, 7: 30,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 50, 2: 40, 3: 30, 4: 10, 5: 50, 6: 30, 7: 20,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("3"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 1, 5),
+			expectedErr:         nil,
+			expectedMinDistance: true,
+		},
+		{
+			description: "4 NUMA node optimal distance, non sequential ids",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10,
+						2: 12,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 12,
+						2: 10,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 10,
+						6: 12,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 12,
+						6: 10,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("2"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 2),
+			expectedErr:         nil,
+			expectedMinDistance: true,
+		},
+		{
+			description: "4 NUMA node non optimal distance, non sequential ids",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10,
+						2: 12,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 12,
+						2: 10,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 10,
+						6: 12,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 12,
+						6: 10,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("2"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 6),
+			expectedErr:         nil,
+			expectedMinDistance: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR intends to supersedes https://github.com/kubernetes-sigs/scheduler-plugins/pull/615. 
I have incorporated test case from @283713406 (Thanks for that!) and also added test case to make sure we calculated proper bitmask when NUMA node ids are not sequential to make sure we are not propagating this issue https://github.com/kubernetes/kubernetes/issues/113781

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #614 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix incorrect score calculation for NodeResourceTopology LeastNUMANodes scoring strategy when NUMA nodes ids are not sorted.
```
