### PR TITLE
[noderesourcetopology] complete the contextual logging integration

### DIFF
--- a/pkg/noderesourcetopology/cache/discardreserved.go
+++ b/pkg/noderesourcetopology/cache/discardreserved.go
@@ -78,7 +78,7 @@ func (pt *DiscardReserved) NodeMaybeOverReserved(nodeName string, pod *corev1.Po
 func (pt *DiscardReserved) NodeHasForeignPods(nodeName string, pod *corev1.Pod)    {}
 
 func (pt *DiscardReserved) ReserveNodeResources(nodeName string, pod *corev1.Pod) {
-	pt.lh.V(5).Info("NRT Reserve", "logID", logging.PodLogID(pod), "podUID", pod.GetUID(), "node", nodeName)
+	pt.lh.V(5).Info("NRT Reserve", logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 	pt.rMutex.Lock()
 	defer pt.rMutex.Unlock()
 
@@ -89,14 +89,14 @@ func (pt *DiscardReserved) ReserveNodeResources(nodeName string, pod *corev1.Pod
 }
 
 func (pt *DiscardReserved) UnreserveNodeResources(nodeName string, pod *corev1.Pod) {
-	pt.lh.V(5).Info("NRT Unreserve", "logID", klog.KObj(pod), "podUID", pod.GetUID(), "node", nodeName)
+	pt.lh.V(5).Info("NRT Unreserve", logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 
 	pt.removeReservationForNode(nodeName, pod)
 }
 
 // PostBind is invoked to cleanup reservationMap
 func (pt *DiscardReserved) PostBind(nodeName string, pod *corev1.Pod) {
-	pt.lh.V(5).Info("NRT PostBind", "logID", klog.KObj(pod), "podUID", pod.GetUID(), "node", nodeName)
+	pt.lh.V(5).Info("NRT PostBind", logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 
 	pt.removeReservationForNode(nodeName, pod)
 }

--- a/pkg/noderesourcetopology/cache/foreign_pods.go
+++ b/pkg/noderesourcetopology/cache/foreign_pods.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	k8scache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/logging"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/resourcerequests"
@@ -50,7 +51,7 @@ func SetupForeignPodsDetector(lh logr.Logger, schedProfileName string, podInform
 		}
 
 		cc.NodeHasForeignPods(pod.Spec.NodeName, pod)
-		lh.V(6).Info("detected foreign pods", "logID", logging.PodLogID(pod), "podUID", pod.GetUID(), "node", pod.Spec.NodeName)
+		lh.V(6).Info("detected foreign pods", logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, pod.Spec.NodeName)
 	}
 
 	podInformer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{

--- a/pkg/noderesourcetopology/cache/store_test.go
+++ b/pkg/noderesourcetopology/cache/store_test.go
@@ -516,7 +516,7 @@ func TestResourceStoreUpdate(t *testing.T) {
 	}
 
 	logID := "testResourceStoreUpdate"
-	rs.UpdateNRT(logID, nrt)
+	rs.UpdateNRT(nrt, "logID", logID)
 
 	cpuInfo0 := findResourceInfo(nrt.Zones[0].Resources, cpu)
 	if cpuInfo0.Capacity.Cmp(resource.MustParse("20")) != 0 {

--- a/pkg/noderesourcetopology/logging/logging.go
+++ b/pkg/noderesourcetopology/logging/logging.go
@@ -18,21 +18,16 @@ package logging
 
 import (
 	"fmt"
+	"reflect"
 	"time"
-
-	"github.com/go-logr/logr"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
-// before to replace with FromContext(), at least in filter and score,
-// we would need a way to inject a logger instance (preferably a
-// per-plugin logger instance) when we create the Scheduler
-// (with app.NewSchedulerCommand)
-
 // well-known structured log keys
 const (
 	KeyLogID  string = "logID"
+	KeyPod    string = "pod"
 	KeyPodUID string = "podUID"
 	KeyNode   string = "node"
 	KeyFlow   string = "flow"
@@ -44,32 +39,22 @@ const (
 )
 
 const (
-	FlowCacheSync string = "cachesync"
-	FlowFilter    string = "filter"
-	FlowPostBind  string = "postbind"
-	FlowReserve   string = "reserve"
-	FlowUnreserve string = "unreserve"
-	FlowScore     string = "score"
+	FlowCacheSync string = "resync"
 )
 
-var logh logr.Logger
+const (
+	SubsystemForeignPods string = "foreignpods"
+	SubsystemNRTCache    string = "nrtcache"
+)
 
-func SetLogger(lh logr.Logger) {
-	logh = lh
-}
-
-func Log() logr.Logger {
-	return logh
-}
-
-func PodLogID(pod *corev1.Pod) string {
+func PodUID(pod *corev1.Pod) string {
 	if pod == nil {
 		return "<nil>"
 	}
-	if pod.Namespace == "" {
-		return pod.Name
+	if val := reflect.ValueOf(pod); val.Kind() == reflect.Ptr && val.IsNil() {
+		return "<nil>"
 	}
-	return pod.Namespace + "/" + pod.Name
+	return string(pod.GetUID())
 }
 
 func TimeLogID() string {

--- a/pkg/noderesourcetopology/plugin.go
+++ b/pkg/noderesourcetopology/plugin.go
@@ -31,7 +31,6 @@ import (
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 	"sigs.k8s.io/scheduler-plugins/apis/config/validation"
 	nrtcache "sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/cache"
-	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/logging"
 
 	"github.com/go-logr/logr"
 	topologyapi "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology"
@@ -120,9 +119,7 @@ func (tm *TopologyMatch) Name() string {
 
 // New initializes a new plugin and returns it.
 func New(ctx context.Context, args runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	// we do this later to make sure klog is initialized. We don't need this anyway before this point
-	lh := klog.Background()
-	logging.SetLogger(lh)
+	lh := klog.FromContext(ctx)
 
 	lh.V(5).Info("creating new noderesourcetopology plugin")
 	tcfg, ok := args.(*apiconfig.NodeResourceTopologyMatchArgs)

--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -33,6 +33,7 @@ import (
 
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 	nrtcache "sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/cache"
+	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/logging"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/podprovider"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/stringify"
 )
@@ -50,16 +51,16 @@ func initNodeTopologyInformer(ctx context.Context, lh logr.Logger,
 	}
 
 	if tcfg.DiscardReservedNodes {
-		return nrtcache.NewDiscardReserved(lh.WithName("nrtcache"), client), nil
+		return nrtcache.NewDiscardReserved(lh.WithName(logging.SubsystemNRTCache), client), nil
 	}
 
 	if tcfg.CacheResyncPeriodSeconds <= 0 {
-		return nrtcache.NewPassthrough(lh.WithName("nrtcache"), client), nil
+		return nrtcache.NewPassthrough(lh.WithName(logging.SubsystemNRTCache), client), nil
 	}
 
 	podSharedInformer, podLister, isPodRelevant := podprovider.NewFromHandle(lh, handle, tcfg.Cache)
 
-	nrtCache, err := nrtcache.NewOverReserve(ctx, lh.WithName("nrtcache"), tcfg.Cache, client, podLister, isPodRelevant)
+	nrtCache, err := nrtcache.NewOverReserve(ctx, lh.WithName(logging.SubsystemNRTCache), tcfg.Cache, client, podLister, isPodRelevant)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,8 @@ func initNodeTopologyForeignPodsDetection(lh logr.Logger, cfg *apiconfig.NodeRes
 	} else {
 		nrtcache.TrackAllForeignPods()
 	}
-	nrtcache.RegisterSchedulerProfileName(lh.WithName("foreignpods"), profileName)
-	nrtcache.SetupForeignPodsDetector(lh.WithName("foreignpods"), profileName, podSharedInformer, nrtCache)
+	nrtcache.RegisterSchedulerProfileName(lh.WithName(logging.SubsystemForeignPods), profileName)
+	nrtcache.SetupForeignPodsDetector(lh.WithName(logging.SubsystemForeignPods), profileName, podSharedInformer, nrtCache)
 }
 
 func createNUMANodeList(lh logr.Logger, zones topologyv1alpha2.ZoneList) NUMANodeList {

--- a/pkg/noderesourcetopology/podprovider/podprovider.go
+++ b/pkg/noderesourcetopology/podprovider/podprovider.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
+	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/logging"
 )
 
 type PodFilterFunc func(lh logr.Logger, pod *corev1.Pod) bool
@@ -69,12 +70,12 @@ func IsPodRelevantDedicated(lh logr.Logger, pod *corev1.Pod) bool {
 	// Note PodUnknown is deprecated and reportedly no longer set since 2015 (!!)
 	if pod.Status.Phase == corev1.PodPending {
 		// this is unexpected, so we're loud about it
-		lh.V(2).Info("listed pod in Pending phase, ignored", "podUID", pod.GetUID())
+		lh.V(2).Info("listed pod in Pending phase, ignored", logging.KeyPodUID, logging.PodUID(pod))
 		return false
 	}
 	if pod.Spec.NodeName == "" {
 		// this is very unexpected, so we're louder about it
-		lh.Info("listed pod unbound, ignored", "podUID", pod.GetUID())
+		lh.Info("listed pod unbound, ignored", logging.KeyPodUID, logging.PodUID(pod))
 		return false
 	}
 	return true

--- a/pkg/noderesourcetopology/postbind.go
+++ b/pkg/noderesourcetopology/postbind.go
@@ -20,12 +20,13 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/logging"
 )
 
 func (tm *TopologyMatch) PostBind(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeName string) {
-	lh := logging.Log().WithValues(logging.KeyLogID, logging.PodLogID(pod), logging.KeyPodUID, pod.GetUID(), logging.KeyNode, nodeName, logging.KeyFlow, logging.FlowPostBind)
+	lh := klog.FromContext(ctx).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)
 

--- a/pkg/noderesourcetopology/reserve.go
+++ b/pkg/noderesourcetopology/reserve.go
@@ -20,12 +20,14 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/logging"
 )
 
 func (tm *TopologyMatch) Reserve(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeName string) *framework.Status {
-	lh := logging.Log().WithValues(logging.KeyLogID, logging.PodLogID(pod), logging.KeyPodUID, pod.GetUID(), logging.KeyNode, nodeName, logging.KeyFlow, logging.FlowReserve)
+	// the scheduler framework will add the node/name key/value pair
+	lh := klog.FromContext(ctx).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod))
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)
 
@@ -35,7 +37,8 @@ func (tm *TopologyMatch) Reserve(ctx context.Context, state *framework.CycleStat
 }
 
 func (tm *TopologyMatch) Unreserve(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeName string) {
-	lh := logging.Log().WithValues(logging.KeyLogID, logging.PodLogID(pod), logging.KeyPodUID, pod.GetUID(), logging.KeyNode, nodeName, logging.KeyFlow, logging.FlowUnreserve)
+	// the scheduler framework will add the node/name key/value pair
+	lh := klog.FromContext(ctx).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod))
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This is the second and last part of the contextual logging/logr porting/log cleanup tracked in #709 and begun in #710 . Working on #710, addressing the review comments, and reviewing the changes in kube 1.28 and beyond (see #712) lead to the realization that some better integration is desirable. That's completed in this PR.

#### Which issue(s) this PR fixes:
Related to #709 

#### Special notes for your reviewer:
Further minor tweaks of the log levels of some key messages are planned, but the vast majority of the work is considered done with this PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
