### PR TITLE
fix: fix wrong PreemptionToleration policy example

### DIFF
--- a/pkg/preemptiontoleration/README.md
+++ b/pkg/preemptiontoleration/README.md
@@ -39,10 +39,11 @@ Preemption toleration policy can be defined on each `PriorityClass` resource by 
 # Any pod P in this priority class can not be preempted (can tolerate preemption)
 # - by preemptor pods with priority < 10000 
 # - and if P is within 1h since being scheduled
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: toleration-policy-sample
-  annotation:
+  annotations:
     preemption-toleration.scheduling.x-k8s.io/minimum-preemptable-priority: "10000"
     preemption-toleration.scheduling.x-k8s.io/toleration-seconds: "3600"
 value: 8000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes the wrong PreemptionToleration policy example.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
