### PR TITLE
Ensure consistent casing in Dockerfiles

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 ARG GO_BASE_IMAGE
 ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
-FROM --platform=${BUILDPLATFORM} $GO_BASE_IMAGE as builder
+FROM --platform=${BUILDPLATFORM} $GO_BASE_IMAGE AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 ARG GO_BASE_IMAGE
 ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
-FROM --platform=${BUILDPLATFORM} $GO_BASE_IMAGE as builder
+FROM --platform=${BUILDPLATFORM} $GO_BASE_IMAGE AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
It will eliminate the warning we get from the incosistent casing of the "FROM" and "as" keywords
laying in the Dockerfiles when we use the Makefile to build the images.



