### PR TITLE
Add ARG for base image customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ RELEASE_REGISTRY?=gcr.io/k8s-staging-scheduler-plugins
 RELEASE_VERSION?=v$(shell date +%Y%m%d)-$(shell git describe --tags --match "v*")
 RELEASE_IMAGE:=kube-scheduler:$(RELEASE_VERSION)
 RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
+GO_BASE_IMAGE?=golang
 
 # VERSION is the scheduler's version
 #
@@ -80,6 +81,8 @@ release-image.amd64: clean
 	REGISTRY=$(RELEASE_REGISTRY) \
 	IMAGE=$(RELEASE_IMAGE)-amd64 \
 	CONTROLLER_IMAGE=$(RELEASE_CONTROLLER_IMAGE)-amd64 \
+	GO_BASE_IMAGE=$(GO_BASE_IMAGE) \
+	ALPINE_BASE_IMAGE=$(ALPINE_BASE_IMAGE) \
 	hack/build-images.sh
 
 .PHONY: release-image.arm64v8
@@ -89,6 +92,8 @@ release-image.arm64v8: clean
 	REGISTRY=$(RELEASE_REGISTRY) \
 	IMAGE=$(RELEASE_IMAGE)-arm64 \
 	CONTROLLER_IMAGE=$(RELEASE_CONTROLLER_IMAGE)-arm64 \
+	GO_BASE_IMAGE=$(GO_BASE_IMAGE) \
+	ALPINE_BASE_IMAGE=$(ALPINE_BASE_IMAGE) \
 	hack/build-images.sh
 
 .PHONY: push-release-images

--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.20
+ARG GO_BASE_IMAGE=golang
+ARG ALPINE_BASE_IMAGE=$ARCH/alpine
+FROM $GO_BASE_IMAGE:1.21
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
 ARG ARCH
 RUN make build-controller.$ARCH
 
-FROM $ARCH/alpine:3.16
+FROM $ALPINE_BASE_IMAGE:3.16
 
 COPY --from=0 /go/src/sigs.k8s.io/scheduler-plugins/bin/controller /bin/controller
 

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.20
+ARG GO_BASE_IMAGE=golang
+ARG ALPINE_BASE_IMAGE=$ARCH/alpine
+FROM $GO_BASE_IMAGE:1.21
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
@@ -20,7 +22,7 @@ ARG ARCH
 ARG RELEASE_VERSION
 RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler.$ARCH
 
-FROM $ARCH/alpine:3.16
+FROM $ALPINE_BASE_IMAGE:3.16
 
 COPY --from=0 /go/src/sigs.k8s.io/scheduler-plugins/bin/kube-scheduler /bin/kube-scheduler
 

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -26,7 +26,6 @@ CONTROLLER_DIR="${SCRIPT_ROOT}"/build/controller
 REGISTRY=${REGISTRY:-"localhost:5000/scheduler-plugins"}
 IMAGE=${IMAGE:-"kube-scheduler:latest"}
 CONTROLLER_IMAGE=${CONTROLLER_IMAGE:-"controller:latest"}
-
 RELEASE_VERSION=${RELEASE_VERSION:-"v0.0.0"}
 
 BUILDER=${BUILDER:-"docker"}
@@ -40,15 +39,22 @@ if [[ "${ARCH}" == "arm64" ]]; then
   ARCH="arm64v8"
 fi
 
+GO_BASE_IMAGE=${GO_BASE_IMAGE:-"golang"}
+ALPINE_BASE_IMAGE=${ALPINE_BASE_IMAGE:-"$ARCH/alpine"}
+
 cd "${SCRIPT_ROOT}"
 
 ${BUILDER} build \
            -f ${SCHEDULER_DIR}/Dockerfile \
            --build-arg ARCH=${ARCH} \
            --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+           --build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
+           --build-arg ALPINE_BASE_IMAGE=${ALPINE_BASE_IMAGE} \
            -t ${REGISTRY}/${IMAGE} .
 ${BUILDER} build \
            -f ${CONTROLLER_DIR}/Dockerfile \
            --build-arg ARCH=${ARCH} \
            --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+           --build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
+           --build-arg ALPINE_BASE_IMAGE=${ALPINE_BASE_IMAGE} \
            -t ${REGISTRY}/${CONTROLLER_IMAGE} .


### PR DESCRIPTION
Add ARG to define the base image parameters so a downstream pipeline can override which the base golang image to use when building container images.