### PR TITLE
use `/bin/kube-scheduler` and `/bin/controller` as the entrypoints of Dockerfiles

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -22,8 +22,8 @@ RUN make build-controller GO_BUILD_ENV='CGO_ENABLED=0 GOOS=linux GOARCH=${TARGET
 
 FROM --platform=${BUILDPLATFORM} $DISTROLESS_BASE_IMAGE
 
-WORKDIR /
+WORKDIR /bin
 COPY --from=builder /workspace/bin/controller .
 USER 65532:65532
 
-ENTRYPOINT ["/controller"]
+ENTRYPOINT ["/bin/controller"]

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -22,8 +22,8 @@ RUN make build-scheduler GO_BUILD_ENV='CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETA
 
 FROM --platform=${BUILDPLATFORM} $DISTROLESS_BASE_IMAGE
 
-WORKDIR /
+WORKDIR /bin
 COPY --from=builder /workspace/bin/kube-scheduler .
 USER 65532:65532
 
-ENTRYPOINT ["/kube-scheduler"]
+ENTRYPOINT ["/bin/kube-scheduler"]

--- a/manifests/appgroup/deploy-appgroup-controller.yaml
+++ b/manifests/appgroup/deploy-appgroup-controller.yaml
@@ -60,6 +60,4 @@ spec:
       containers:
         - name: appgroup-controller
           image: localhost:5000/appgroup-controller/controller:latest
-          command:
-            - /bin/controller
           imagePullPolicy: IfNotPresent

--- a/manifests/networktopology/deploy-networktopology-controller.yaml
+++ b/manifests/networktopology/deploy-networktopology-controller.yaml
@@ -69,6 +69,4 @@ spec:
       containers:
         - name: networktopology-controller
           image: localhost:5000/networktopology-controller/controller:latest
-          command:
-            - /bin/controller
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Revert entrypoints back to /bin/* to make the image backwards-compatible: https://kubernetes.slack.com/archives/C09TP78DV/p1723546975114219.

Will cherrypick this to release-1.29.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
