### PR TITLE
fix(QOSSort): refine queue sorting logic by adding inqueue timestamp

### DIFF
--- a/pkg/qos/queue_sort.go
+++ b/pkg/qos/queue_sort.go
@@ -41,22 +41,43 @@ func (pl *Sort) Name() string {
 
 // Less is the function used by the activeQ heap algorithm to sort pods.
 // It sorts pods based on their priorities. When the priorities are equal, it uses
-// the Pod QoS classes to break the tie.
+// the Pod QoS classes to break the tie. If both the priority and QoS class are equal,
+// it uses PodQueueInfo.timestamp to determine the order.
 func (*Sort) Less(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
 	p1 := corev1helpers.PodPriority(pInfo1.Pod)
 	p2 := corev1helpers.PodPriority(pInfo2.Pod)
-	return (p1 > p2) || (p1 == p2 && compQOS(pInfo1.Pod, pInfo2.Pod))
+
+	if p1 != p2 {
+		return p1 > p2
+	}
+	qosResult := compQOS(pInfo1.Pod, pInfo2.Pod)
+	if qosResult != 0 {
+		return qosResult > 0
+	}
+	return pInfo1.Timestamp.Before(pInfo2.Timestamp)
 }
 
-func compQOS(p1, p2 *v1.Pod) bool {
+// compQOS compares the QoS classes of two Pods and returns:
+//
+//	 1 if p1 has a higher precedence QoS class than p2,
+//	-1 if p2 has a higher precedence QoS class than p1,
+//	 0 if both have the same QoS class.
+func compQOS(p1, p2 *v1.Pod) int {
 	p1QOS, p2QOS := v1qos.GetPodQOS(p1), v1qos.GetPodQOS(p2)
-	if p1QOS == v1.PodQOSGuaranteed {
-		return true
+
+	// Define the precedence order of QoS classes using a map
+	qosOrder := map[v1.PodQOSClass]int{
+		v1.PodQOSBestEffort: 1,
+		v1.PodQOSBurstable:  2,
+		v1.PodQOSGuaranteed: 3,
 	}
-	if p1QOS == v1.PodQOSBurstable {
-		return p2QOS != v1.PodQOSGuaranteed
+
+	if qosOrder[p1QOS] > qosOrder[p2QOS] {
+		return 1
+	} else if qosOrder[p1QOS] < qosOrder[p2QOS] {
+		return -1
 	}
-	return p2QOS == v1.PodQOSBestEffort
+	return 0
 }
 
 // New initializes a new plugin and returns it.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- After comparing with the k/k queuesort package, we seem to be missing timestamp comparison.
https://github.com/kubernetes/kubernetes/blob/35d6959ace07a4edc2a17da3bd4d0fcd625caa83/pkg/scheduler/framework/plugins/queuesort/priority_sort.go#L40-L49

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
