### PR TITLE
replace deprecated method

### DIFF
--- a/pkg/controllers/elasticquota_controller_test.go
+++ b/pkg/controllers/elasticquota_controller_test.go
@@ -203,8 +203,7 @@ func TestElasticQuotaController_Run(t *testing.T) {
 					t.Errorf("reconcile: (%v)", err)
 				}
 			}
-
-			err := wait.Poll(200*time.Millisecond, 1*time.Second, func() (done bool, err error) {
+			err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 1*time.Second, false, func(ctx context.Context) (done bool, err error) {
 				for _, v := range c.want {
 					eq := &v1alpha1.ElasticQuota{
 						ObjectMeta: metav1.ObjectMeta{

--- a/pkg/networkaware/networkoverhead/networkoverhead_test.go
+++ b/pkg/networkaware/networkoverhead/networkoverhead_test.go
@@ -549,7 +549,7 @@ func BenchmarkNetworkOverheadPreFilter(b *testing.B) {
 			state := framework.NewCycleState()
 
 			// Wait for the pods to be scheduled.
-			if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 				return true, nil
 			}); err != nil {
 				b.Errorf("pods not scheduled yet: %v ", err)
@@ -767,7 +767,7 @@ func TestNetworkOverheadScore(t *testing.T) {
 			}
 
 			// Wait for the pods to be scheduled.
-			if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 				return true, nil
 			}); err != nil {
 				t.Errorf("pods not scheduled yet: %v ", err)
@@ -1016,7 +1016,7 @@ func BenchmarkNetworkOverheadScore(b *testing.B) {
 			state := framework.NewCycleState()
 
 			// Wait for the pods to be scheduled.
-			if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 				return true, nil
 			}); err != nil {
 				b.Errorf("pods not scheduled yet: %v ", err)
@@ -1245,7 +1245,7 @@ func TestNetworkOverheadFilter(t *testing.T) {
 			}
 
 			// Wait for the pods to be scheduled.
-			if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 				return true, nil
 			}); err != nil {
 				t.Errorf("pods not scheduled yet: %v ", err)
@@ -1471,7 +1471,7 @@ func BenchmarkNetworkOverheadFilter(b *testing.B) {
 			}
 
 			// Wait for the pods to be scheduled.
-			if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 				return true, nil
 			}); err != nil {
 				b.Errorf("pods not scheduled yet: %v ", err)

--- a/test/integration/allocatable_test.go
+++ b/test/integration/allocatable_test.go
@@ -134,7 +134,7 @@ func TestAllocatablePlugin(t *testing.T) {
 
 	for i := range pods {
 		// Wait for the pod to be scheduled.
-		err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 			return podScheduled(cs, pods[i].Namespace, pods[i].Name), nil
 		})
 		if err != nil {

--- a/test/integration/capacity_scheduling_test.go
+++ b/test/integration/capacity_scheduling_test.go
@@ -48,7 +48,7 @@ func TestCapacityScheduling(t *testing.T) {
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -522,7 +522,7 @@ func TestCapacityScheduling(t *testing.T) {
 				}
 			}
 
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, pod := range tt.existPods {
 					if !podScheduled(cs, pod.Namespace, pod.Name) {
 						return false, nil
@@ -541,7 +541,7 @@ func TestCapacityScheduling(t *testing.T) {
 				}
 			}
 
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.expectedPods {
 					if !podScheduled(cs, v.Namespace, v.Name) {
 						return false, nil

--- a/test/integration/coscheduling_test.go
+++ b/test/integration/coscheduling_test.go
@@ -53,7 +53,7 @@ func TestCoschedulingPlugin(t *testing.T) {
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -361,7 +361,7 @@ func TestCoschedulingPlugin(t *testing.T) {
 					t.Fatalf("Failed to create Pod %q: %v", tt.pods[i].Name, err)
 				}
 			}
-			err = wait.Poll(1*time.Second, 120*time.Second, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.expectedPods {
 					if !podScheduled(cs, ns, v) {
 						return false, nil
@@ -386,7 +386,7 @@ func TestPodgroupBackoff(t *testing.T) {
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -539,7 +539,7 @@ func TestPodgroupBackoff(t *testing.T) {
 					t.Fatalf("Failed to create Pod %q: %v", tt.pods[i].Name, err)
 				}
 			}
-			err = wait.Poll(1*time.Second, 120*time.Second, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.expectedPods {
 					if !podScheduled(cs, ns, v) {
 						return false, nil

--- a/test/integration/elasticquota_controller_test.go
+++ b/test/integration/elasticquota_controller_test.go
@@ -78,7 +78,7 @@ func TestElasticController(t *testing.T) {
 		}
 	}()
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -301,7 +301,7 @@ func TestElasticController(t *testing.T) {
 					}
 				}
 			}
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, pod := range tt.incomingPods {
 					if !podScheduled(cs, pod.Namespace, pod.Name) {
 						return false, nil
@@ -312,10 +312,10 @@ func TestElasticController(t *testing.T) {
 				t.Fatalf("%v Waiting existPods created error: %v", tt.name, err.Error())
 			}
 
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.used {
 					var eq schedv1alpha1.ElasticQuota
-					if err := extClient.Get(testCtx.Ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &eq); err != nil {
+					if err := extClient.Get(ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &eq); err != nil {
 						// This could be a connection error so we want to retry.
 						klog.ErrorS(err, "Failed to obtain the elasticQuota clientSet")
 						return false, err
@@ -335,7 +335,7 @@ func TestElasticController(t *testing.T) {
 					t.Fatalf("Failed to update Pod status %q: %v", pod.Name, err)
 				}
 			}
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, pod := range tt.incomingPods {
 					if !podScheduled(cs, pod.Namespace, pod.Name) {
 						return false, nil
@@ -346,10 +346,10 @@ func TestElasticController(t *testing.T) {
 				t.Fatalf("%v Waiting nextPods update status error: %v", tt.name, err.Error())
 			}
 
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.want {
 					var eq schedv1alpha1.ElasticQuota
-					if err := extClient.Get(testCtx.Ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &eq); err != nil {
+					if err := extClient.Get(ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &eq); err != nil {
 						// This could be a connection error so we want to retry.
 						klog.ErrorS(err, "Failed to obtain the elasticQuota clientSet")
 						return false, err

--- a/test/integration/loadVariationRiskBalancing_test.go
+++ b/test/integration/loadVariationRiskBalancing_test.go
@@ -183,7 +183,7 @@ func TestLoadVariationRiskBalancingPlugin(t *testing.T) {
 
 	expected := [2]string{"node-1", "node-1"}
 	for i := range newPods {
-		err := wait.Poll(1*time.Second, 10*time.Second, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 			return podScheduled(cs, newPods[i].Namespace, newPods[i].Name), nil
 		})
 		assert.Nil(t, err)

--- a/test/integration/lowriskovercommitment_test.go
+++ b/test/integration/lowriskovercommitment_test.go
@@ -197,7 +197,7 @@ func TestLowRiskOverCommitmentPlugin(t *testing.T) {
 
 	expectedNodes := []string{"node-1"}
 	for i := numExistingPods; i < numPods; i++ {
-		err = wait.Poll(1*time.Second, 10*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 			return podScheduled(cs, pods[i].Namespace, pods[i].Name), nil
 		})
 		assert.Nil(t, err)

--- a/test/integration/networkoverhead_test.go
+++ b/test/integration/networkoverhead_test.go
@@ -65,7 +65,7 @@ func TestNetworkOverheadPlugin(t *testing.T) {
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -81,7 +81,7 @@ func TestNetworkOverheadPlugin(t *testing.T) {
 		t.Fatalf("Timed out waiting for AppGroup CRD to be ready: %v", err)
 	}
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -279,7 +279,7 @@ func TestNetworkOverheadPlugin(t *testing.T) {
 			for _, p := range tt.pods {
 				if len(tt.expectedNodes) > 0 {
 					// Wait for the pod to be scheduled.
-					if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 						return podScheduled(cs, ns, p.Name), nil
 
 					}); err != nil {

--- a/test/integration/noderesourcetopology_cache_test.go
+++ b/test/integration/noderesourcetopology_cache_test.go
@@ -889,9 +889,9 @@ func waitForPodList(cs clientset.Interface, podDescs []podDesc, timeout time.Dur
 			defer wg.Done()
 
 			var updatedPod *corev1.Pod
-			err := wait.Poll(5*time.Second, timeout, func() (bool, error) {
+			err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 				var nerr error
-				updatedPod, nerr = cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+				updatedPod, nerr = cs.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 				if nerr != nil {
 					klog.ErrorS(nerr, "Failed to get pod", "pod", klog.KRef(pod.Namespace, pod.Name))
 					return false, nerr

--- a/test/integration/noderesourcetopology_test.go
+++ b/test/integration/noderesourcetopology_test.go
@@ -144,7 +144,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -1984,7 +1984,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			for _, p := range tt.pods {
 				if len(tt.expectedNodes) > 0 {
 					// Wait for the pod to be scheduled.
-					if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 						return podScheduled(cs, ns, p.Name), nil
 
 					}); err != nil {
@@ -2008,7 +2008,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					// wait for the pod scheduling to failed.
 					var err error
 					var events []v1.Event
-					if err := wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 5*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 						events, err = getPodEvents(cs, ns, p.Name)
 						if err != nil {
 							// This could be a connection error, so we want to retry.

--- a/test/integration/nrtutils.go
+++ b/test/integration/nrtutils.go
@@ -50,7 +50,7 @@ const (
 )
 
 func waitForNRT(cs *clientset.Clientset) error {
-	return wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -205,8 +205,8 @@ func (n *nrtWrapper) Obj() *topologyv1alpha2.NodeResourceTopology {
 func podIsScheduled(interval time.Duration, times int, cs clientset.Interface, podNamespace, podName string) (*corev1.Pod, error) {
 	var err error
 	var pod *corev1.Pod
-	waitErr := wait.Poll(interval, time.Duration(times)*interval, func() (bool, error) {
-		pod, err = cs.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	waitErr := wait.PollUntilContextTimeout(context.TODO(), interval, time.Duration(times)*interval, false, func(ctx context.Context) (bool, error) {
+		pod, err = cs.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			klog.ErrorS(err, "Failed to get pod", "pod", klog.KRef(podNamespace, podName))

--- a/test/integration/pod_state_test.go
+++ b/test/integration/pod_state_test.go
@@ -128,7 +128,7 @@ func TestPodStatePlugin(t *testing.T) {
 				pods = append(pods, p)
 
 				// Ensure the existing Pods are scheduled successfully except for the nominated pods.
-				if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
+				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 					return podScheduled(cs, ns, pod.Name), nil
 				}); err != nil {
 					t.Logf("pod %q failed to be scheduled", pod.Name)
@@ -151,7 +151,7 @@ func TestPodStatePlugin(t *testing.T) {
 			defer cleanupPods(t, testCtx, []*v1.Pod{p})
 
 			// Ensure the Pod is scheduled successfully.
-			if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 				return podScheduled(cs, ns, tt.pod.Name), nil
 			}); err != nil {
 				t.Errorf("pod %q failed to be scheduled: %v", tt.pod.Name, err)

--- a/test/integration/podgroup_controller_test.go
+++ b/test/integration/podgroup_controller_test.go
@@ -83,7 +83,7 @@ func TestPodGroupController(t *testing.T) {
 		}
 	}()
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -291,7 +291,7 @@ func TestPodGroupController(t *testing.T) {
 					}
 				}
 			}
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, pod := range tt.incomingPods {
 					if !podScheduled(cs, ns, pod.Name) {
 						return false, nil
@@ -302,10 +302,10 @@ func TestPodGroupController(t *testing.T) {
 				t.Fatalf("%v Waiting existPods create error: %v", tt.name, err.Error())
 			}
 
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.intermediatePGState {
 					var pg v1alpha1.PodGroup
-					if err := extClient.Get(testCtx.Ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &pg); err != nil {
+					if err := extClient.Get(ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &pg); err != nil {
 						// This could be a connection error so we want to retry.
 						klog.ErrorS(err, "Failed to obtain the PodGroup clientSet")
 						return false, err
@@ -327,7 +327,7 @@ func TestPodGroupController(t *testing.T) {
 				}
 			}
 			// wait for all incomingPods to be scheduled
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, pod := range tt.incomingPods {
 					if !podScheduled(cs, pod.Namespace, pod.Name) {
 						return false, nil
@@ -338,10 +338,10 @@ func TestPodGroupController(t *testing.T) {
 				t.Fatalf("%v Waiting incomingPods scheduled error: %v", tt.name, err.Error())
 			}
 
-			if err := wait.Poll(time.Millisecond*200, 10*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.expectedPGState {
 					var pg v1alpha1.PodGroup
-					if err := extClient.Get(testCtx.Ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &pg); err != nil {
+					if err := extClient.Get(ctx, types.NamespacedName{Namespace: v.Namespace, Name: v.Name}, &pg); err != nil {
 						// This could be a connection error so we want to retry.
 						klog.ErrorS(err, "Failed to obtain the PodGroup clientSet")
 						return false, err

--- a/test/integration/preemption_toleration_test.go
+++ b/test/integration/preemption_toleration_test.go
@@ -216,14 +216,14 @@ func TestPreemptionTolerationPlugin(t *testing.T) {
 			if victimCandidate, err = cs.CoreV1().Pods(ns).Create(testCtx.Ctx, victimCandidate, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("failed to create victim candidate pod %q: %v", victimCandidate.Name, err)
 			}
-			if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 				return podScheduled(cs, ns, victimCandidate.Name), nil
 			}); err != nil {
 				t.Fatalf("victim candidate pod %q failed to be scheduled: %v", victimCandidate.Name, err)
 			}
 			// simulate pod scheduled time
-			if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
-				vc, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, victimCandidate.Name, metav1.GetOptions{})
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+				vc, err := cs.CoreV1().Pods(ns).Get(ctx, victimCandidate.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}
@@ -266,7 +266,7 @@ func TestPreemptionTolerationPlugin(t *testing.T) {
 			} else {
 				// - the preemptor pod got scheduled successfully
 				// - the victim pod does not exist (preempted)
-				if err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 					return podScheduled(cs, ns, tt.preemptor.Name) && util.PodNotExist(cs, ns, victimCandidate.Name), nil
 				}); err != nil {
 					t.Fatalf("preemptor pod %q failed to be scheduled: %v", tt.preemptor.Name, err)

--- a/test/integration/qos_test.go
+++ b/test/integration/qos_test.go
@@ -124,7 +124,7 @@ func TestQOSPlugin(t *testing.T) {
 	defer cleanupPods(t, testCtx, pods)
 
 	// Wait for all Pods are in the scheduling queue.
-	err = wait.Poll(time.Millisecond*200, wait.ForeverTestTimeout, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
 		if len(pendingPods) == len(pods) {
 			return true, nil

--- a/test/integration/sysched_test.go
+++ b/test/integration/sysched_test.go
@@ -143,7 +143,7 @@ func TestSyschedPlugin(t *testing.T) {
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -253,7 +253,7 @@ func TestSyschedPlugin(t *testing.T) {
 			t.Fatalf("Failed to create Pod %q: %v", pods[i].Name, err)
 		}
 		// Wait for all Pods to be scheduled.
-		err = wait.Poll(time.Millisecond*20, wait.ForeverTestTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*20, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 			if !podScheduled(cs, pods[i].Namespace, pods[i].Name) {
 				return false, nil
 			}

--- a/test/integration/targetloadpacking_test.go
+++ b/test/integration/targetloadpacking_test.go
@@ -176,7 +176,7 @@ func TestTargetNodePackingPlugin(t *testing.T) {
 
 	expected := [2]string{nodeNames[0], nodeNames[0]}
 	for i := range newPods {
-		err := wait.Poll(1*time.Second, 10*time.Second, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 			return podScheduled(cs, newPods[i].Namespace, newPods[i].Name), nil
 		})
 		assert.Nil(t, err)

--- a/test/integration/topologicalsort_test.go
+++ b/test/integration/topologicalsort_test.go
@@ -64,7 +64,7 @@ func TestTopologicalSortPlugin(t *testing.T) {
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig
 
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {
 			return false, nil
@@ -372,7 +372,7 @@ func TestTopologicalSortPlugin(t *testing.T) {
 
 			// Wait for all Pods are in the scheduling queue.
 			t.Logf("Step 3 -  Wait for pods being in the scheduling queue....")
-			err = wait.Poll(time.Millisecond*200, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
 				if len(pendingPods) == len(tt.pods) {
 					return true, nil

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -226,16 +226,16 @@ func cleanupPods(t *testing.T, testCtx *testContext, pods []*v1.Pod) {
 		}
 	}
 	for _, p := range pods {
-		if err := wait.Poll(time.Millisecond, wait.ForeverTestTimeout,
+		if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond, wait.ForeverTestTimeout, false,
 			podDeleted(testCtx.ClientSet, p.Namespace, p.Name)); err != nil {
 			t.Errorf("error while waiting for pod  %s/%s to get deleted: %v", p.Namespace, p.Name, err)
 		}
 	}
 }
 
-func podDeleted(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		_, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func podDeleted(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		_, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`Poll` method has been deprecated in favor of `PollUntilContextTimeout`.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes-sigs/scheduler-plugins/issues/734#event-12776086054

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
