### PR TITLE
Automated cherry pick of #672: Coscheduling: Remove the postBind filter in the

### DIFF
--- a/manifests/coscheduling/scheduler-config.yaml
+++ b/manifests/coscheduling/scheduler-config.yaml
@@ -24,9 +24,6 @@ profiles:
     reserve:
       enabled:
       - name: Coscheduling
-    postBind:
-      enabled:
-      - name: Coscheduling
   pluginConfig:
   - name: Coscheduling
     args:


### PR DESCRIPTION
Cherry pick of #672 on release-1.27.
#672: Coscheduling: Remove the postBind filter in the
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
NONE
```