### PR TITLE
solve struct literal uses unkeyed fields

### DIFF
--- a/pkg/networkaware/networkoverhead/networkoverhead_test.go
+++ b/pkg/networkaware/networkoverhead/networkoverhead_test.go
@@ -286,8 +286,8 @@ func GetAppGroupCROnlineBoutique() *agv1alpha1.AppGroup {
 			},
 		},
 		Status: agv1alpha1.AppGroupStatus{
-			ScheduleStartTime:       metav1.Time{time.Now()},
-			TopologyCalculationTime: metav1.Time{time.Now()},
+			ScheduleStartTime:       metav1.Time{Time: time.Now()},
+			TopologyCalculationTime: metav1.Time{Time: time.Now()},
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p10-deployment", Selector: "p10", APIVersion: "apps/v1", Namespace: "default"}, Index: 2},
@@ -331,7 +331,7 @@ func GetAppGroupCRBasic() *agv1alpha1.AppGroup {
 		},
 		Status: agv1alpha1.AppGroupStatus{
 			RunningWorkloads:  3,
-			ScheduleStartTime: metav1.Time{time.Now()}, TopologyCalculationTime: metav1.Time{time.Now()},
+			ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{
 					Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},

--- a/pkg/networkaware/networkoverhead/networkoverhead_test.go
+++ b/pkg/networkaware/networkoverhead/networkoverhead_test.go
@@ -286,8 +286,8 @@ func GetAppGroupCROnlineBoutique() *agv1alpha1.AppGroup {
 			},
 		},
 		Status: agv1alpha1.AppGroupStatus{
-			ScheduleStartTime:       metav1.Time{Time: time.Now()},
-			TopologyCalculationTime: metav1.Time{Time: time.Now()},
+			ScheduleStartTime:       metav1.Now(),
+			TopologyCalculationTime: metav1.Now(),
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p10-deployment", Selector: "p10", APIVersion: "apps/v1", Namespace: "default"}, Index: 2},
@@ -330,8 +330,9 @@ func GetAppGroupCRBasic() *agv1alpha1.AppGroup {
 			},
 		},
 		Status: agv1alpha1.AppGroupStatus{
-			RunningWorkloads:  3,
-			ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
+			RunningWorkloads:        3,
+			ScheduleStartTime:       metav1.Now(),
+			TopologyCalculationTime: metav1.Now(),
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{
 					Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},

--- a/pkg/networkaware/topologicalsort/topologicalsort_test.go
+++ b/pkg/networkaware/topologicalsort/topologicalsort_test.go
@@ -105,8 +105,8 @@ func GetAppGroupCROnlineBoutique() *agv1alpha1.AppGroup {
 			},
 		},
 		Status: agv1alpha1.AppGroupStatus{
-			ScheduleStartTime:       metav1.Time{time.Now()},
-			TopologyCalculationTime: metav1.Time{time.Now()},
+			ScheduleStartTime:       metav1.Time{Time: time.Now()},
+			TopologyCalculationTime: metav1.Time{Time: time.Now()},
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p10-deployment", Selector: "p10", APIVersion: "apps/v1", Namespace: "default"}, Index: 2},
@@ -146,7 +146,7 @@ func GetAppGroupCRBasic() *agv1alpha1.AppGroup {
 		},
 		Status: agv1alpha1.AppGroupStatus{
 			RunningWorkloads:  3,
-			ScheduleStartTime: metav1.Time{time.Now()}, TopologyCalculationTime: metav1.Time{time.Now()},
+			ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{
 					Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},

--- a/pkg/networkaware/topologicalsort/topologicalsort_test.go
+++ b/pkg/networkaware/topologicalsort/topologicalsort_test.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"sort"
 	"testing"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,8 +104,8 @@ func GetAppGroupCROnlineBoutique() *agv1alpha1.AppGroup {
 			},
 		},
 		Status: agv1alpha1.AppGroupStatus{
-			ScheduleStartTime:       metav1.Time{Time: time.Now()},
-			TopologyCalculationTime: metav1.Time{Time: time.Now()},
+			ScheduleStartTime:       metav1.Now(),
+			TopologyCalculationTime: metav1.Now(),
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
 				agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p10-deployment", Selector: "p10", APIVersion: "apps/v1", Namespace: "default"}, Index: 2},
@@ -145,8 +144,9 @@ func GetAppGroupCRBasic() *agv1alpha1.AppGroup {
 			},
 		},
 		Status: agv1alpha1.AppGroupStatus{
-			RunningWorkloads:  3,
-			ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
+			RunningWorkloads:        3,
+			ScheduleStartTime:       metav1.Now(),
+			TopologyCalculationTime: metav1.Now(),
 			TopologyOrder: agv1alpha1.AppGroupTopologyList{
 				agv1alpha1.AppGroupTopologyInfo{
 					Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1-deployment", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},

--- a/test/integration/networkoverhead_test.go
+++ b/test/integration/networkoverhead_test.go
@@ -181,8 +181,9 @@ func TestNetworkOverheadPlugin(t *testing.T) {
 			},
 		},
 	).Status(agv1alpha1.AppGroupStatus{
-		RunningWorkloads:  3,
-		ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
+		RunningWorkloads:        3,
+		ScheduleStartTime:       metav1.Now(),
+		TopologyCalculationTime: metav1.Now(),
 		TopologyOrder: agv1alpha1.AppGroupTopologyList{
 			agv1alpha1.AppGroupTopologyInfo{
 				Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},

--- a/test/integration/networkoverhead_test.go
+++ b/test/integration/networkoverhead_test.go
@@ -182,7 +182,7 @@ func TestNetworkOverheadPlugin(t *testing.T) {
 		},
 	).Status(agv1alpha1.AppGroupStatus{
 		RunningWorkloads:  3,
-		ScheduleStartTime: metav1.Time{time.Now()}, TopologyCalculationTime: metav1.Time{time.Now()},
+		ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
 		TopologyOrder: agv1alpha1.AppGroupTopologyList{
 			agv1alpha1.AppGroupTopologyInfo{
 				Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},

--- a/test/integration/topologicalsort_test.go
+++ b/test/integration/topologicalsort_test.go
@@ -145,7 +145,7 @@ func TestTopologicalSortPlugin(t *testing.T) {
 		},
 	).Status(agv1alpha1.AppGroupStatus{
 		RunningWorkloads:  3,
-		ScheduleStartTime: metav1.Time{time.Now()}, TopologyCalculationTime: metav1.Time{time.Now()},
+		ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
 		TopologyOrder: agv1alpha1.AppGroupTopologyList{
 			agv1alpha1.AppGroupTopologyInfo{
 				Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
@@ -222,7 +222,7 @@ func TestTopologicalSortPlugin(t *testing.T) {
 		},
 	).Status(agv1alpha1.AppGroupStatus{
 		RunningWorkloads:  3,
-		ScheduleStartTime: metav1.Time{time.Now()}, TopologyCalculationTime: metav1.Time{time.Now()},
+		ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
 		TopologyOrder: agv1alpha1.AppGroupTopologyList{
 			agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
 			agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p10", Selector: "p10", APIVersion: "apps/v1", Namespace: "default"}, Index: 2},

--- a/test/integration/topologicalsort_test.go
+++ b/test/integration/topologicalsort_test.go
@@ -144,8 +144,9 @@ func TestTopologicalSortPlugin(t *testing.T) {
 			},
 		},
 	).Status(agv1alpha1.AppGroupStatus{
-		RunningWorkloads:  3,
-		ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
+		RunningWorkloads:        3,
+		ScheduleStartTime:       metav1.Now(),
+		TopologyCalculationTime: metav1.Now(),
 		TopologyOrder: agv1alpha1.AppGroupTopologyList{
 			agv1alpha1.AppGroupTopologyInfo{
 				Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
@@ -221,8 +222,9 @@ func TestTopologicalSortPlugin(t *testing.T) {
 			},
 		},
 	).Status(agv1alpha1.AppGroupStatus{
-		RunningWorkloads:  3,
-		ScheduleStartTime: metav1.Time{Time: time.Now()}, TopologyCalculationTime: metav1.Time{Time: time.Now()},
+		RunningWorkloads:        3,
+		ScheduleStartTime:       metav1.Now(),
+		TopologyCalculationTime: metav1.Now(),
 		TopologyOrder: agv1alpha1.AppGroupTopologyList{
 			agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p1", Selector: "p1", APIVersion: "apps/v1", Namespace: "default"}, Index: 1},
 			agv1alpha1.AppGroupTopologyInfo{Workload: agv1alpha1.AppGroupWorkloadInfo{Kind: "Deployment", Name: "p10", Selector: "p10", APIVersion: "apps/v1", Namespace: "default"}, Index: 2},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 - solve complaints of `struct literal uses unkeyed fields` when go vet.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE

```release-note

```
