### PR TITLE
clientutil: verify if cache is synced

### DIFF
--- a/pkg/util/client_util.go
+++ b/pkg/util/client_util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -19,6 +20,9 @@ func NewClientWithCachedReader(ctx context.Context, config *rest.Config, scheme 
 	}
 	go ccache.Start(ctx)
 	ccache.WaitForCacheSync(ctx)
+	if !ccache.WaitForCacheSync(ctx) {
+		return nil, nil, fmt.Errorf("failed to sync cache")
+	}
 	c, err := client.New(config, client.Options{
 		Scheme: scheme,
 		Cache: &client.CacheOptions{


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

A follow-up of https://github.com/kubernetes-sigs/scheduler-plugins/pull/895#discussion_r2062363236

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

It's manually patched to release-1.30: https://github.com/kubernetes-sigs/scheduler-plugins/pull/896#discussion_r2062479356

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
