### PR TITLE
Enable buildx in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,12 +7,14 @@ timeout: 2400s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
+  # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - RELEASE_VERSION=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
+    - DOCKER_BUILDX_CMD=/buildx-entrypoint
     args:
     - push-release-images
 substitutions:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression


#### What this PR does / why we need it:

When introducing distroless build, the cloud build failed with error `buildx` option not found.

#### Which issue(s) this PR fixes:
 
A follow-up of #746

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
