### PR TITLE
nrt: log: return updated generation value for cache

### DIFF
--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -340,7 +340,7 @@ func (ov *OverReserve) Resync() {
 }
 
 // FlushNodes drops all the cached information about a given node, resetting its state clean.
-func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.NodeResourceTopology) {
+func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.NodeResourceTopology) uint64 {
 	ov.lock.Lock()
 	defer ov.lock.Unlock()
 
@@ -354,12 +354,14 @@ func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.Node
 	}
 
 	if len(nrts) == 0 {
-		return
+		return ov.generation
 	}
 
 	// increase only if we mutated the internal state
 	ov.generation += 1
 	lh.V(2).Info("generation", "new", ov.generation)
+	return ov.generation
+
 }
 
 // to be used only in tests

--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -101,17 +101,16 @@ func NewOverReserve(ctx context.Context, lh logr.Logger, cfg *apiconfig.NodeReso
 func (ov *OverReserve) GetCachedNRTCopy(ctx context.Context, nodeName string, pod *corev1.Pod) (*topologyv1alpha2.NodeResourceTopology, CachedNRTInfo) {
 	ov.lock.Lock()
 	defer ov.lock.Unlock()
+	info := CachedNRTInfo{Generation: ov.generation}
 	if ov.nodesWithForeignPods.IsSet(nodeName) {
-		return nil, CachedNRTInfo{}
+		return nil, info
 	}
 
-	info := CachedNRTInfo{Fresh: true}
+	info.Fresh = true
 	nrt := ov.nrts.GetNRTCopyByNodeName(nodeName)
 	if nrt == nil {
 		return nil, info
 	}
-
-	info.Generation = ov.generation
 	nodeAssumedResources, ok := ov.assumedResources[nodeName]
 	if !ok {
 		return nrt, info


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
A bug in the logs

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The logs show misaligned generation value when tackling the same node in overreserve.go and filter.go logs where the former is always up to date while the latter is never updated (generation=0):

```
1 overreserve.go:310] "NodeTopology podset fingerprint mismatch" logger="nrtcache.resync" generation=3 node="node-1"
...
1 filter.go:202] "invalid topology data" logger="FilterWithNominatedPods.Filter.NodeResourceTopologyMatch" pod="default/test-6f798bf799-tj7bc" pod="default/test-6f798bf799-tj7bc" podUID="f221ce7c-09c9-4462-a67a-95f5fdec3fb7" node="node-1" generation=0
```

The only cache implementation that defines and uses "generation" is OverReserve thus this commit updates the method GetCachedNRTCopy() to return updated generation value in the returned CachedNRTInfo.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
