### PR TITLE
remove manual edit strings from crd manifests

### DIFF
--- a/hack/verify-crdgen.sh
+++ b/hack/verify-crdgen.sh
@@ -34,7 +34,7 @@ api_paths="./apis/scheduling/v1alpha1/...;./vendor/github.com/k8stopologyawaresc
 
 ${CONTROLLER_GEN} ${CRD_OPTIONS} paths="${api_paths}" output:dir="./manifests/crds"
 
-if ! _out="$(git --no-pager diff -I"edited\smanually" --exit-code ./manifests)"; then
+if ! _out="$(git --no-pager diff --exit-code ./manifests)"; then
     echo "Generated output differs" >&2
     echo "${_out}" >&2
     echo "Verification for CRD generators failed."

--- a/manifests/appgroup/crd.yaml
+++ b/manifests/appgroup/crd.yaml
@@ -3,7 +3,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/432 # edited manually
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: appgroups.appgroup.diktyo.x-k8s.io

--- a/manifests/networktopology/crd.yaml
+++ b/manifests/networktopology/crd.yaml
@@ -3,7 +3,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/432 # edited manually
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: networktopologies.networktopology.diktyo.x-k8s.io


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

With this PR, CRDs hosted in this repo or referenced in externals repos are recommended to add:

```
// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes-sigs/scheduler-plugins/pull/XYZ"
```

to their types.go, but not mandatory.

`hack/verify-crdgen.sh` is able to catch any inconsistency between types.go and CRD manifests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
A follow-up of #479.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
+kubebuilder:metadata:annotations is recommended but no longer mandatory to be defined in CRD types.go
```
