### PR TITLE
docs: anyone should be any

### DIFF
--- a/apis/scheduling/v1alpha1/types.go
+++ b/apis/scheduling/v1alpha1/types.go
@@ -136,12 +136,12 @@ type PodGroup struct {
 type PodGroupSpec struct {
 	// MinMember defines the minimal number of members/tasks to run the pod group;
 	// if there's not enough resources to start all tasks, the scheduler
-	// will not start anyone.
+	// will not start any.
 	MinMember int32 `json:"minMember,omitempty"`
 
 	// MinResources defines the minimal resource of members/tasks to run the pod group;
 	// if there's not enough resources to start all tasks, the scheduler
-	// will not start anyone.
+	// will not start any.
 	MinResources v1.ResourceList `json:"minResources,omitempty"`
 
 	// ScheduleTimeoutSeconds defines the maximal time of members/tasks to wait before run the pod group;

--- a/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
+++ b/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
@@ -42,7 +42,7 @@ spec:
               minMember:
                 description: MinMember defines the minimal number of members/tasks
                   to run the pod group; if there's not enough resources to start all
-                  tasks, the scheduler will not start anyone.
+                  tasks, the scheduler will not start any.
                 format: int32
                 type: integer
               minResources:
@@ -54,7 +54,7 @@ spec:
                   x-kubernetes-int-or-string: true
                 description: MinResources defines the minimal resource of members/tasks
                   to run the pod group; if there's not enough resources to start all
-                  tasks, the scheduler will not start anyone.
+                  tasks, the scheduler will not start any.
                 type: object
               scheduleTimeoutSeconds:
                 description: ScheduleTimeoutSeconds defines the maximal time of members/tasks

--- a/kep/42-podgroup-coscheduling/README.md
+++ b/kep/42-podgroup-coscheduling/README.md
@@ -41,12 +41,12 @@ We define a CRD name PodGroup to help schedule, its definition is as follows:
 type PodGroupSpec struct {
 	// MinMember defines the minimal number of members/tasks to run the pod group;
 	// if there's not enough resources to start all tasks, the scheduler
-	// will not start anyone.
+	// will not start any.
 	MinMember uint32 `json:"minMember"`
 
 	// MinResources defines the minimal resource of members/tasks to run the pod group;
 	// if there's not enough resources to start all tasks, the scheduler
-	// will not start anyone.
+	// will not start any.
 	MinResources *v1.ResourceList `json:"minResources,omitempty"`
 
 	// ScheduleTimeoutSeconds defines the maximal time of members/tasks to wait before run the pod group;

--- a/manifests/coscheduling/crd.yaml
+++ b/manifests/coscheduling/crd.yaml
@@ -42,7 +42,7 @@ spec:
               minMember:
                 description: MinMember defines the minimal number of members/tasks
                   to run the pod group; if there's not enough resources to start all
-                  tasks, the scheduler will not start anyone.
+                  tasks, the scheduler will not start any.
                 format: int32
                 type: integer
               minResources:
@@ -54,7 +54,7 @@ spec:
                   x-kubernetes-int-or-string: true
                 description: MinResources defines the minimal resource of members/tasks
                   to run the pod group; if there's not enough resources to start all
-                  tasks, the scheduler will not start anyone.
+                  tasks, the scheduler will not start any.
                 type: object
               scheduleTimeoutSeconds:
                 description: ScheduleTimeoutSeconds defines the maximal time of members/tasks

--- a/site/content/en/docs/kep/42-podgroup-coscheduling/README.md
+++ b/site/content/en/docs/kep/42-podgroup-coscheduling/README.md
@@ -45,12 +45,12 @@ We define a CRD name PodGroup to help schedule, its definition is as follows:
 type PodGroupSpec struct {
 	// MinMember defines the minimal number of members/tasks to run the pod group;
 	// if there's not enough resources to start all tasks, the scheduler
-	// will not start anyone.
+	// will not start any.
 	MinMember uint32 `json:"minMember"`
 
 	// MinResources defines the minimal resource of members/tasks to run the pod group;
 	// if there's not enough resources to start all tasks, the scheduler
-	// will not start anyone.
+	// will not start any.
 	MinResources *v1.ResourceList `json:"minResources,omitempty"`
 
 	// ScheduleTimeoutSeconds defines the maximal time of members/tasks to wait before run the pod group;


### PR DESCRIPTION
Problem: the comment and associated docs should say if there are not resources available needed for the group, the scheduler should not start any.

Solution: update all references anyone->any.

It could also be stated "not start any one" but "not start any" is a more natural way to say it

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

It's a subtle word choice mistake.

#### Which issue(s) this PR fixes:

None - did not open an issue for something so small.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
