### PR TITLE
add crd(podgroup, elasticquotas) field

### DIFF
--- a/apis/scheduling/v1alpha1/types.go
+++ b/apis/scheduling/v1alpha1/types.go
@@ -29,6 +29,9 @@ import (
 // +kubebuilder:resource:shortName={eq,eqs}
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes-sigs/scheduler-plugins/pull/52"
+// +kubebuilder:printcolumn:name="Used",JSONPath=".status.used",type=string,description="Used is the current observed total usage of the resource in the namespace."
+// +kubebuilder:printcolumn:name="Max",JSONPath=".spec.max",type=integer,description="Max is the set of desired max limits for each named resource."
+// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Age is the time ElasticQuota was created."
 type ElasticQuota struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -116,6 +119,12 @@ const (
 // +kubebuilder:resource:shortName={pg,pgs}
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes-sigs/scheduler-plugins/pull/50"
+// +kubebuilder:printcolumn:name="Phase",JSONPath=".status.phase",type=string,description="Current phase of PodGroup."
+// +kubebuilder:printcolumn:name="MinMember",JSONPath=".spec.minMember",type=integer,description="MinMember defines the minimal number of members/tasks to run the pod group."
+// +kubebuilder:printcolumn:name="Running",JSONPath=".status.running",type=string,description="The number of actively running pods."
+// +kubebuilder:printcolumn:name="Succeeded",JSONPath=".status.succeeded",type=string,description="The number of pods which reached phase Succeeded."
+// +kubebuilder:printcolumn:name="Failed",JSONPath=".status.failed",type=string,description="The number of pods which reached phase Failed."
+// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Age is the time PodGroup was created."
 type PodGroup struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/apis/scheduling/v1alpha1/types.go
+++ b/apis/scheduling/v1alpha1/types.go
@@ -30,7 +30,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes-sigs/scheduler-plugins/pull/52"
 // +kubebuilder:printcolumn:name="Used",JSONPath=".status.used",type=string,description="Used is the current observed total usage of the resource in the namespace."
-// +kubebuilder:printcolumn:name="Max",JSONPath=".spec.max",type=integer,description="Max is the set of desired max limits for each named resource."
+// +kubebuilder:printcolumn:name="Max",JSONPath=".spec.max",type=string,description="Max is the set of desired max limits for each named resource."
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Age is the time ElasticQuota was created."
 type ElasticQuota struct {
 	metav1.TypeMeta `json:",inline"`
@@ -121,9 +121,9 @@ const (
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes-sigs/scheduler-plugins/pull/50"
 // +kubebuilder:printcolumn:name="Phase",JSONPath=".status.phase",type=string,description="Current phase of PodGroup."
 // +kubebuilder:printcolumn:name="MinMember",JSONPath=".spec.minMember",type=integer,description="MinMember defines the minimal number of members/tasks to run the pod group."
-// +kubebuilder:printcolumn:name="Running",JSONPath=".status.running",type=string,description="The number of actively running pods."
-// +kubebuilder:printcolumn:name="Succeeded",JSONPath=".status.succeeded",type=string,description="The number of pods which reached phase Succeeded."
-// +kubebuilder:printcolumn:name="Failed",JSONPath=".status.failed",type=string,description="The number of pods which reached phase Failed."
+// +kubebuilder:printcolumn:name="Running",JSONPath=".status.running",type=integer,description="The number of actively running pods."
+// +kubebuilder:printcolumn:name="Succeeded",JSONPath=".status.succeeded",type=integer,description="The number of pods which reached phase Succeeded."
+// +kubebuilder:printcolumn:name="Failed",JSONPath=".status.failed",type=integer,description="The number of pods which reached phase Failed."
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Age is the time PodGroup was created."
 type PodGroup struct {
 	metav1.TypeMeta `json:",inline"`

--- a/config/crd/bases/scheduling.x-k8s.io_elasticquotas.yaml
+++ b/config/crd/bases/scheduling.x-k8s.io_elasticquotas.yaml
@@ -28,7 +28,7 @@ spec:
     - description: Max is the set of desired max limits for each named resource.
       jsonPath: .spec.max
       name: Max
-      type: integer
+      type: string
     - description: Age is the time ElasticQuota was created.
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/crd/bases/scheduling.x-k8s.io_elasticquotas.yaml
+++ b/config/crd/bases/scheduling.x-k8s.io_elasticquotas.yaml
@@ -19,7 +19,21 @@ spec:
     singular: elasticquota
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Used is the current observed total usage of the resource in the
+        namespace.
+      jsonPath: .status.used
+      name: Used
+      type: string
+    - description: Max is the set of desired max limits for each named resource.
+      jsonPath: .spec.max
+      name: Max
+      type: integer
+    - description: Age is the time ElasticQuota was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ElasticQuota sets elastic quota restrictions per namespace

--- a/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
+++ b/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
@@ -19,7 +19,33 @@ spec:
     singular: podgroup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Current phase of PodGroup.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: MinMember defines the minimal number of members/tasks to run the
+        pod group.
+      jsonPath: .spec.minMember
+      name: MinMember
+      type: integer
+    - description: The number of actively running pods.
+      jsonPath: .status.running
+      name: Running
+      type: string
+    - description: The number of pods which reached phase Succeeded.
+      jsonPath: .status.succeeded
+      name: Succeeded
+      type: string
+    - description: The number of pods which reached phase Failed.
+      jsonPath: .status.failed
+      name: Failed
+      type: string
+    - description: Age is the time PodGroup was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PodGroup is a collection of Pod; used for batch workload.

--- a/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
+++ b/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
@@ -32,15 +32,15 @@ spec:
     - description: The number of actively running pods.
       jsonPath: .status.running
       name: Running
-      type: string
+      type: integer
     - description: The number of pods which reached phase Succeeded.
       jsonPath: .status.succeeded
       name: Succeeded
-      type: string
+      type: integer
     - description: The number of pods which reached phase Failed.
       jsonPath: .status.failed
       name: Failed
-      type: string
+      type: integer
     - description: Age is the time PodGroup was created.
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/manifests/capacityscheduling/crd.yaml
+++ b/manifests/capacityscheduling/crd.yaml
@@ -28,7 +28,7 @@ spec:
     - description: Max is the set of desired max limits for each named resource.
       jsonPath: .spec.max
       name: Max
-      type: integer
+      type: string
     - description: Age is the time ElasticQuota was created.
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/manifests/capacityscheduling/crd.yaml
+++ b/manifests/capacityscheduling/crd.yaml
@@ -19,7 +19,21 @@ spec:
     singular: elasticquota
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Used is the current observed total usage of the resource in the
+        namespace.
+      jsonPath: .status.used
+      name: Used
+      type: string
+    - description: Max is the set of desired max limits for each named resource.
+      jsonPath: .spec.max
+      name: Max
+      type: integer
+    - description: Age is the time ElasticQuota was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ElasticQuota sets elastic quota restrictions per namespace

--- a/manifests/coscheduling/crd.yaml
+++ b/manifests/coscheduling/crd.yaml
@@ -19,7 +19,33 @@ spec:
     singular: podgroup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Current phase of PodGroup.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: MinMember defines the minimal number of members/tasks to run the
+        pod group.
+      jsonPath: .spec.minMember
+      name: MinMember
+      type: integer
+    - description: The number of actively running pods.
+      jsonPath: .status.running
+      name: Running
+      type: string
+    - description: The number of pods which reached phase Succeeded.
+      jsonPath: .status.succeeded
+      name: Succeeded
+      type: string
+    - description: The number of pods which reached phase Failed.
+      jsonPath: .status.failed
+      name: Failed
+      type: string
+    - description: Age is the time PodGroup was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PodGroup is a collection of Pod; used for batch workload.

--- a/manifests/coscheduling/crd.yaml
+++ b/manifests/coscheduling/crd.yaml
@@ -32,15 +32,15 @@ spec:
     - description: The number of actively running pods.
       jsonPath: .status.running
       name: Running
-      type: string
+      type: integer
     - description: The number of pods which reached phase Succeeded.
       jsonPath: .status.succeeded
       name: Succeeded
-      type: string
+      type: integer
     - description: The number of pods which reached phase Failed.
       jsonPath: .status.failed
       name: Failed
-      type: string
+      type: integer
     - description: Age is the time PodGroup was created.
       jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- add crd(podgroup, elasticquotas) field
```bash
➜  bases git:(add_crd_field) ✗ kubectl get elasticquotas.scheduling.x-k8s.io  
NAME   USED                                            MAX                                             AGE
test   {"cpu":"0","memory":"0","nvidia.com/gpu":"0"}   {"cpu":20,"memory":"40Gi","nvidia.com/gpu":2}   3d6h
➜  bases git:(add_crd_field) ✗ kubectl get podgroups.scheduling.x-k8s.io
NAME   PHASE     MINMEMBER   RUNNING   SUCCEEDED   FAILED   AGE
pg1    Running   2           3                              41h

```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/scheduler-plugins/issues/730
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
