### PR TITLE
Allow specifying the scheduler container entrypoint in the helm chart

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -45,9 +45,10 @@ scheduler-plugins-scheduler    1/1     1            1           7s
 The following table lists the configurable parameters of the as-a-second-scheduler chart and their default values.
 
 | Parameter                 | Description                 | Default                                                                                         |
-|---------------------------|-----------------------------|-------------------------------------------------------------------------------------------------|
+| ------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------- |
 | `scheduler.name`          | Scheduler name              | `scheduler-plugins-scheduler`                                                                   |
 | `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.29.7`                                      |
+| `scheduler.command`       | Scheduler command           | `["/bin/kube-scheduler"]`                                                                       |
 | `scheduler.leaderElect`   | Scheduler leaderElection    | `false`                                                                                         |
 | `scheduler.replicaCount`  | Scheduler replicaCount      | `1`                                                                                             |
 | `scheduler.nodeSelector`  | Scheduler nodeSelector      | `{}`                                                                                            |

--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -50,7 +50,8 @@ spec:
     spec:
       serviceAccountName: {{ .Values.scheduler.name }}
       containers:
-      - args:
+      - command: {{- toYaml .Values.scheduler.command | nindent 8 }}
+        args:
         - --config=/etc/kubernetes/scheduler-config.yaml
         image: {{ .Values.scheduler.image }}
         imagePullPolicy: IfNotPresent

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -5,6 +5,8 @@
 scheduler:
   name: scheduler-plugins-scheduler
   image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.29.7
+  command:
+  - /bin/kube-scheduler
   replicaCount: 1
   leaderElect: false
   nodeSelector: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

The current chart template doesn't support the older kube-scheduler image which doesn't specify ENTRYPOINT in the image. This PR allows customizing the container entrypoint through the new `scheduler.command` value.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
