### PR TITLE
allow priorityClassName to be configured in Helm chart

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -44,23 +44,25 @@ scheduler-plugins-scheduler    1/1     1            1           7s
 
 The following table lists the configurable parameters of the as-a-second-scheduler chart and their default values.
 
-| Parameter                 | Description                 | Default                                                                                         |
-|---------------------------|-----------------------------|-------------------------------------------------------------------------------------------------|
-| `scheduler.name`          | Scheduler name              | `scheduler-plugins-scheduler`                                                                   |
-| `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.30.6`                                      |
-| `scheduler.command`       | Scheduler command           | `["/bin/kube-scheduler"]`                                                                       |
-| `scheduler.leaderElect`   | Scheduler leaderElection    | `false`                                                                                         |
-| `scheduler.replicaCount`  | Scheduler replicaCount      | `1`                                                                                             |
-| `scheduler.resources`     | Scheduler resources         | `{}`                                                                                            |
-| `scheduler.nodeSelector`  | Scheduler nodeSelector      | `{}`                                                                                            |
-| `scheduler.affinity`      | Scheduler affinity          | `{}`                                                                                            |
-| `scheduler.tolerations`   | Scheduler tolerations       | `[]`                                                                                            |
-| `controller.name`         | Controller name             | `scheduler-plugins-controller`                                                                  |
-| `controller.image`        | Controller image            | `registry.k8s.io/scheduler-plugins/controller:v0.29.7`                                          |
-| `controller.replicaCount` | Controller replicaCount     | `1`                                                                                             |
-s| `controller.resources`    | Controller resources        | `{}`                                                                                            |
-| `controller.nodeSelector` | Controller nodeSelector     | `{}`                                                                                            |
-| `controller.affinity`     | Controller affinity         | `{}`                                                                                            |
-| `controller.tolerations`  | Controller tolerations      | `[]`                                                                                            |
-| `plugins.enabled`         | Plugins enabled by default  | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
-| `plugins.disabled`        | Plugins disabled by default | `["PrioritySort"]`                                                                              |
+| Parameter                      | Description                  | Default                                                                                         |
+|--------------------------------|------------------------------|-------------------------------------------------------------------------------------------------|
+| `scheduler.name`               | Scheduler name               | `scheduler-plugins-scheduler`                                                                   |
+| `scheduler.image`              | Scheduler image              | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.30.6`                                      |
+| `scheduler.command`            | Scheduler command            | `["/bin/kube-scheduler"]`                                                                       |
+| `scheduler.leaderElect`        | Scheduler leaderElection     | `false`                                                                                         |
+| `scheduler.replicaCount`       | Scheduler replicaCount       | `1`                                                                                             |
+| `scheduler.priorityClassName`  | Scheduler priorityClassName  | `""`                                                                                            |
+| `scheduler.resources`          | Scheduler resources          | `{}`                                                                                            |
+| `scheduler.nodeSelector`       | Scheduler nodeSelector       | `{}`                                                                                            |
+| `scheduler.affinity`           | Scheduler affinity           | `{}`                                                                                            |
+| `scheduler.tolerations`        | Scheduler tolerations        | `[]`                                                                                            |
+| `controller.name`              | Controller name              | `scheduler-plugins-controller`                                                                  |
+| `controller.image`             | Controller image             | `registry.k8s.io/scheduler-plugins/controller:v0.29.7`                                          |
+| `controller.replicaCount`      | Controller replicaCount      | `1`                                                                                             |
+| `controller.priorityClassName` | Controller priorityClassName | `""`                                                                                            |
+| `controller.resources`         | Controller resources         | `{}`                                                                                            |
+| `controller.nodeSelector`      | Controller nodeSelector      | `{}`                                                                                            |
+| `controller.affinity`          | Controller affinity          | `{}`                                                                                            |
+| `controller.tolerations`       | Controller tolerations       | `[]`                                                                                            |
+| `plugins.enabled`              | Plugins enabled by default   | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
+| `plugins.disabled`             | Plugins disabled by default  | `["PrioritySort"]`                                                                              |

--- a/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: scheduler-plugins-controller
     spec:
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ .Values.controller.name }}
       containers:
       - name: scheduler-plugins-controller
@@ -51,6 +54,9 @@ spec:
       labels:
         component: scheduler
     spec:
+      {{- with .Values.scheduler.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ .Values.scheduler.name }}
       containers:
       - command: {{- toYaml .Values.scheduler.command | nindent 8 }}

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -9,6 +9,7 @@ scheduler:
   - /bin/kube-scheduler
   replicaCount: 1
   leaderElect: false
+  priorityClassName: ""
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -18,6 +19,7 @@ controller:
   name: scheduler-plugins-controller
   image: registry.k8s.io/scheduler-plugins/controller:v0.30.6
   replicaCount: 1
+  priorityClassName: ""
   resources: {}
   nodeSelector: {}
   affinity: {}

--- a/site/content/en/docs/user-guide/installing-the-chart.md
+++ b/site/content/en/docs/user-guide/installing-the-chart.md
@@ -49,23 +49,25 @@ scheduler-plugins-scheduler    1/1     1            1           7s
 
 The following table lists the configurable parameters of the as-a-second-scheduler chart and their default values.
 
-| Parameter                 | Description                 | Default                                                                                         |
-|---------------------------|-----------------------------|-------------------------------------------------------------------------------------------------|
-| `scheduler.name`          | Scheduler name              | `scheduler-plugins-scheduler`                                                                   |
-| `scheduler.image`         | Scheduler image             | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.30.6`                                      |
-| `scheduler.command`       | Scheduler command           | `["/bin/kube-scheduler"]`                                                                       |
-| `scheduler.leaderElect`   | Scheduler leaderElection    | `false`                                                                                         |
-| `scheduler.replicaCount`  | Scheduler replicaCount      | `1`                                                                                             |
-| `scheduler.resources`     | Scheduler resources         | `{}`                                                                                            |
-| `scheduler.nodeSelector`  | Scheduler nodeSelector      | `{}`                                                                                            |
-| `scheduler.affinity`      | Scheduler affinity          | `{}`                                                                                            |
-| `scheduler.tolerations`   | Scheduler tolerations       | `[]`                                                                                            |
-| `controller.name`         | Controller name             | `scheduler-plugins-controller`                                                                  |
-| `controller.image`        | Controller image            | `registry.k8s.io/scheduler-plugins/controller:v0.29.7`                                          |
-| `controller.replicaCount` | Controller replicaCount     | `1`                                                                                             |
-| `controller.resources`    | Controller resources        | `{}`                                                                                            |
-| `controller.nodeSelector` | Controller nodeSelector     | `{}`                                                                                            |
-| `controller.affinity`     | Controller affinity         | `{}`                                                                                            |
-| `controller.tolerations`  | Controller tolerations      | `[]`                                                                                            |
-| `plugins.enabled`         | Plugins enabled by default  | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
-| `plugins.disabled`        | Plugins disabled by default | `["PrioritySort"]`                                                                              |
+| Parameter                      | Description                  | Default                                                                                         |
+|--------------------------------|------------------------------|-------------------------------------------------------------------------------------------------|
+| `scheduler.name`               | Scheduler name               | `scheduler-plugins-scheduler`                                                                   |
+| `scheduler.image`              | Scheduler image              | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.30.6`                                      |
+| `scheduler.command`            | Scheduler command            | `["/bin/kube-scheduler"]`                                                                       |
+| `scheduler.leaderElect`        | Scheduler leaderElection     | `false`                                                                                         |
+| `scheduler.replicaCount`       | Scheduler replicaCount       | `1`                                                                                             |
+| `scheduler.priorityClassName`  | Scheduler priorityClassName  | `""`                                                                                            |
+| `scheduler.resources`          | Scheduler resources          | `{}`                                                                                            |
+| `scheduler.nodeSelector`       | Scheduler nodeSelector       | `{}`                                                                                            |
+| `scheduler.affinity`           | Scheduler affinity           | `{}`                                                                                            |
+| `scheduler.tolerations`        | Scheduler tolerations        | `[]`                                                                                            |
+| `controller.name`              | Controller name              | `scheduler-plugins-controller`                                                                  |
+| `controller.image`             | Controller image             | `registry.k8s.io/scheduler-plugins/controller:v0.29.7`                                          |
+| `controller.replicaCount`      | Controller replicaCount      | `1`                                                                                             |
+| `controller.priorityClassName` | Controller priorityClassName | `""`                                                                                            |
+| `controller.resources`         | Controller resources         | `{}`                                                                                            |
+| `controller.nodeSelector`      | Controller nodeSelector      | `{}`                                                                                            |
+| `controller.affinity`          | Controller affinity          | `{}`                                                                                            |
+| `controller.tolerations`       | Controller tolerations       | `[]`                                                                                            |
+| `plugins.enabled`              | Plugins enabled by default   | `["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch", "NodeResourcesAllocatable"]` |
+| `plugins.disabled`             | Plugins disabled by default  | `["PrioritySort"]`                                                                              |


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

adds the ability for defining priorityClassName

#### Does this PR introduce a user-facing change?
```release-notes
Added the ability in Helm chart for defining priorityClassName
```
