### PR TITLE
migrate misplaced RBAC in Helm chart

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -74,6 +74,11 @@ rules:
   resources: [ "networktopologies" ]
   verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
 {{- end }}
+{{- if has "PreemptionToleration" .Values.plugins.enabled }}
+- apiGroups: ["scheduling.k8s.io"]
+  resources: ["priorityclasses"]
+  verbs: ["get", "list", "watch"]
+{{- end }}
 {{- if has "SySched" .Values.plugins.enabled }}
 - apiGroups: ["security-profiles-operator.x-k8s.io"]
   resources: ["seccompprofiles", "profilebindings"]
@@ -114,11 +119,6 @@ rules:
   resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 {{- /* resources need to be updated with the scheduler plugins used */}}
-{{- if has "PreemptionToleration" .Values.plugins.enabled }}
-- apiGroups: ["scheduling.k8s.io"]
-  resources: ["priorityclasses"]
-  verbs: ["get", "list", "watch"]
-{{- end }}
 {{- if has "SySched" .Values.plugins.enabled }}
 - apiGroups: ["security-profiles-operator.x-k8s.io"]
   resources: ["seccompprofiles", "profilebindings"]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:

Made a mistake in my previous [PR](https://github.com/kubernetes-sigs/scheduler-plugins/pull/818) as this permission should exist for the scheduler and not for the controller

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
