### PR TITLE
refactor: replace math.Min/math.Max with min/max

### DIFF
--- a/pkg/trimaran/loadvariationriskbalancing/analysis.go
+++ b/pkg/trimaran/loadvariationriskbalancing/analysis.go
@@ -38,9 +38,9 @@ func computeScore(logger klog.Logger, rs *trimaran.ResourceStats, margin float64
 	}
 
 	// make sure values are within bounds
-	rs.Req = math.Max(rs.Req, 0)
-	rs.UsedAvg = math.Max(math.Min(rs.UsedAvg, rs.Capacity), 0)
-	rs.UsedStdev = math.Max(math.Min(rs.UsedStdev, rs.Capacity), 0)
+	rs.Req = max(rs.Req, 0)
+	rs.UsedAvg = max(min(rs.UsedAvg, rs.Capacity), 0)
+	rs.UsedStdev = max(min(rs.UsedStdev, rs.Capacity), 0)
 
 	// calculate average and deviation factors
 	mu, sigma := trimaran.GetMuSigma(rs)
@@ -51,7 +51,7 @@ func computeScore(logger klog.Logger, rs *trimaran.ResourceStats, margin float64
 	}
 	// apply multiplier
 	sigma *= margin
-	sigma = math.Max(math.Min(sigma, 1), 0)
+	sigma = max(min(sigma, 1), 0)
 
 	// evaluate overall risk factor
 	risk := (mu + sigma) / 2

--- a/pkg/trimaran/loadvariationriskbalancing/loadvariationriskbalancing.go
+++ b/pkg/trimaran/loadvariationriskbalancing/loadvariationriskbalancing.go
@@ -113,9 +113,9 @@ func (pl *LoadVariationRiskBalancing) Score(ctx context.Context, cycleState *fra
 	// calculate total score
 	var totalScore float64 = 0
 	if memoryOK && cpuOK {
-		totalScore = math.Min(memoryScore, cpuScore)
+		totalScore = min(memoryScore, cpuScore)
 	} else {
-		totalScore = math.Max(memoryScore, cpuScore)
+		totalScore = max(memoryScore, cpuScore)
 	}
 	score = int64(math.Round(totalScore))
 	logger.V(6).Info("Calculating totalScore", "pod", klog.KObj(pod), "nodeName", nodeName, "totalScore", score)

--- a/pkg/trimaran/lowriskovercommitment/beta.go
+++ b/pkg/trimaran/lowriskovercommitment/beta.go
@@ -110,7 +110,7 @@ func (b *BetaDistribution) MatchMoments(m1, m2 float64) bool {
 		return false
 	}
 	temp := (m1 * (1 - m1) / variance) - 1
-	temp = math.Max(temp, math.SmallestNonzeroFloat64)
+	temp = max(temp, math.SmallestNonzeroFloat64)
 	b.alpha = m1 * temp
 	b.beta = (1 - m1) * temp
 	return b.computeMoments()

--- a/pkg/trimaran/resourcestats.go
+++ b/pkg/trimaran/resourcestats.go
@@ -17,8 +17,6 @@ limitations under the License.
 package trimaran
 
 import (
-	"math"
-
 	"github.com/paypal/load-watcher/pkg/watcher"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -80,9 +78,9 @@ func GetMuSigma(rs *ResourceStats) (float64, float64) {
 		return 0, 0
 	}
 	mu := (rs.UsedAvg + rs.Req) / rs.Capacity
-	mu = math.Max(math.Min(mu, 1), 0)
+	mu = max(min(mu, 1), 0)
 	sigma := rs.UsedStdev / rs.Capacity
-	sigma = math.Max(math.Min(sigma, 1), 0)
+	sigma = max(min(sigma, 1), 0)
 	return mu, sigma
 }
 

--- a/pkg/trimaran/resourcestats_test.go
+++ b/pkg/trimaran/resourcestats_test.go
@@ -18,7 +18,6 @@ package trimaran
 
 import (
 	"context"
-	"math"
 	"reflect"
 	"strconv"
 	"testing"
@@ -522,12 +521,12 @@ func TestGetNodeRequestsAndLimits(t *testing.T) {
 			},
 			want: &NodeRequestsAndLimits{
 				NodeRequest: &framework.Resource{
-					MilliCPU: int64(math.Min(float64(GetResourceRequested(pod).MilliCPU), float64(capCpu))),
-					Memory:   int64(math.Min(float64(GetResourceRequested(pod).Memory), float64(capMem))),
+					MilliCPU: min(GetResourceRequested(pod).MilliCPU, capCpu),
+					Memory:   min(GetResourceRequested(pod).Memory, capMem),
 				},
 				NodeLimit: &framework.Resource{
-					MilliCPU: int64(math.Max(float64(GetResourceRequested(pod).MilliCPU), float64(GetResourceLimits(pod).MilliCPU))),
-					Memory:   int64(math.Max(float64(GetResourceRequested(pod).Memory), float64(GetResourceLimits(pod).Memory))),
+					MilliCPU: max(GetResourceRequested(pod).MilliCPU, GetResourceLimits(pod).MilliCPU),
+					Memory:   max(GetResourceRequested(pod).Memory, GetResourceLimits(pod).Memory),
 				},
 				NodeRequestMinusPod: &framework.Resource{
 					MilliCPU: 0,
@@ -555,16 +554,16 @@ func TestGetNodeRequestsAndLimits(t *testing.T) {
 			},
 			want: &NodeRequestsAndLimits{
 				NodeRequest: &framework.Resource{
-					MilliCPU: int64(math.Min(float64(GetResourceRequested(pod4).MilliCPU), float64(capCpu))),
-					Memory:   int64(math.Min(float64(GetResourceRequested(pod4).Memory), float64(capMem))),
+					MilliCPU: min(GetResourceRequested(pod4).MilliCPU, capCpu),
+					Memory:   min(GetResourceRequested(pod4).Memory, capMem),
 				},
 				NodeLimit: &framework.Resource{
-					MilliCPU: int64(math.Min(
-						math.Max(float64(GetResourceRequested(pod4).MilliCPU), float64(GetResourceLimits(pod4).MilliCPU)),
-						float64(capCpu))),
-					Memory: int64(math.Min(
-						math.Max(float64(GetResourceRequested(pod4).Memory), float64(GetResourceLimits(pod4).Memory)),
-						float64(capMem))),
+					MilliCPU: min(
+						max(GetResourceRequested(pod4).MilliCPU, GetResourceLimits(pod4).MilliCPU),
+						capCpu),
+					Memory: min(
+						max(GetResourceRequested(pod4).Memory, GetResourceLimits(pod4).Memory),
+						capMem),
 				},
 				NodeRequestMinusPod: &framework.Resource{
 					MilliCPU: 0,


### PR DESCRIPTION
#### What type of PR is this?

The PR refactors code by replacing `math.Min/math.Max` with builtin `min/max`.

/kind cleanup

#### What this PR does / why we need it:

It simplifies code.

#### Special notes for your reviewer:

https://pkg.go.dev/builtin@go1.22.0#min
https://pkg.go.dev/builtin@go1.22.0#max

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
