### PR TITLE
Add scheduling op to helm chart

### DIFF
--- a/hack/install-envtest.sh
+++ b/hack/install-envtest.sh
@@ -32,6 +32,6 @@ version=$(cat ${SCRIPT_ROOT}/go.mod | grep 'k8s.io/kubernetes' | grep -v '=>' | 
 
 GOPATH=$(go env GOPATH)
 TEMP_DIR=${TMPDIR-/tmp}
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.15
 "${GOPATH}"/bin/setup-envtest use -p env "${version}" > "${TEMP_DIR}/setup-envtest"
 

--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -48,8 +48,14 @@ The following table lists the configurable parameters of the as-a-second-schedul
 | `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.27.8`                                      |
 | `scheduler.leaderElect`   | Scheduler leaderElection    | `false`                                                                                         |
 | `scheduler.replicaCount`  | Scheduler replicaCount      | `1`                                                                                             |
+| `scheduler.nodeSelector`  | Scheduler nodeSelector      | `{}`                                                                                            |
+| `scheduler.affinity`      | Scheduler affinity          | `{}`                                                                                            |
+| `scheduler.tolerations`   | Scheduler tolerations       | `[]`                                                                                            |
 | `controller.name`         | Controller name             | `scheduler-plugins-controller`                                                                  |
 | `controller.image`        | Controller image            | `registry.k8s.io/scheduler-plugins/controller:v0.27.8`                                          |
 | `controller.replicaCount` | Controller replicaCount     | `1`                                                                                             |
+| `controller.nodeSelector` | Controller nodeSelector     | `{}`                                                                                            |
+| `controller.affinity`     | Controller affinity         | `{}`                                                                                            |
+| `controller.tolerations`  | Controller tolerations      | `[]`                                                                                            |
 | `plugins.enabled`         | Plugins enabled by default  | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
 | `plugins.disabled`        | Plugins disabled by default | `["PrioritySort"]`                                                                              |

--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -20,6 +20,16 @@ spec:
       - name: scheduler-plugins-controller
         image: {{ .Values.controller.image }}
         imagePullPolicy: IfNotPresent
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations: {{- toYaml . | nindent 8}}
+      {{- end }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -72,3 +82,13 @@ spec:
       - name: scheduler-config
         configMap:
           name: scheduler-config
+      {{- with .Values.scheduler.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.scheduler.affinity }}
+      affinity: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.scheduler.tolerations }}
+      tolerations: {{- toYaml . | nindent 8}}
+      {{- end }}
+      

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -7,11 +7,17 @@ scheduler:
   image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.27.8
   replicaCount: 1
   leaderElect: false
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 controller:
   name: scheduler-plugins-controller
   image: registry.k8s.io/scheduler-plugins/controller:v0.27.8
   replicaCount: 1
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 # LoadVariationRiskBalancing and TargetLoadPacking are not enabled by default
 # as they need extra RBAC privileges on metrics.k8s.io.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add ability to change `nodeSelector`, `affinity` and `tolerations` of Pods installed via Helm Chart.

#### Which issue(s) this PR fixes:
Fixes #696

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Adds ability to change NodeSelector, affinity, and tolerance to Helm Chart.
```
