### PR TITLE
refactor coscheduling to use controller-runtime client

### DIFF
--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -147,7 +147,7 @@ func (cs *Coscheduling) PreFilter(ctx context.Context, state *framework.CycleSta
 // PostFilter is used to reject a group of pods if a pod does not pass PreFilter or Filter.
 func (cs *Coscheduling) PostFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod,
 	filteredNodeStatusMap framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
-	pgName, pg := cs.pgMgr.GetPodGroup(pod)
+	pgName, pg := cs.pgMgr.GetPodGroup(ctx, pod)
 	if pg == nil {
 		klog.V(4).InfoS("Pod does not belong to any group", "pod", klog.KObj(pod))
 		return &framework.PostFilterResult{}, framework.NewStatus(framework.Unschedulable, "can not find pod group")
@@ -209,7 +209,7 @@ func (cs *Coscheduling) Permit(ctx context.Context, state *framework.CycleState,
 		return framework.NewStatus(framework.Unschedulable, "PodGroup not found"), 0
 	case core.Wait:
 		klog.InfoS("Pod is waiting to be scheduled to node", "pod", klog.KObj(pod), "nodeName", nodeName)
-		_, pg := cs.pgMgr.GetPodGroup(pod)
+		_, pg := cs.pgMgr.GetPodGroup(ctx, pod)
 		if wait := util.GetWaitTimeDuration(pg, cs.scheduleTimeout); wait != 0 {
 			waitTime = wait
 		}
@@ -239,7 +239,7 @@ func (cs *Coscheduling) Reserve(ctx context.Context, state *framework.CycleState
 
 // Unreserve rejects all other Pods in the PodGroup when one of the pods in the group times out.
 func (cs *Coscheduling) Unreserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
-	pgName, pg := cs.pgMgr.GetPodGroup(pod)
+	pgName, pg := cs.pgMgr.GetPodGroup(ctx, pod)
 	if pg == nil {
 		return
 	}

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -24,17 +24,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
+	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/scheduler-plugins/apis/config"
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling"
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling/core"
-	pgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"
-	pgformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
@@ -66,16 +65,23 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 		return nil, fmt.Errorf("want args to be of type CoschedulingArgs, got %T", obj)
 	}
 
-	pgClient := pgclientset.NewForConfigOrDie(handle.KubeConfig())
-	pgInformerFactory := pgformers.NewSharedInformerFactory(pgClient, 0)
-	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
-	podInformer := handle.SharedInformerFactory().Core().V1().Pods()
+	scheme := runtime.NewScheme()
+	_ = clientscheme.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	client, err := client.New(handle.KubeConfig(), client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
 
 	scheduleTimeDuration := time.Duration(args.PermitWaitingTimeSeconds) * time.Second
-
-	ctx := context.TODO()
-
-	pgMgr := core.NewPodGroupManager(pgClient, handle.SnapshotSharedLister(), &scheduleTimeDuration, pgInformer, podInformer)
+	pgMgr := core.NewPodGroupManager(
+		client,
+		handle.SnapshotSharedLister(),
+		&scheduleTimeDuration,
+		// Keep the podInformer (from frameworkHandle) as the single source of Pods.
+		handle.SharedInformerFactory().Core().V1().Pods(),
+	)
 	plugin := &Coscheduling{
 		frameworkHandler: handle,
 		pgMgr:            pgMgr,
@@ -88,12 +94,6 @@ func New(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) 
 	} else if args.PodGroupBackoffSeconds > 0 {
 		pgBackoff := time.Duration(args.PodGroupBackoffSeconds) * time.Second
 		plugin.pgBackoff = &pgBackoff
-	}
-	pgInformerFactory.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), pgInformer.Informer().HasSynced) {
-		err := fmt.Errorf("WaitForCacheSync failed")
-		klog.ErrorS(err, "Cannot sync caches")
-		return nil, err
 	}
 	return plugin, nil
 }

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -20,81 +20,117 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/events"
+	clicache "k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
-	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	fwkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/utils/pointer"
 
 	_ "sigs.k8s.io/scheduler-plugins/apis/config/scheme"
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling/core"
-	fakepgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/fake"
-	pgformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
-	testutil "sigs.k8s.io/scheduler-plugins/test/util"
+	tu "sigs.k8s.io/scheduler-plugins/test/util"
 )
 
 func TestPodGroupBackoffTime(t *testing.T) {
+	scheduleDuration := 10 * time.Second
+	capacity := map[v1.ResourceName]string{
+		v1.ResourceCPU: "4",
+	}
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node").Capacity(capacity).Obj(),
+	}
+
 	tests := []struct {
-		name string
-		pod1 *v1.Pod
-		pod2 *v1.Pod
-		pod3 *v1.Pod
+		name              string
+		pods              []*v1.Pod
+		pgs               []*v1alpha1.PodGroup
+		wantActivatedPods []string
+		want              framework.Code
 	}{
 		{
-			name: "pod in infinite scheduling loop.",
-			pod1: st.MakePod().Name("pod1").UID("pod1").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
-			pod2: st.MakePod().Name("pod2").UID("pod2").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
-			pod3: st.MakePod().Name("pod3").UID("pod3").Namespace("ns1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			name: "prevent pod falling into infinite scheduling loop",
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod1").UID("pod1").Namespace("ns").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pod2").UID("pod2").Namespace("ns").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("pod3").UID("pod3").Namespace("ns").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(3).Obj(),
+			},
+			wantActivatedPods: []string{"ns/pod2", "ns/pod3"},
+			want:              framework.UnschedulableAndUnresolvable,
 		},
 	}
-	ctx := context.Background()
-	cs := fakepgclientset.NewSimpleClientset()
-	pgInformerFactory := pgformers.NewSharedInformerFactory(cs, 0)
-	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
-	pgInformerFactory.Start(ctx.Done())
-	pg1 := testutil.MakePG("pg1", "ns1", 3, nil, nil)
-	pgInformer.Informer().GetStore().Add(pg1)
 
-	fakeClient := clientsetfake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
-	podInformer := informerFactory.Core().V1().Pods()
-	informerFactory.Start(ctx.Done())
-	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
-	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
-	// Compose a framework handle.
-	registeredPlugins := []st.RegisterPluginFunc{
-		st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-	}
-	f, err := st.NewFramework(registeredPlugins, "", ctx.Done(),
-		frameworkruntime.WithClientSet(fakeClient),
-		frameworkruntime.WithEventRecorder(&events.FakeRecorder{}),
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	scheduleDuration := 10 * time.Second
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			podInformer.Informer().GetStore().Add(tt.pod1)
-			podInformer.Informer().GetStore().Add(tt.pod2)
-			podInformer.Informer().GetStore().Add(tt.pod3)
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheduleDuration, pgInformer, podInformer)
-			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheduleDuration, pgBackoff: pointer.Duration(time.Duration(1 * time.Second))}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Compile all objects into `objs`.
+			var objs []runtime.Object
+			for _, pod := range tt.pods {
+				objs = append(objs, pod)
+			}
+			for _, pg := range tt.pgs {
+				objs = append(objs, pg)
+			}
+
+			client, err := tu.NewFakeClient(objs...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Compose a fake framework handle.
+			cs := clientsetfake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			podInformer := informerFactory.Core().V1().Pods()
+			registeredPlugins := []st.RegisterPluginFunc{
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			f, err := st.NewFramework(registeredPlugins, "default-scheduler", ctx.Done(), fwkruntime.WithInformerFactory(informerFactory))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			pgMgr := core.NewPodGroupManager(
+				client,
+				tu.NewFakeSharedLister(tt.pods, nodes),
+				// In this UT, 5 seconds should suffice to test the PreFilter's return code.
+				pointer.Duration(5*time.Second),
+				podInformer,
+			)
+			pl := &Coscheduling{
+				frameworkHandler: f,
+				pgMgr:            pgMgr,
+				scheduleTimeout:  &scheduleDuration,
+				pgBackoff:        pointer.Duration(1 * time.Second),
+			}
+
+			informerFactory.Start(ctx.Done())
+			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
+				t.Fatal("WaitForCacheSync failed")
+			}
+			for _, p := range tt.pods {
+				podInformer.Informer().GetStore().Add(p)
+			}
+
 			state := framework.NewCycleState()
 			state.Write(framework.PodsToActivateKey, framework.NewPodsToActivate())
-			code, _ := coscheduling.Permit(context.Background(), state, tt.pod1, "test")
+			code, _ := pl.Permit(ctx, state, tt.pods[0], "test")
 			if code.Code() != framework.Wait {
 				t.Errorf("expected %v, got %v", framework.Wait, code.Code())
 				return
@@ -110,23 +146,24 @@ func TestPodGroupBackoffTime(t *testing.T) {
 				t.Errorf("cannot convert type %t to *framework.PodsToActivate", podsToActiveObj)
 				return
 			}
-
-			var expectPodsToActivate = map[string]*v1.Pod{
-				"ns1/pod2": tt.pod2, "ns1/pod3": tt.pod3,
+			var got []string
+			for podName := range podsToActive.Map {
+				got = append(got, podName)
 			}
-			if !reflect.DeepEqual(expectPodsToActivate, podsToActive.Map) {
-				t.Errorf("expected %v, got %v", expectPodsToActivate, podsToActive.Map)
+			sort.Strings(got)
+			if diff := cmp.Diff(got, tt.wantActivatedPods); diff != "" {
+				t.Errorf("unexpected activatedPods (-want, +got): %s\n", diff)
 				return
 			}
 
-			coscheduling.PostFilter(context.Background(), framework.NewCycleState(), tt.pod2, nil)
+			pl.PostFilter(ctx, framework.NewCycleState(), tt.pods[1], nil)
 
-			_, code = coscheduling.PreFilter(context.Background(), framework.NewCycleState(), tt.pod3)
-			if code.Code() != framework.UnschedulableAndUnresolvable {
-				t.Errorf("expected %v, got %v", framework.UnschedulableAndUnresolvable, code.Code())
+			_, code = pl.PreFilter(ctx, framework.NewCycleState(), tt.pods[2])
+			if code.Code() != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, code.Code())
 				return
 			}
-			pgFullName, _ := pgMgr.GetPodGroup(tt.pod1)
+			pgFullName, _ := pgMgr.GetPodGroup(tt.pods[0])
 			if code.Reasons()[0] != fmt.Sprintf("podGroup %v failed recently", pgFullName) {
 				t.Errorf("expected %v, got %v", pgFullName, code.Reasons()[0])
 				return
@@ -135,371 +172,462 @@ func TestPodGroupBackoffTime(t *testing.T) {
 	}
 }
 
+func ptrTime(tm time.Time) *time.Time {
+	return &tm
+}
+
 func TestLess(t *testing.T) {
+	lowPriority, highPriority := int32(10), int32(100)
 	now := time.Now()
-	times := make([]time.Time, 0)
-	for _, d := range []time.Duration{0, 1, 2, 3, -2, -1} {
-		times = append(times, now.Add(d*time.Second))
-	}
-	ctx := context.Background()
-	cs := fakepgclientset.NewSimpleClientset()
-	pgInformerFactory := pgformers.NewSharedInformerFactory(cs, 0)
-	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
-	pgInformerFactory.Start(ctx.Done())
-	for _, pgInfo := range []struct {
-		createTime time.Time
-		pgNme      string
-		ns         string
-		minMember  int32
-	}{
-		{
-			createTime: times[2],
-			pgNme:      "pg1",
-			ns:         "namespace1",
-		},
-		{
-			createTime: times[3],
-			pgNme:      "pg2",
-			ns:         "namespace2",
-		},
-		{
-			createTime: times[4],
-			pgNme:      "pg3",
-			ns:         "namespace2",
-		},
-		{
-			createTime: times[5],
-			pgNme:      "pg4",
-			ns:         "namespace2",
-		},
-	} {
-		pg := testutil.MakePG(pgInfo.pgNme, pgInfo.ns, 5, &pgInfo.createTime, nil)
-		pgInformer.Informer().GetStore().Add(pg)
-	}
 
-	fakeClient := clientsetfake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
-	podInformer := informerFactory.Core().V1().Pods()
-	informerFactory.Start(ctx.Done())
-
-	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
-	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
-	scheduleDuration := 10 * time.Second
-	var lowPriority, highPriority = int32(10), int32(100)
-	ns1, ns2 := "namespace1", "namespace2"
-	for _, tt := range []struct {
-		name     string
-		p1       *framework.QueuedPodInfo
-		p2       *framework.QueuedPodInfo
-		expected bool
+	tests := []struct {
+		name string
+		p1   *framework.QueuedPodInfo
+		p2   *framework.QueuedPodInfo
+		pgs  []*v1alpha1.PodGroup
+		want bool
 	}{
 		{
 			name: "p1.priority less than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(lowPriority).Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).Obj()),
 			},
-			expected: false, // p2 should be ahead of p1 in the queue
+			want: false,
 		},
 		{
 			name: "p1.priority greater than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(lowPriority).Obj()),
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			want: true,
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: &times[0],
+				PodInfo:                 tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: &times[1],
+				PodInfo:                 tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 2)),
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			want: true,
 		},
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: &times[1],
+				PodInfo:                 tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 2)),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: &times[0],
+				PodInfo:                 tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
 			},
-			expected: false, // p2 should be ahead of p1 in the queue
+			want: false,
 		},
 		{
-			name: "p1.priority less than p2.priority, p1 belongs to podGroup1",
+			name: "p1.priority less than p2.priority, p1 belongs to pg1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(lowPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).Obj()),
 			},
-			expected: false, // p2 should be ahead of p1 in the queue
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Obj(),
+			},
+			want: false,
 		},
 		{
-			name: "p1.priority greater than p2.priority, p1 belongs to podGroup1",
+			name: "p1.priority greater than p2.priority, p1 belongs to pg1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Obj()),
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(lowPriority).Obj()),
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Obj(),
+			},
+			want: true,
 		},
 		{
-			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to podGroup3",
+			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to pg1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
-				InitialAttemptTimestamp: &times[0],
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: &times[1],
+				PodInfo:                 tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 2)),
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Time(now.Add(time.Second * 1)).Obj(),
+			},
+			want: true,
 		},
 		{
-			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to podGroup3",
+			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to pg1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
-				InitialAttemptTimestamp: &times[1],
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 2)),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: &times[0],
+				PodInfo:                 tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
 			},
-			expected: false, // p2 should be ahead of p1 in the queue
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Time(now.Add(time.Second * 2)).Obj(),
+			},
+			want: false,
 		},
+		{
+			name: "p1.priority less than p2.priority, p1 belongs to pg1 and p2 belongs to pg2",
+			p1: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(lowPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+			},
+			p2: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Time(now.Add(time.Second * 1)).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns2").Time(now.Add(time.Second * 2)).Obj(),
+			},
+			want: false,
+		},
+		{
+			name: "p1.priority greater than p2.priority, p1 belongs to pg1 and and p2 belongs to pg2",
+			p1: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+			},
+			p2: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(lowPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Time(now.Add(time.Second * 1)).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns2").Time(now.Add(time.Second * 2)).Obj(),
+			},
+			want: true,
+		},
+		{
+			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to pg1 and p2 belongs to pg2",
+			p1: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
+			},
+			p2: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 2)),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Time(now.Add(time.Second * 1)).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns2").Time(now.Add(time.Second * 2)).Obj(),
+			},
+			want: true,
+		},
+		{
+			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to pg2 and p2 belongs to pg1",
+			p1: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns").Priority(lowPriority).
+					Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
+			},
+			p2: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 2)),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").Time(now.Add(time.Second * 1)).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns").Time(now.Add(time.Second * 2)).Obj(),
+			},
+			want: false,
+		},
+		{
+			name: "equal priority and creation time, p1 belongs pg1 and p2 belong to pg2",
+			p1: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
+			},
+			p2: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns1").Time(now.Add(time.Second * 1)).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns2").Time(now.Add(time.Second * 2)).Obj(),
+			},
+			want: true,
+		},
+		{
+			name: "equal priority and creation time, and p2 belong to pg2",
+			p1: &framework.QueuedPodInfo{
+				PodInfo:                 tu.MustNewPodInfo(t, st.MakePod().Name("p1").Namespace("ns1").Priority(highPriority).Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
+			},
+			p2: &framework.QueuedPodInfo{
+				PodInfo: tu.MustNewPodInfo(t, st.MakePod().Name("p2").Namespace("ns2").Priority(highPriority).
+					Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				InitialAttemptTimestamp: ptrTime(now.Add(time.Second * 1)),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg2").Namespace("ns2").Time(now.Add(time.Second * 2)).Obj(),
+			},
+			want: true,
+		},
+	}
 
-		{
-			name: "p1.priority less than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
-			p1: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
-			},
-			p2: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
-			},
-			expected: false, // p2 should be ahead of p1 in the queue
-		},
-		{
-			name: "p1.priority greater than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
-			p1: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
-			},
-			p2: &framework.QueuedPodInfo{
-				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
-			},
-			expected: true, // p1 should be ahead of p2 in the queue
-		},
-		{
-			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to podGroup1 and p2 belongs to podGroup2",
-			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
-				InitialAttemptTimestamp: &times[0],
-			},
-			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
-				InitialAttemptTimestamp: &times[1],
-			},
-			expected: true, // p1 should be ahead of p2 in the queue
-		},
-		{
-			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to podGroup4 and p2 belongs to podGroup3",
-			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg4").Obj()),
-				InitialAttemptTimestamp: &times[1],
-			},
-			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
-				InitialAttemptTimestamp: &times[0],
-			},
-			expected: false, // p2 should be ahead of p1 in the queue
-		},
-		{
-			name: "equal priority and creation time, p1 belongs to podGroup1 and p2 belongs to podGroup2",
-			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
-				InitialAttemptTimestamp: &times[0],
-			},
-			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
-				InitialAttemptTimestamp: &times[0],
-			},
-			expected: true, // p1 should be ahead of p2 in the queue
-		},
-		{
-			name: "equal priority and creation time, p2 belong to podGroup2",
-			p1: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: &times[0],
-			},
-			p2: &framework.QueuedPodInfo{
-				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
-				InitialAttemptTimestamp: &times[0],
-			},
-			expected: true, // p1 should be ahead of p2 in the queue
-		},
-	} {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheduleDuration, pgInformer, podInformer)
-			coscheduling := &Coscheduling{pgMgr: pgMgr}
-			if got := coscheduling.Less(tt.p1, tt.p2); got != tt.expected {
-				t.Errorf("expected %v, got %v", tt.expected, got)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Compile all objects into `objs`.
+			var objs []runtime.Object
+			for _, pg := range tt.pgs {
+				objs = append(objs, pg)
+			}
+
+			client, err := tu.NewFakeClient(objs...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cs := clientsetfake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			podInformer := informerFactory.Core().V1().Pods()
+
+			pl := &Coscheduling{pgMgr: core.NewPodGroupManager(client, nil, nil, podInformer)}
+
+			informerFactory.Start(ctx.Done())
+			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
+				t.Fatal("WaitForCacheSync failed")
+			}
+
+			if got := pl.Less(tt.p1, tt.p2); got != tt.want {
+				t.Errorf("Want %v, got %v", tt.want, got)
 			}
 		})
 	}
 }
 
 func TestPermit(t *testing.T) {
+	scheduleTimeout := 10 * time.Second
+	capacity := map[v1.ResourceName]string{
+		v1.ResourceCPU: "4",
+	}
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node").Capacity(capacity).Obj(),
+	}
+
 	tests := []struct {
-		name     string
-		pod      *v1.Pod
-		expected framework.Code
+		name string
+		pod  *v1.Pod
+		pgs  []*v1alpha1.PodGroup
+		want framework.Code
 	}{
 		{
-			name:     "pods do not belong to any podGroup",
-			pod:      st.MakePod().Name("pod1").UID("pod1").Obj(),
-			expected: framework.Success,
+			name: "pods do not belong to any podGroup",
+			pod:  st.MakePod().Name("p").Namespace("ns").UID("p").Obj(),
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(1).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns").MinMember(2).Obj(),
+			},
+			want: framework.Success,
 		},
 		{
-			name:     "pods belong to a podGroup, Wait",
-			pod:      st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
-			expected: framework.Wait,
+			name: "pods belong to a pg1, but quorum not satisfied",
+			pod:  st.MakePod().Name("p").Namespace("ns").UID("p").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(1).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns").MinMember(2).Obj(),
+			},
+			want: framework.Wait,
 		},
 		{
-			name:     "pods belong to a podGroup, Allow",
-			pod:      st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg2").Obj(),
-			expected: framework.Success,
+			name: "pods belong to a podGroup, and quorum satisfied",
+			pod:  st.MakePod().Name("p").Namespace("ns").UID("p").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(1).Obj(),
+				tu.MakePodGroup().Name("pg2").Namespace("ns").MinMember(2).Obj(),
+			},
+			want: framework.Success,
 		},
 	}
-	ctx := context.Background()
-	cs := fakepgclientset.NewSimpleClientset()
-	pgInformerFactory := pgformers.NewSharedInformerFactory(cs, 0)
-	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
-	pgInformerFactory.Start(ctx.Done())
-	pg1 := testutil.MakePG("pg1", "ns1", 2, nil, nil)
-	pg2 := testutil.MakePG("pg2", "ns1", 1, nil, nil)
-	pgInformer.Informer().GetStore().Add(pg1)
-	pgInformer.Informer().GetStore().Add(pg2)
 
-	fakeClient := clientsetfake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
-	podInformer := informerFactory.Core().V1().Pods()
-	informerFactory.Start(ctx.Done())
-	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
-	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
-	// Compose a framework handle.
-	registeredPlugins := []st.RegisterPluginFunc{
-		st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-	}
-	f, err := st.NewFramework(registeredPlugins, "", ctx.Done(),
-		frameworkruntime.WithClientSet(fakeClient),
-		frameworkruntime.WithEventRecorder(&events.FakeRecorder{}),
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	scheduleDuration := 10 * time.Second
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pgMgr := core.NewPodGroupManager(cs, snapshot, &scheduleDuration, pgInformer, podInformer)
-			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheduleDuration}
-			code, _ := coscheduling.Permit(context.Background(), framework.NewCycleState(), tt.pod, "test")
-			if code.Code() != tt.expected {
-				t.Errorf("expected %v, got %v", tt.expected, code.Code())
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Compile all objects into `objs`.
+			var objs []runtime.Object
+			objs = append(objs, tt.pod)
+			for _, pg := range tt.pgs {
+				objs = append(objs, pg)
+			}
+
+			client, err := tu.NewFakeClient(objs...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Compose a fake framework handle.
+			registeredPlugins := []st.RegisterPluginFunc{
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			f, err := st.NewFramework(registeredPlugins, "default-scheduler", ctx.Done())
+			if err != nil {
+				t.Fatal(err)
+			}
+			cs := clientsetfake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			podInformer := informerFactory.Core().V1().Pods()
+
+			pl := &Coscheduling{
+				frameworkHandler: f,
+				pgMgr:            core.NewPodGroupManager(client, tu.NewFakeSharedLister(nil, nodes), nil, podInformer),
+				scheduleTimeout:  &scheduleTimeout,
+			}
+
+			informerFactory.Start(ctx.Done())
+			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
+				t.Fatal("WaitForCacheSync failed")
+			}
+
+			code, _ := pl.Permit(ctx, framework.NewCycleState(), tt.pod, "node")
+			if got := code.Code(); got != tt.want {
+				t.Errorf("Want %v, but got %v", tt.want, got)
 			}
 		})
 	}
 }
 
 func TestPostFilter(t *testing.T) {
-	nodeStatusMap := framework.NodeToStatusMap{"node1": framework.NewStatus(framework.Success, "")}
-	ctx := context.Background()
-	cs := fakepgclientset.NewSimpleClientset()
-	pgInformerFactory := pgformers.NewSharedInformerFactory(cs, 0)
-	pgInformer := pgInformerFactory.Scheduling().V1alpha1().PodGroups()
-	pgInformerFactory.Start(ctx.Done())
-	pg := testutil.MakePG("pg", "ns1", 2, nil, nil)
-	pgInformer.Informer().GetStore().Add(pg)
-	fakeClient := clientsetfake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
-	podInformer := informerFactory.Core().V1().Pods()
-	informerFactory.Start(ctx.Done())
+	scheduleTimeout := 10 * time.Second
+	capacity := map[v1.ResourceName]string{
+		v1.ResourceCPU: "4",
+	}
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node").Capacity(capacity).Obj(),
+	}
+	nodeStatusMap := framework.NodeToStatusMap{"node": framework.NewStatus(framework.Success, "")}
 
-	existingPods, allNodes := testutil.MakeNodesAndPods(map[string]string{"test": "a"}, 60, 30)
-	snapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
-	// Compose a framework handle.
-	registeredPlugins := []st.RegisterPluginFunc{
-		st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-	}
-	f, err := st.NewFramework(registeredPlugins, "", ctx.Done(),
-		frameworkruntime.WithClientSet(fakeClient),
-		frameworkruntime.WithEventRecorder(&events.FakeRecorder{}),
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	existingPods, allNodes = testutil.MakeNodesAndPods(map[string]string{v1alpha1.PodGroupLabel: "pg"}, 10, 30)
-	for _, pod := range existingPods {
-		pod.Namespace = "ns1"
-	}
-	groupPodSnapshot := testutil.NewFakeSharedLister(existingPods, allNodes)
-	scheduleDuration := 10 * time.Second
 	tests := []struct {
-		name                 string
-		pod                  *v1.Pod
-		expectedEmptyMsg     bool
-		snapshotSharedLister framework.SharedLister
+		name         string
+		pod          *v1.Pod
+		existingPods []*v1.Pod
+		pgs          []*v1alpha1.PodGroup
+		want         *framework.Status
 	}{
 		{
-			name:             "pod does not belong to any pod group",
-			pod:              st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Obj(),
-			expectedEmptyMsg: false,
+			name: "pod does not belong to any pod group",
+			pod:  st.MakePod().Name("p").Namespace("ns").UID("p").Obj(),
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(2).Obj(),
+			},
+			want: framework.NewStatus(framework.Unschedulable, "can not find pod group"),
 		},
 		{
-			name:                 "enough pods assigned, do not reject all",
-			pod:                  st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg").Obj(),
-			expectedEmptyMsg:     true,
-			snapshotSharedLister: groupPodSnapshot,
+			name: "enough pods assigned, do not reject all",
+			pod:  st.MakePod().Name("p").Namespace("ns").UID("p").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			existingPods: []*v1.Pod{
+				st.MakePod().Name("p1").Namespace("ns").UID("p1").Node("node").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(1).Obj(),
+			},
+			want: framework.NewStatus(framework.Unschedulable),
 		},
 		{
-			name:             "pod failed at filter phase, reject all pods",
-			pod:              st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label(v1alpha1.PodGroupLabel, "pg").Obj(),
-			expectedEmptyMsg: false,
+			name: "pod failed at filter phase, reject all pods",
+			pod:  st.MakePod().Name("p").Namespace("ns").UID("p").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			existingPods: []*v1.Pod{
+				st.MakePod().Name("p1").Namespace("ns").UID("p1").Node("node").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(2).Obj(),
+			},
+			want: framework.NewStatus(
+				framework.Unschedulable,
+				"PodGroup ns/pg1 gets rejected due to Pod p is unschedulable even after PostFilter",
+			),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cycleState := framework.NewCycleState()
-			mgrSnapShot := snapshot
-			if tt.snapshotSharedLister != nil {
-				mgrSnapShot = tt.snapshotSharedLister
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Compile all objects into `objs`.
+			var objs []runtime.Object
+			for _, pod := range append(tt.existingPods, tt.pod) {
+				objs = append(objs, pod)
+			}
+			for _, pg := range tt.pgs {
+				objs = append(objs, pg)
 			}
 
-			pgMgr := core.NewPodGroupManager(cs, mgrSnapShot, &scheduleDuration, pgInformer, podInformer)
-			coscheduling := &Coscheduling{pgMgr: pgMgr, frameworkHandler: f, scheduleTimeout: &scheduleDuration}
-			_, code := coscheduling.PostFilter(context.Background(), cycleState, tt.pod, nodeStatusMap)
-			if code.Message() == "" != tt.expectedEmptyMsg {
-				t.Errorf("expectedEmptyMsg %v, got %v", tt.expectedEmptyMsg, code.Message() == "")
+			client, err := tu.NewFakeClient(objs...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Compose a fake framework handle.
+			registeredPlugins := []st.RegisterPluginFunc{
+				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			f, err := st.NewFramework(registeredPlugins, "default-scheduler", ctx.Done())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cs := clientsetfake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			podInformer := informerFactory.Core().V1().Pods()
+
+			pl := &Coscheduling{
+				frameworkHandler: f,
+				pgMgr: core.NewPodGroupManager(
+					client,
+					tu.NewFakeSharedLister(tt.existingPods, nodes),
+					&scheduleTimeout,
+					podInformer,
+				),
+				scheduleTimeout: &scheduleTimeout,
+			}
+
+			informerFactory.Start(ctx.Done())
+			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
+				t.Fatal("WaitForCacheSync failed")
+			}
+			for _, p := range tt.existingPods {
+				podInformer.Informer().GetStore().Add(p)
+			}
+
+			_, got := pl.PostFilter(ctx, framework.NewCycleState(), tt.pod, nodeStatusMap)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Want %v, but got %v", tt.want, got)
 			}
 		})
 	}

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -163,7 +163,7 @@ func TestPodGroupBackoffTime(t *testing.T) {
 				t.Errorf("expected %v, got %v", tt.want, code.Code())
 				return
 			}
-			pgFullName, _ := pgMgr.GetPodGroup(tt.pods[0])
+			pgFullName, _ := pgMgr.GetPodGroup(ctx, tt.pods[0])
 			if code.Reasons()[0] != fmt.Sprintf("podGroup %v failed recently", pgFullName) {
 				t.Errorf("expected %v, got %v", pgFullName, code.Reasons()[0])
 				return

--- a/test/integration/podgroup_controller_test.go
+++ b/test/integration/podgroup_controller_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -41,7 +42,6 @@ import (
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/controllers"
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling"
-	"sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"
 	"sigs.k8s.io/scheduler-plugins/test/util"
 
 	gocmp "github.com/google/go-cmp/cmp"
@@ -53,7 +53,7 @@ func TestPodGroupController(t *testing.T) {
 	testCtx.Ctx, testCtx.CancelFn = context.WithCancel(context.Background())
 
 	cs := kubernetes.NewForConfigOrDie(globalKubeConfig)
-	extClient := versioned.NewForConfigOrDie(globalKubeConfig)
+	extClient := util.NewClientOrDie(globalKubeConfig)
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
@@ -301,8 +301,8 @@ func TestPodGroupController(t *testing.T) {
 
 			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
 				for _, v := range tt.intermediatePGState {
-					pg, err := extClient.SchedulingV1alpha1().PodGroups(v.Namespace).Get(testCtx.Ctx, v.Name, metav1.GetOptions{})
-					if err != nil {
+					var pg v1alpha1.PodGroup
+					if err := extClient.Get(testCtx.Ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &pg); err != nil {
 						// This could be a connection error so we want to retry.
 						klog.ErrorS(err, "Failed to obtain the PodGroup clientSet")
 						return false, err
@@ -337,8 +337,8 @@ func TestPodGroupController(t *testing.T) {
 
 			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
 				for _, v := range tt.expectedPGState {
-					pg, err := extClient.SchedulingV1alpha1().PodGroups(v.Namespace).Get(testCtx.Ctx, v.Name, metav1.GetOptions{})
-					if err != nil {
+					var pg v1alpha1.PodGroup
+					if err := extClient.Get(testCtx.Ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &pg); err != nil {
 						// This could be a connection error so we want to retry.
 						klog.ErrorS(err, "Failed to obtain the PodGroup clientSet")
 						return false, err

--- a/test/util/podgroup_wrapper.go
+++ b/test/util/podgroup_wrapper.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
+)
+
+type PodGroupWrapper struct{ v1alpha1.PodGroup }
+
+func MakePodGroup() *PodGroupWrapper {
+	return &PodGroupWrapper{v1alpha1.PodGroup{}}
+}
+
+func (p *PodGroupWrapper) Obj() *v1alpha1.PodGroup {
+	return &p.PodGroup
+}
+
+func (p *PodGroupWrapper) Name(s string) *PodGroupWrapper {
+	p.SetName(s)
+	return p
+}
+
+func (p *PodGroupWrapper) Namespace(s string) *PodGroupWrapper {
+	p.SetNamespace(s)
+	return p
+}
+
+func (p *PodGroupWrapper) MinMember(i int32) *PodGroupWrapper {
+	p.Spec.MinMember = i
+	return p
+}
+
+func (p *PodGroupWrapper) Time(t time.Time) *PodGroupWrapper {
+	p.CreationTimestamp.Time = t
+	return p
+}
+
+func (p *PodGroupWrapper) MinResources(resources map[v1.ResourceName]string) *PodGroupWrapper {
+	res := make(v1.ResourceList)
+	for name, value := range resources {
+		res[name] = resource.MustParse(value)
+	}
+	p.PodGroup.Spec.MinResources = res
+	return p
+}
+
+func (p *PodGroupWrapper) Phase(phase v1alpha1.PodGroupPhase) *PodGroupWrapper {
+	p.Status.Phase = phase
+	return p
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As #485 stated, we're migrating all plugins and controllers to use controller-runtime client. With the migration's completion, we should be able to eliminate all typed clients along with its generated bits.

This PR aims to migrate coscheduling.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #485

#### Special notes for your reviewer:

This PR also polished existing tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
migrate coscheduling to use controller-runtime client 
```
