### PR TITLE
flake: fix qos sort plugin flaky integration test

### DIFF
--- a/test/integration/qos_test.go
+++ b/test/integration/qos_test.go
@@ -98,18 +98,22 @@ func TestQOSPlugin(t *testing.T) {
 	// Make pods[1] Burstable.
 	pods[1].Spec.Containers[0].Resources = v1.ResourceRequirements{
 		Requests: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(50, resource.DecimalSI),
 			v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
 		},
 		Limits: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
 			v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
 		},
 	}
 	// Make pods[2] Guaranteed.
 	pods[2].Spec.Containers[0].Resources = v1.ResourceRequirements{
 		Requests: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
 			v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
 		},
 		Limits: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
 			v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
 		},
 	}
@@ -161,7 +165,6 @@ func TestQOSPlugin(t *testing.T) {
 		actualOrder[i] = podInfo.Pod.Name
 		t.Logf("Popped Pod %q", podInfo.Pod.Name)
 	}
-
 	if !reflect.DeepEqual(actualOrder, expectedOrder) {
 		t.Errorf("Expected Pod order %v, but got %v", expectedOrder, actualOrder)
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- During local testing, I found that the integration test was unstable. I guess that the creation and entry into the scheduling queue are not simultaneous, this causes unstable results.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
