### PR TITLE
fix: add validation for pggroup

### DIFF
--- a/apis/scheduling/v1alpha1/types.go
+++ b/apis/scheduling/v1alpha1/types.go
@@ -146,6 +146,8 @@ type PodGroupSpec struct {
 	// MinMember defines the minimal number of members/tasks to run the pod group;
 	// if there's not enough resources to start all tasks, the scheduler
 	// will not start any.
+	// The minimum is 1
+	// +kubebuilder:validation:Minimum=1
 	MinMember int32 `json:"minMember,omitempty"`
 
 	// MinResources defines the minimal resource of members/tasks to run the pod group;

--- a/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
+++ b/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
@@ -74,7 +74,9 @@ spec:
                   MinMember defines the minimal number of members/tasks to run the pod group;
                   if there's not enough resources to start all tasks, the scheduler
                   will not start any.
+                  The minimum is 1
                 format: int32
+                minimum: 1
                 type: integer
               minResources:
                 additionalProperties:

--- a/manifests/coscheduling/crd.yaml
+++ b/manifests/coscheduling/crd.yaml
@@ -74,7 +74,9 @@ spec:
                   MinMember defines the minimal number of members/tasks to run the pod group;
                   if there's not enough resources to start all tasks, the scheduler
                   will not start any.
+                  The minimum is 1
                 format: int32
+                minimum: 1
                 type: integer
               minResources:
                 additionalProperties:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Avoid panic caused by podgroup Spec MinMember field being 0
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
refer to https://github.com/kubernetes-sigs/scheduler-plugins/pull/724

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
