### PR TITLE
use high memory machine to speedup cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,7 @@ timeout: 3000s
 # or any new substitutions added in the future.
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
 steps:
   # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

We now build 4 platforms:

https://github.com/kubernetes-sigs/scheduler-plugins/blob/1c436c586f3772cc66e29cc7c2a83aa4a7ec63e9/Makefile#L20

in a distroless build. Which seems to be pretty slow and [constantly time out](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-scheduler-plugins-push-images/1816225617260056576):

```
#31 [linux/amd64 stage-0 4/4] RUN RELEASE_VERSION=v20240724-v0.28.8-71-g9ae8f214 make build-scheduler
#31 DONE 1290.7s
```

^ shows for one single platform, it takes 21.5 min.

This PR tries to pin a high memory machine for cloudbuild. Hope it works.

PS: this is inspired by https://github.com/kubernetes-sigs/kueue/pull/2303.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
