### PR TITLE
refactor the internal logic of podGroupManager

### DIFF
--- a/pkg/coscheduling/core/core_test.go
+++ b/pkg/coscheduling/core/core_test.go
@@ -266,13 +266,13 @@ func TestPermit(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
 			podInformer := informerFactory.Core().V1().Pods()
 
-			pgMgr := NewPodGroupManager(client, tu.NewFakeSharedLister(tt.existingPods, nodes), &scheduleTimeout, podInformer)
+			pgMgr := NewPodGroupManager(ctx, client, tu.NewFakeSharedLister(tt.existingPods, nodes), &scheduleTimeout, podInformer)
 
 			informerFactory.Start(ctx.Done())
 			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
 				t.Fatal("WaitForCacheSync failed")
 			}
-			addFunc := AddPodFactory(pgMgr)
+			addFunc := AddPodFactory(ctx, pgMgr)
 			for _, p := range tt.existingPods {
 				podInformer.Informer().GetStore().Add(p)
 				// we call add func here because we can not ensure existing pods are added before premit are called

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -84,6 +84,7 @@ func New(ctx context.Context, obj runtime.Object, handle framework.Handle) (fram
 
 	scheduleTimeDuration := time.Duration(args.PermitWaitingTimeSeconds) * time.Second
 	pgMgr := core.NewPodGroupManager(
+		ctx,
 		client,
 		handle.SnapshotSharedLister(),
 		&scheduleTimeDuration,
@@ -246,6 +247,7 @@ func (cs *Coscheduling) Permit(ctx context.Context, state *framework.CycleState,
 
 // Reserve is the functions invoked by the framework at "reserve" extension point.
 func (cs *Coscheduling) Reserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+	cs.pgMgr.Reserve(ctx, pod)
 	return nil
 }
 

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -114,6 +114,7 @@ func TestPodGroupBackoffTime(t *testing.T) {
 			}
 
 			pgMgr := core.NewPodGroupManager(
+				ctx,
 				client,
 				tu.NewFakeSharedLister(tt.pods, nodes),
 				// In this UT, 5 seconds should suffice to test the PreFilter's return code.
@@ -421,7 +422,7 @@ func TestLess(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
 			podInformer := informerFactory.Core().V1().Pods()
 
-			pl := &Coscheduling{pgMgr: core.NewPodGroupManager(client, nil, nil, podInformer)}
+			pl := &Coscheduling{pgMgr: core.NewPodGroupManager(ctx, client, nil, nil, podInformer)}
 
 			informerFactory.Start(ctx.Done())
 			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
@@ -516,7 +517,7 @@ func TestPermit(t *testing.T) {
 
 			pl := &Coscheduling{
 				frameworkHandler: f,
-				pgMgr:            core.NewPodGroupManager(client, tu.NewFakeSharedLister(nil, nodes), nil, podInformer),
+				pgMgr:            core.NewPodGroupManager(ctx, client, tu.NewFakeSharedLister(nil, nodes), nil, podInformer),
 				scheduleTimeout:  &scheduleTimeout,
 			}
 
@@ -623,6 +624,7 @@ func TestPostFilter(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
 			podInformer := informerFactory.Core().V1().Pods()
 			pgMgr := core.NewPodGroupManager(
+				ctx,
 				client,
 				tu.NewFakeSharedLister(tt.existingPods, nodes),
 				&scheduleTimeout,
@@ -638,7 +640,7 @@ func TestPostFilter(t *testing.T) {
 			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
 				t.Fatal("WaitForCacheSync failed")
 			}
-			addFunc := core.AddPodFactory(pgMgr)
+			addFunc := core.AddPodFactory(ctx, pgMgr)
 			for _, p := range tt.existingPods {
 				podInformer.Informer().GetStore().Add(p)
 				// we call add func here because we can not ensure existing pods are added before premit are called


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- refactor the internal logic of podGroupManager
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
