### PR TITLE
Find correct combination with given NUMA node ID

### DIFF
--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -197,6 +197,9 @@ func findSuitableCombination(identifier string, qos v1.PodQOSClass, numaNodes NU
 		minDistance float32 = 256
 	)
 	for _, combination := range numaNodesCombination {
+		if isInvalidCombineResources(numaNodes, resources, combination) {
+			continue
+		}
 		combinationResources := combineResources(numaNodes, combination)
 		resourcesFit := checkResourcesFit(identifier, qos, resources, combinationResources)
 
@@ -229,4 +232,15 @@ func checkResourcesFit(identifier string, qos v1.PodQOSClass, resources v1.Resou
 	}
 
 	return true
+}
+
+func isInvalidCombineResources(numaNodes NUMANodeList, resources v1.ResourceList, combination []int) bool {
+	for _, nodeIndex := range combination {
+		for resourceName := range resources {
+			if _, ok := numaNodes[nodeIndex].Resources[resourceName]; !ok {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -197,7 +197,7 @@ func findSuitableCombination(identifier string, qos v1.PodQOSClass, numaNodes NU
 		minDistance float32 = 256
 	)
 	for _, combination := range numaNodesCombination {
-		if isInvalidCombineResources(numaNodes, resources, combination) {
+		if !isValidCombineResources(numaNodes, resources, combination) {
 			continue
 		}
 		combinationResources := combineResources(numaNodes, combination)
@@ -234,13 +234,13 @@ func checkResourcesFit(identifier string, qos v1.PodQOSClass, resources v1.Resou
 	return true
 }
 
-func isInvalidCombineResources(numaNodes NUMANodeList, resources v1.ResourceList, combination []int) bool {
+func isValidCombineResources(numaNodes NUMANodeList, resources v1.ResourceList, combination []int) bool {
 	for _, nodeIndex := range combination {
 		for resourceName := range resources {
 			if _, ok := numaNodes[nodeIndex].Resources[resourceName]; !ok {
-				return true
+				return false
 			}
 		}
 	}
-	return false
+	return true
 }

--- a/pkg/noderesourcetopology/least_numa_test.go
+++ b/pkg/noderesourcetopology/least_numa_test.go
@@ -374,6 +374,104 @@ func TestNUMANodesRequired(t *testing.T) {
 			expectedMinDistance: true,
 		},
 		{
+			description: "8 NUMA node non optimal distance, not sorted ids, odd digit NUMA node without memory",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10, 1: 20, 2: 40, 3: 30, 4: 20, 5: 30, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 3,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 40, 2: 20, 3: 10, 4: 30, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 5,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 20, 2: 50, 3: 20, 4: 50, 5: 10, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 7,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 50, 2: 30, 3: 50, 4: 20, 5: 40, 6: 30, 7: 10,
+					},
+				},
+				{
+					NUMAID: 1,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 10, 2: 30, 3: 40, 4: 50, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 50, 1: 40, 2: 20, 3: 40, 4: 30, 5: 50, 6: 10, 7: 30,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 30, 2: 10, 3: 20, 4: 40, 5: 50, 6: 20, 7: 30,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 50, 2: 40, 3: 30, 4: 10, 5: 50, 6: 30, 7: 20,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("3"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(2, 4, 6),
+			expectedErr:         nil,
+			expectedMinDistance: false,
+		},
+		{
 			description: "4 NUMA node optimal distance, non sequential ids",
 			numaNodes: NUMANodeList{
 				{
@@ -510,6 +608,74 @@ func TestNUMANodesRequired(t *testing.T) {
 			},
 			node:                node,
 			expectedBitmask:     NewTestBitmask(0, 6),
+			expectedErr:         nil,
+			expectedMinDistance: false,
+		},
+		{
+			description: "4 NUMA node non optimal distance, non sequential ids, NUMA node-2 and node-6 without memory",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10,
+						2: 12,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 12,
+						2: 10,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 10,
+						6: 12,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 12,
+						6: 10,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("2"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 4),
 			expectedErr:         nil,
 			expectedMinDistance: false,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

This PR solves the issue #626 

Excluding combinations containing NUMA nodes without memory modules

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #626

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note
Fix findSuitableCombination calculation logic for selecting a combination when it contains NUMA nodes without memory modules
```
