### PR TITLE
Create runner_scheduler_dockerhub.yaml

### DIFF
--- a/.github/workflows/runner_scheduler_dockerhub.yaml
+++ b/.github/workflows/runner_scheduler_dockerhub.yaml
@@ -1,0 +1,39 @@
+name: runner scheduler image to dockerhub
+on:
+  workflow_dispatch:
+
+jobs:
+  Run-npm-on-Ubuntu:
+    name: Run npm on Ubuntu
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release-1.28
+
+      - run: |
+          pwd
+          ls -l
+          tree
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/arm64
+          context: .
+          push: true
+          build-args: |
+            ARCH=arm64v8
+            RELEASE_VERSION=v1.0
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/scheduler-plugins:${{ github.sha }}


### PR DESCRIPTION
将`release-1.28`分支打包成arm64架构的镜像并且上传到dockerhub