### PR TITLE
migrate elasticquota/capacityscheduling to controller-runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ update-vendor:
 	hack/update-vendor.sh
 
 .PHONY: unit-test
-unit-test:
+unit-test: install-envtest
 	hack/unit-test.sh
 
 .PHONY: install-envtest

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -21,6 +21,10 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${SCRIPT_ROOT}/hack/lib/init.sh"
 
+kube::log::status "Configuring envtest"
+TEMP_DIR=${TMPDIR-/tmp}
+source "${TEMP_DIR}/setup-envtest"
+
 # TODO: make args customizable.
 go test -mod=vendor \
   sigs.k8s.io/scheduler-plugins/cmd/... \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind cleanup


#### What this PR does / why we need it:

migrate elasticquota/capacityscheduling to controller-runtime

This is the last piece to complete #485.

#### Which issue(s) this PR fixes:

Part of #485

#### Special notes for your reviewer:

Now, `pkg/generated` is the only package that include generated type client bits:

```
⇒  ag "scheduler-plugins/pkg/generated/clientset/versioned"
pkg/generated/informers/externalversions/scheduling/v1alpha1/elasticquota.go
30:	versioned "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"

pkg/generated/informers/externalversions/scheduling/v1alpha1/podgroup.go
30:	versioned "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"

pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
27:	versioned "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"

pkg/generated/informers/externalversions/factory.go
30:	versioned "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"

pkg/generated/clientset/versioned/clientset.go
28:	schedulingv1alpha1 "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/typed/scheduling/v1alpha1"

pkg/generated/clientset/versioned/typed/scheduling/v1alpha1/elasticquota.go
30:	scheme "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/scheme"

pkg/generated/clientset/versioned/typed/scheduling/v1alpha1/podgroup.go
30:	scheme "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/scheme"

pkg/generated/clientset/versioned/typed/scheduling/v1alpha1/scheduling_client.go
26:	"sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/scheme"

pkg/generated/clientset/versioned/typed/scheduling/v1alpha1/fake/fake_scheduling_client.go
24:	v1alpha1 "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/typed/scheduling/v1alpha1"

pkg/generated/clientset/versioned/fake/clientset_generated.go
27:	clientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned"
28:	schedulingv1alpha1 "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/typed/scheduling/v1alpha1"
29:	fakeschedulingv1alpha1 "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/typed/scheduling/v1alpha1/fake"
```

**But**, I'm not going to remove them. Instead, I will send out a notice and deprecation notice in the release notes (v0.27). So plugins that use this repo's typed clientset have buffer to make changes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
migrate elasticquota/capacityscheduling to controller-runtime
```
