### PR TITLE
nrt: fix handling of ephemeral-storage requests

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -131,7 +131,9 @@ func resourcesAvailableInAnyNUMANodes(logID string, numaNodes NUMANodeList, reso
 			klog.V(6).InfoS("feasible", "logID", logID, "node", nodeName, "NUMA", numaNode.NUMAID, "resource", resource)
 		}
 
-		if !hasNUMAAffinity && !v1helper.IsNativeResource(resource) {
+		// non-native resources or ephemeral-storage may not expose NUMA affinity,
+		// but since they are available at node level, this is fine
+		if !hasNUMAAffinity && (!v1helper.IsNativeResource(resource) || resource == v1.ResourceEphemeralStorage) {
 			klog.V(6).InfoS("resource available at node level (no NUMA affinity)", "logID", logID, "node", nodeName, "resource", resource)
 			continue
 		}

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -661,6 +661,16 @@ func TestNodeResourceTopology(t *testing.T) {
 			node:       nodes[1],
 			wantStatus: nil,
 		},
+		{
+			name: "Guaranteed QoS, ephemeral-storage (non-NUMA), pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:              *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory:           resource.MustParse("2Gi"),
+				v1.ResourceEphemeralStorage: resource.MustParse("100Mi"),
+			}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
 	}
 
 	fakeClient := faketopologyv1alpha2.NewSimpleClientset()


### PR DESCRIPTION
Add ephemeral-storage to the special-case handling for resources which
lack NUMA affinity.

Signed-off-by: Phil Sphicas <philsphicas@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix filter handling of ephemeral-storage requests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #645

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
