### PR TITLE
Add support for ppc64le and s390x architectures and distroless builds

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -11,17 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG ARCH
 ARG GO_BASE_IMAGE=golang
-ARG ALPINE_BASE_IMAGE=$ARCH/alpine
+ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
 FROM $GO_BASE_IMAGE:1.21
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
-ARG ARCH
-RUN make build-controller.$ARCH
+RUN make build-controller
 
-FROM $ALPINE_BASE_IMAGE:3.16
+FROM $DISTROLESS_BASE_IMAGE
 
 COPY --from=0 /go/src/sigs.k8s.io/scheduler-plugins/bin/controller /bin/controller
 

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -11,18 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG ARCH
 ARG GO_BASE_IMAGE=golang
-ARG ALPINE_BASE_IMAGE=$ARCH/alpine
+ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
 FROM $GO_BASE_IMAGE:1.21
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
-ARG ARCH
 ARG RELEASE_VERSION
-RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler.$ARCH
+RUN RELEASE_VERSION=${RELEASE_VERSION} make build-scheduler
 
-FROM $ALPINE_BASE_IMAGE:3.16
+FROM $DISTROLESS_BASE_IMAGE
 
 COPY --from=0 /go/src/sigs.k8s.io/scheduler-plugins/bin/kube-scheduler /bin/kube-scheduler
 

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -26,35 +26,41 @@ CONTROLLER_DIR="${SCRIPT_ROOT}"/build/controller
 REGISTRY=${REGISTRY:-"localhost:5000/scheduler-plugins"}
 IMAGE=${IMAGE:-"kube-scheduler:latest"}
 CONTROLLER_IMAGE=${CONTROLLER_IMAGE:-"controller:latest"}
+
 RELEASE_VERSION=${RELEASE_VERSION:-"v0.0.0"}
 
 BUILDER=${BUILDER:-"docker"}
 
+GO_BASE_IMAGE=${GO_BASE_IMAGE:-"golang"}
+DISTROLESS_BASE_IMAGE=${DISTROLESS_BASE_IMAGE:-"gcr.io/distroless/static:nonroot"}
+
+# -t is the Docker engine default
+TAG_FLAG="-t"
+
+# nerdctl doesn't seem to have buildx
 if ! command -v ${BUILDER} && command -v nerdctl >/dev/null; then
   BUILDER=nerdctl
 fi
 
-ARCH=${ARCH:-$(go env GOARCH)}
-if [[ "${ARCH}" == "arm64" ]]; then
-  ARCH="arm64v8"
+# podman needs the manifest flag in order to create a single image.
+if [[ "${BUILDER}" == "podman" ]]
+then
+  TAG_FLAG="--manifest"
 fi
 
-GO_BASE_IMAGE=${GO_BASE_IMAGE:-"golang"}
-ALPINE_BASE_IMAGE=${ALPINE_BASE_IMAGE:-"$ARCH/alpine"}
-
 cd "${SCRIPT_ROOT}"
+${BUILDER} buildx build \
+            --platform=${PLATFORMS} \
+            -f ${SCHEDULER_DIR}/Dockerfile \
+            --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+            --build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
+            --build-arg DISTROLESS_BASE_IMAGE=${DISTROLESS_BASE_IMAGE} \
+            ${TAG_FLAG} ${REGISTRY}/${IMAGE} .
 
-${BUILDER} build \
-           -f ${SCHEDULER_DIR}/Dockerfile \
-           --build-arg ARCH=${ARCH} \
-           --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
-           --build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
-           --build-arg ALPINE_BASE_IMAGE=${ALPINE_BASE_IMAGE} \
-           -t ${REGISTRY}/${IMAGE} .
-${BUILDER} build \
-           -f ${CONTROLLER_DIR}/Dockerfile \
-           --build-arg ARCH=${ARCH} \
-           --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
-           --build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
-           --build-arg ALPINE_BASE_IMAGE=${ALPINE_BASE_IMAGE} \
-           -t ${REGISTRY}/${CONTROLLER_IMAGE} .
+${BUILDER} buildx build \
+            --platform=${PLATFORMS} \
+            -f ${CONTROLLER_DIR}/Dockerfile \
+            --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+            --build-arg GO_BASE_IMAGE=${GO_BASE_IMAGE} \
+            --build-arg DISTROLESS_BASE_IMAGE=${DISTROLESS_BASE_IMAGE} \
+            ${TAG_FLAG} ${REGISTRY}/${CONTROLLER_IMAGE} .


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Kubernetes supports multiple architectures - amd64 arm arm64 ppc64le s390x. In order to use scheduler plugins on ppc64le or s390x, I'd like to build the scheduler-plugins container image with support for s390x and ppc64le in the sig.

This would be in addition to the already provided x86_64,arm64 container image.
This request is similar to https://github.com/kubernetes-sigs/scheduler-plugins/issues/113

#### Which issue(s) this PR fixes:
Fixes #745 

#### Special notes for your reviewer:
We are using the scheduler-plugins on multiple-architectures.

#### Does this PR introduce a user-facing change?
```release-note
adds container images for the  ppc64le and s390x
```
