### PR TITLE
Mitigate potential range panic

### DIFF
--- a/pkg/controllers/podgroup_controller.go
+++ b/pkg/controllers/podgroup_controller.go
@@ -105,7 +105,7 @@ func (r *PodGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	case "":
 		pgCopy.Status.Phase = schedv1alpha1.PodGroupPending
 	case schedv1alpha1.PodGroupPending:
-		if len(pods) >= int(pg.Spec.MinMember) {
+		if (int(pg.Spec.MinMember) > 0) && (len(pods) >= int(pg.Spec.MinMember)) {
 			pgCopy.Status.Phase = schedv1alpha1.PodGroupScheduling
 			fillOccupiedObj(pgCopy, &pods[0])
 		}

--- a/pkg/controllers/podgroup_controller_test.go
+++ b/pkg/controllers/podgroup_controller_test.go
@@ -155,6 +155,15 @@ func Test_Run(t *testing.T) {
 			previousPhase:     v1alpha1.PodGroupRunning,
 			desiredGroupPhase: v1alpha1.PodGroupPending,
 		},
+		{
+			name:              "Group with minMember 0 remains pending",
+			pgName:            "pg11",
+			minMember:         0,
+			podNames:          nil,
+			podPhase:          v1.PodPending,
+			previousPhase:     v1alpha1.PodGroupPending,
+			desiredGroupPhase: v1alpha1.PodGroupPending,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -311,6 +320,9 @@ func makePods(podNames []string, pgName string, phase v1.PodPhase, reference []m
 			pod.OwnerReferences = reference
 		}
 		pds = append(pds, pod)
+	}
+	if len(podNames) == 0 {
+		return nil
 	}
 	return pds
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a podgroup has a MinMember set to 0 and no pods exist, the reconciler can encounter a range exception.

I have observed this on v0.26.7.  The underlying code is still the same so it is likely the same weakness exists in the currently.

The crash appears as follows

```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 227 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:119 +0x1fa
panic({0x16c9880, 0xc0001dc000})
	/usr/local/go/src/runtime/panic.go:884 +0x212
sigs.k8s.io/scheduler-plugins/pkg/controllers.(*PodGroupReconciler).Reconcile(0xc000477d60, {0x1a1fbb8, 0xc0003cf230}, {{{0xc000a08378?, 0x10?}, {0xc0005010c0?, 0x40da67?}}})
	/go/src/sigs.k8s.io/scheduler-plugins/pkg/controllers/podgroup_controller.go:112 +0x9c6
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1a1fbb8?, {0x1a1fbb8?, 0xc0003cf230?}, {{{0xc000a08378?, 0x1567320?}, {0xc0005010c0?, 0x0?}}})
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:122 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000422a00, {0x1a1fb10, 0xc0008a0c80}, {0x1634dc0?, 0xc000460020?})
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:323 +0x38f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000422a00, {0x1a1fb10, 0xc0008a0c80})
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/go/src/sigs.k8s.io/scheduler-plugins/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:231 +0x333
``` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
