### PR TITLE
refactor: replace deprecated sets.String with sets.Set

### DIFF
--- a/pkg/capacityscheduling/capacity_scheduling_test.go
+++ b/pkg/capacityscheduling/capacity_scheduling_test.go
@@ -385,7 +385,7 @@ func TestReserve(t *testing.T) {
 			elasticQuotas: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.String{},
+					pods:      sets.Set[string]{},
 					Min: &framework.Resource{
 						Memory: 1000,
 					},
@@ -405,7 +405,7 @@ func TestReserve(t *testing.T) {
 				{
 					"ns1": {
 						Namespace: "ns1",
-						pods:      sets.NewString("t1-p1"),
+						pods:      sets.New("t1-p1"),
 						Min: &framework.Resource{
 							Memory: 1000,
 						},
@@ -423,7 +423,7 @@ func TestReserve(t *testing.T) {
 				{
 					"ns1": {
 						Namespace: "ns1",
-						pods:      sets.NewString("t1-p1"),
+						pods:      sets.New("t1-p1"),
 						Min: &framework.Resource{
 							Memory: 1000,
 						},
@@ -499,7 +499,7 @@ func TestUnreserve(t *testing.T) {
 			elasticQuotas: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.NewString("t1-p3", "t1-p4"),
+					pods:      sets.New("t1-p3", "t1-p4"),
 					Min: &framework.Resource{
 						Memory: 1000,
 					},
@@ -515,7 +515,7 @@ func TestUnreserve(t *testing.T) {
 				{
 					"ns1": {
 						Namespace: "ns1",
-						pods:      sets.NewString("t1-p3", "t1-p4"),
+						pods:      sets.New("t1-p3", "t1-p4"),
 						Min: &framework.Resource{
 							Memory: 1000,
 						},
@@ -530,7 +530,7 @@ func TestUnreserve(t *testing.T) {
 				{
 					"ns1": {
 						Namespace: "ns1",
-						pods:      sets.NewString("t1-p3", "t1-p4"),
+						pods:      sets.New("t1-p3", "t1-p4"),
 						Min: &framework.Resource{
 							Memory: 1000,
 						},
@@ -545,7 +545,7 @@ func TestUnreserve(t *testing.T) {
 				{
 					"ns1": {
 						Namespace: "ns1",
-						pods:      sets.NewString("t1-p4"),
+						pods:      sets.New("t1-p4"),
 						Min: &framework.Resource{
 							Memory: 1000,
 						},
@@ -1030,7 +1030,7 @@ func TestAddElasticQuota(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.String{},
+					pods:      sets.Set[string]{},
 					Max: &framework.Resource{
 						MilliCPU: 100,
 						Memory:   1000,
@@ -1055,7 +1055,7 @@ func TestAddElasticQuota(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.String{},
+					pods:      sets.Set[string]{},
 					Max: &framework.Resource{
 						MilliCPU:         UpperBoundOfMax,
 						Memory:           UpperBoundOfMax,
@@ -1081,7 +1081,7 @@ func TestAddElasticQuota(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.String{},
+					pods:      sets.Set[string]{},
 					Max: &framework.Resource{
 						MilliCPU: 100,
 						Memory:   1000,
@@ -1107,7 +1107,7 @@ func TestAddElasticQuota(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.String{},
+					pods:      sets.Set[string]{},
 					Max: &framework.Resource{
 						MilliCPU:         UpperBoundOfMax,
 						Memory:           UpperBoundOfMax,
@@ -1182,7 +1182,7 @@ func TestUpdateElasticQuota(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.String{},
+					pods:      sets.Set[string]{},
 					Max: &framework.Resource{
 						MilliCPU: 300,
 						Memory:   1000,
@@ -1309,7 +1309,7 @@ func TestAddPod(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.NewString("t1-p1", "t1-p2", "t1-p3"),
+					pods:      sets.New("t1-p1", "t1-p2", "t1-p3"),
 					Max: &framework.Resource{
 						MilliCPU: 100,
 						Memory:   1000,
@@ -1389,7 +1389,7 @@ func TestUpdatePod(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.NewString("t1-p1"),
+					pods:      sets.New("t1-p1"),
 					Max: &framework.Resource{
 						MilliCPU: 100,
 						Memory:   1000,
@@ -1421,7 +1421,7 @@ func TestUpdatePod(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.String{},
+					pods:      sets.Set[string]{},
 					Max: &framework.Resource{
 						MilliCPU: 100,
 						Memory:   1000,
@@ -1505,7 +1505,7 @@ func TestDeletePod(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.NewString(),
+					pods:      sets.New[string](),
 					Max: &framework.Resource{
 						MilliCPU: 100,
 						Memory:   1000,
@@ -1538,7 +1538,7 @@ func TestDeletePod(t *testing.T) {
 			expected: map[string]*ElasticQuotaInfo{
 				"ns1": {
 					Namespace: "ns1",
-					pods:      sets.NewString("t1-p2"),
+					pods:      sets.New("t1-p2"),
 					Max: &framework.Resource{
 						MilliCPU: 100,
 						Memory:   1000,

--- a/pkg/capacityscheduling/elasticquota.go
+++ b/pkg/capacityscheduling/elasticquota.go
@@ -62,7 +62,7 @@ func (e ElasticQuotaInfos) aggregatedUsedOverMinWith(podRequest framework.Resour
 // Each namespace can only have one ElasticQuota.
 type ElasticQuotaInfo struct {
 	Namespace string
-	pods      sets.String
+	pods      sets.Set[string]
 	Min       *framework.Resource
 	Max       *framework.Resource
 	Used      *framework.Resource
@@ -78,7 +78,7 @@ func newElasticQuotaInfo(namespace string, min, max, used v1.ResourceList) *Elas
 
 	elasticQuotaInfo := &ElasticQuotaInfo{
 		Namespace: namespace,
-		pods:      sets.NewString(),
+		pods:      sets.New[string](),
 		Min:       framework.NewResource(min),
 		Max:       framework.NewResource(max),
 		Used:      framework.NewResource(used),
@@ -133,7 +133,7 @@ func (e *ElasticQuotaInfo) usedOverMin() bool {
 func (e *ElasticQuotaInfo) clone() *ElasticQuotaInfo {
 	newEQInfo := &ElasticQuotaInfo{
 		Namespace: e.Namespace,
-		pods:      sets.NewString(),
+		pods:      sets.New[string](),
 	}
 
 	if e.Min != nil {
@@ -145,11 +145,8 @@ func (e *ElasticQuotaInfo) clone() *ElasticQuotaInfo {
 	if e.Used != nil {
 		newEQInfo.Used = e.Used.Clone()
 	}
-	if len(e.pods) > 0 {
-		pods := e.pods.List()
-		for _, pod := range pods {
-			newEQInfo.pods.Insert(pod)
-		}
+	for pod := range e.pods {
+		newEQInfo.pods.Insert(pod)
 	}
 
 	return newEQInfo

--- a/pkg/capacityscheduling/elasticquota_test.go
+++ b/pkg/capacityscheduling/elasticquota_test.go
@@ -526,7 +526,7 @@ func TestNewElasticQuotaInfo(t *testing.T) {
 			},
 			expected: &ElasticQuotaInfo{
 				Namespace: "ns1",
-				pods:      sets.String{},
+				pods:      sets.Set[string]{},
 				Max: &framework.Resource{
 					MilliCPU: 100,
 					Memory:   1000,
@@ -551,7 +551,7 @@ func TestNewElasticQuotaInfo(t *testing.T) {
 			},
 			expected: &ElasticQuotaInfo{
 				Namespace: "ns1",
-				pods:      sets.String{},
+				pods:      sets.Set[string]{},
 				Max: &framework.Resource{
 					MilliCPU:         UpperBoundOfMax,
 					Memory:           UpperBoundOfMax,
@@ -577,7 +577,7 @@ func TestNewElasticQuotaInfo(t *testing.T) {
 			},
 			expected: &ElasticQuotaInfo{
 				Namespace: "ns1",
-				pods:      sets.String{},
+				pods:      sets.Set[string]{},
 				Max: &framework.Resource{
 					MilliCPU: 100,
 					Memory:   1000,
@@ -603,7 +603,7 @@ func TestNewElasticQuotaInfo(t *testing.T) {
 			},
 			expected: &ElasticQuotaInfo{
 				Namespace: "ns1",
-				pods:      sets.String{},
+				pods:      sets.Set[string]{},
 				Max: &framework.Resource{
 					MilliCPU:         UpperBoundOfMax,
 					Memory:           UpperBoundOfMax,

--- a/pkg/noderesourcetopology/cache/foreign_pods.go
+++ b/pkg/noderesourcetopology/cache/foreign_pods.go
@@ -35,7 +35,7 @@ import (
 // Note this is NOT lock-protected because the scheduling framework calls New() sequentially,
 // and plugin instances are meant to register their name using SetupForeignPodsDetector inside their New()
 var (
-	schedProfileNames      = sets.String{}
+	schedProfileNames      = sets.Set[string]{}
 	onlyExclusiveResources = false
 )
 
@@ -75,7 +75,7 @@ func RegisterSchedulerProfileName(lh logr.Logger, schedProfileName string) {
 	lh.Info("setting up detection", "profile", schedProfileName)
 	schedProfileNames.Insert(schedProfileName)
 
-	lh.V(5).Info("registered scheduler profiles", "names", schedProfileNames.List())
+	lh.V(5).Info("registered scheduler profiles", "names", schedProfileNames.UnsortedList())
 }
 
 func IsForeignPod(pod *corev1.Pod) bool {
@@ -95,5 +95,5 @@ func IsForeignPod(pod *corev1.Pod) bool {
 
 // for testing only; NOT thread safe
 func CleanRegisteredSchedulerProfileNames() {
-	schedProfileNames = sets.String{}
+	schedProfileNames = sets.Set[string]{}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces usage of deprecated [`sets.String`](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets#String) with `sets.Set[string]`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
