### PR TITLE
Avoid unnecessary requeue operations in coscheduling

### DIFF
--- a/pkg/coscheduling/core/core.go
+++ b/pkg/coscheduling/core/core.go
@@ -48,12 +48,22 @@ const (
 	PodGroupNotFound Status = "PodGroup not found"
 	Success          Status = "Success"
 	Wait             Status = "Wait"
+
+	preFilterStateKey = "PreFilterCoscheduling"
 )
+
+type PreFilterState struct {
+	Activate bool
+}
+
+func (s *PreFilterState) Clone() framework.StateData {
+	return &PreFilterState{Activate: s.Activate}
+}
 
 // Manager defines the interfaces for PodGroup management.
 type Manager interface {
 	PreFilter(context.Context, *corev1.Pod) error
-	Permit(context.Context, *corev1.Pod) Status
+	Permit(context.Context, *framework.CycleState, *corev1.Pod) Status
 	GetPodGroup(context.Context, *corev1.Pod) (string, *v1alpha1.PodGroup)
 	GetCreationTimestamp(*corev1.Pod, time.Time) time.Time
 	DeletePermittedPodGroup(string)
@@ -105,6 +115,13 @@ func (pgMgr *PodGroupManager) BackoffPodGroup(pgName string, backoff time.Durati
 func (pgMgr *PodGroupManager) ActivateSiblings(pod *corev1.Pod, state *framework.CycleState) {
 	pgName := util.GetPodGroupLabel(pod)
 	if pgName == "" {
+		return
+	}
+
+	// Only proceed if it's explicitly requested to activate sibling pods.
+	if c, err := state.Read(preFilterStateKey); err != nil {
+		return
+	} else if s, ok := c.(*PreFilterState); !ok || !s.Activate {
 		return
 	}
 
@@ -193,7 +210,7 @@ func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, pod *corev1.Pod) er
 }
 
 // Permit permits a pod to run, if the minMember match, it would send a signal to chan.
-func (pgMgr *PodGroupManager) Permit(ctx context.Context, pod *corev1.Pod) Status {
+func (pgMgr *PodGroupManager) Permit(ctx context.Context, state *framework.CycleState, pod *corev1.Pod) Status {
 	pgFullName, pg := pgMgr.GetPodGroup(ctx, pod)
 	if pgFullName == "" {
 		return PodGroupNotSpecified
@@ -209,6 +226,19 @@ func (pgMgr *PodGroupManager) Permit(ctx context.Context, pod *corev1.Pod) Statu
 	if int32(assigned)+1 >= pg.Spec.MinMember {
 		return Success
 	}
+
+	if assigned == 0 {
+		// Given we've reached Permit(), it's mean all PreFilter checks (minMember & minResource)
+		// already pass through, so if assigned == 0, it could be due to:
+		// - minResource get satisfied
+		// - new pods added
+		// In either case, we should and only should use this 0-th pod to trigger activating
+		// its siblings.
+		// It'd be in-efficient if we trigger activating siblings unconditionally.
+		// See https://github.com/kubernetes-sigs/scheduler-plugins/issues/682
+		state.Write(preFilterStateKey, &PreFilterState{Activate: true})
+	}
+
 	return Wait
 }
 

--- a/pkg/coscheduling/core/core.go
+++ b/pkg/coscheduling/core/core.go
@@ -49,15 +49,15 @@ const (
 	Success          Status = "Success"
 	Wait             Status = "Wait"
 
-	preFilterStateKey = "PreFilterCoscheduling"
+	permitStateKey = "PermitCoscheduling"
 )
 
-type PreFilterState struct {
+type PermitState struct {
 	Activate bool
 }
 
-func (s *PreFilterState) Clone() framework.StateData {
-	return &PreFilterState{Activate: s.Activate}
+func (s *PermitState) Clone() framework.StateData {
+	return &PermitState{Activate: s.Activate}
 }
 
 // Manager defines the interfaces for PodGroup management.
@@ -119,9 +119,9 @@ func (pgMgr *PodGroupManager) ActivateSiblings(pod *corev1.Pod, state *framework
 	}
 
 	// Only proceed if it's explicitly requested to activate sibling pods.
-	if c, err := state.Read(preFilterStateKey); err != nil {
+	if c, err := state.Read(permitStateKey); err != nil {
 		return
-	} else if s, ok := c.(*PreFilterState); !ok || !s.Activate {
+	} else if s, ok := c.(*PermitState); !ok || !s.Activate {
 		return
 	}
 
@@ -236,7 +236,7 @@ func (pgMgr *PodGroupManager) Permit(ctx context.Context, state *framework.Cycle
 		// its siblings.
 		// It'd be in-efficient if we trigger activating siblings unconditionally.
 		// See https://github.com/kubernetes-sigs/scheduler-plugins/issues/682
-		state.Write(preFilterStateKey, &PreFilterState{Activate: true})
+		state.Write(permitStateKey, &PermitState{Activate: true})
 	}
 
 	return Wait

--- a/pkg/coscheduling/core/core_test.go
+++ b/pkg/coscheduling/core/core_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clicache "k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	tu "sigs.k8s.io/scheduler-plugins/test/util"
@@ -278,7 +279,7 @@ func TestPermit(t *testing.T) {
 				podInformer.Informer().GetStore().Add(p)
 			}
 
-			if got := pgMgr.Permit(ctx, tt.pod); got != tt.want {
+			if got := pgMgr.Permit(ctx, &framework.CycleState{}, tt.pod); got != tt.want {
 				t.Errorf("Want %v, but got %v", tt.want, got)
 			}
 		})

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -204,7 +204,7 @@ func (cs *Coscheduling) PreFilterExtensions() framework.PreFilterExtensions {
 // Permit is the functions invoked by the framework at "Permit" extension point.
 func (cs *Coscheduling) Permit(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
 	waitTime := *cs.scheduleTimeout
-	s := cs.pgMgr.Permit(ctx, pod)
+	s := cs.pgMgr.Permit(ctx, state, pod)
 	var retStatus *framework.Status
 	switch s {
 	case core.PodGroupNotSpecified:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The current coscheduling code aggressively actives a pod's PodGroup siblings in `Permit()`. For example, if a deployment doesn't reach the minMember, all its pods are in pending state. Once it's scaled up to reach the minMember, it'd trigger `ActivateSiblings()` N times - this causes a ton of unnecessary re-queue operations which cause the CPU usage to spike, and may relates with potential starvation reported in #682.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #682

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Performance fix to eliminate unnecessary re-queue actions in coscheduling plugin
```
