### PR TITLE
Fix update-codegen.sh on macOS

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,6 +19,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[@]}")/..
+
 mkdir -p "${SCRIPT_ROOT}/hack/tools/bin"
 TOOLS_DIR=$(realpath ./hack/tools)
 TOOLS_BIN_DIR="${TOOLS_DIR}/bin"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[@]}")/..
-
+mkdir -p "${SCRIPT_ROOT}/hack/tools/bin"
 TOOLS_DIR=$(realpath ./hack/tools)
 TOOLS_BIN_DIR="${TOOLS_DIR}/bin"
 GO_INSTALL=$(realpath ./hack/go-install.sh)


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
realpath on macOS fails if the file or directory referenced does not exist. hack/update-codegen.sh fails by default on mac because the hack/tools path does not exist when we try to set it to variable with realpath `TOOLS_DIR=$(realpath ./hack/tools)`. This fix simply creates the hack/tools and hack/tools/bin directories before they are referenced

#### Which issue(s) this PR fixes:

Fixes [#](https://github.com/kubernetes-sigs/scheduler-plugins/issues/732)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
