### PR TITLE
update helm chart index to include version 0.29.7

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -23,10 +23,12 @@ Quick start instructions for the setup and configuration of as-a-second-schedule
 
 #### Install chart using Helm v3.0+
 
+> 🆕 Starting v0.28, Helm charts are hosted on https://scheduler-plugins.sigs.k8s.io
+
 ```bash
 $ git clone git@github.com:kubernetes-sigs/scheduler-plugins.git
 $ cd scheduler-plugins/manifests/install/charts
-$ helm install scheduler-plugins as-a-second-scheduler/ --create-namespace --namespace scheduler-plugins
+$ helm install --repo https://scheduler-plugins.sigs.k8s.io scheduler-plugins scheduler-plugins
 ```
 
 #### Verify that scheduler and plugin-controller pod are running properly.

--- a/site/content/en/docs/user-guide/installing-the-chart.md
+++ b/site/content/en/docs/user-guide/installing-the-chart.md
@@ -26,12 +26,14 @@ Quick start instructions for the setup and configuration of as-a-second-schedule
 
 ### Installing the chart
 
+> 🆕 Starting v0.28, Helm charts are hosted on https://scheduler-plugins.sigs.k8s.io
+
 #### Install chart using Helm v3.0+
 
 ```bash
 $ git clone git@github.com:kubernetes-sigs/scheduler-plugins.git
 $ cd scheduler-plugins/manifests/install/charts
-$ helm install scheduler-plugins as-a-second-scheduler/ --create-namespace --namespace scheduler-plugins
+$ helm install --repo https://scheduler-plugins.sigs.k8s.io scheduler-plugins scheduler-plugins
 ```
 
 #### Verify that scheduler and plugin-controller pod are running properly.

--- a/site/static/index.yaml
+++ b/site/static/index.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 entries:
   scheduler-plugins:
   - apiVersion: v2
-    appVersion: 0.28.8
-    created: "2024-05-15T01:12:05.511605+08:00"
+    appVersion: 0.29.7
+    created: "2024-07-29T15:54:48.355364-07:00"
     description: deploy scheduler plugin as a second scheduler in cluster
-    digest: d6e8af47272a285fb2feb59b3aae9207750285d876504039e0cfd65f71ae5f9b
+    digest: 728fd4f18759fb8d154f3fb531d8bbc9488df8f58052a6427f9bf068769cab28
     name: scheduler-plugins
     type: application
     urls:
-    - https://github.com/kubernetes-sigs/scheduler-plugins/releases/download/v0.28.9/scheduler-plugins-0.28.9.tgz
-    version: 0.28.8
-generated: "2024-05-15T01:12:05.511057+08:00"
+    - https://scheduler-plugins.sigs.k8s.io/scheduler-plugins-0.29.7.tgz
+    version: 0.29.7
+generated: "2024-07-29T15:54:48.354857-07:00"


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The manual steps to update are as follows:

1. Wait for `release/v0.29.7` to be generated in [releases page](https://github.com/kubernetes-sigs/scheduler-plugins/releases)
2. Run `cd site/static` in scheduler-plugins folder locally
3. Run `wget https://github.com/kubernetes-sigs/scheduler-plugins/releases/download/v0.29.7/scheduler-plugins-0.29.7.tgz` to download the tgz file
4. Run `helm repo index . --merge index.yaml --url https://scheduler-plugins.sigs.k8s.io`
5. Remove `scheduler-plugins-0.29.7.tgz` and check-in `index.yaml`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #721

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Documented how to use Helm repo in README.
```
