### PR TITLE
NodeResourceTopology updates to match latest kubelet features

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -35,10 +35,6 @@ import (
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
-// The maximum number of NUMA nodes that Topology Manager allows is 8
-// https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#known-limitations
-const highestNUMAID = 8
-
 type PolicyHandler func(pod *v1.Pod, zoneMap topologyv1alpha2.ZoneList) *framework.Status
 
 func singleNUMAContainerLevelHandler(lh logr.Logger, pod *v1.Pod, info *filterInfo) *framework.Status {
@@ -93,7 +89,7 @@ func singleNUMAContainerLevelHandler(lh logr.Logger, pod *v1.Pod, info *filterIn
 // the NUMANodeList built using createNUMANodeList, the topology manager configuration from the NRT objects pertaining
 // to the candidate node.
 func resourcesAvailableInAnyNUMANodes(lh logr.Logger, info *filterInfo, resources v1.ResourceList) (int, bool, string) {
-	numaID := highestNUMAID
+	numaID := info.topologyManager.MaxNUMANodes // highest NUMA ID
 	bitmask := bm.NewEmptyBitMask()
 	// set all bits, each bit is a NUMA node, if resources couldn't be aligned
 	// on the NUMA node, bit should be unset

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -185,8 +185,7 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.Cycle
 
 	nodeName := nodeInfo.Node().Name
 
-	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues("ExtensionPoint", "Filter").
-		WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
+	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)

--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -18,12 +18,10 @@ package noderesourcetopology
 
 import (
 	v1 "k8s.io/api/core/v1"
-	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"github.com/go-logr/logr"
-	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"gonum.org/v1/gonum/stat/combin"
 
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
@@ -34,20 +32,17 @@ const (
 	maxDistanceValue = 255
 )
 
-func leastNUMAContainerScopeScore(lh logr.Logger, pod *v1.Pod, zones topologyv1alpha2.ZoneList) (int64, *framework.Status) {
-	nodes := createNUMANodeList(lh, zones)
-	qos := v1qos.GetPodQOS(pod)
-
+func leastNUMAContainerScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo) (int64, *framework.Status) {
 	maxNUMANodesCount := 0
 	allContainersMinAvgDistance := true
 	// the order how TopologyManager asks for hint is important so doing it in the same order
 	// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/topologymanager/scope_container.go#L52
 	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 		// if a container requests only non NUMA just continue
-		if onlyNonNUMAResources(nodes, container.Resources.Requests) {
+		if onlyNonNUMAResources(info.numaNodes, container.Resources.Requests) {
 			continue
 		}
-		numaNodes, isMinAvgDistance := numaNodesRequired(lh, qos, nodes, container.Resources.Requests)
+		numaNodes, isMinAvgDistance := numaNodesRequired(lh, info.qos, info.numaNodes, container.Resources.Requests)
 		// container's resources can't fit onto node, return MinNodeScore for whole pod
 		if numaNodes == nil {
 			// score plugin should be running after resource filter plugin so we should always find sufficient amount of NUMA nodes
@@ -65,7 +60,7 @@ func leastNUMAContainerScopeScore(lh logr.Logger, pod *v1.Pod, zones topologyv1a
 
 		// subtract the resources requested by the container from the given NUMA.
 		// this is necessary, so we won't allocate the same resources for the upcoming containers
-		subtractFromNUMAs(container.Resources.Requests, nodes, numaNodes.GetBits()...)
+		subtractFromNUMAs(container.Resources.Requests, info.numaNodes, numaNodes.GetBits()...)
 	}
 
 	if maxNUMANodesCount == 0 {
@@ -75,17 +70,14 @@ func leastNUMAContainerScopeScore(lh logr.Logger, pod *v1.Pod, zones topologyv1a
 	return normalizeScore(maxNUMANodesCount, allContainersMinAvgDistance), nil
 }
 
-func leastNUMAPodScopeScore(lh logr.Logger, pod *v1.Pod, zones topologyv1alpha2.ZoneList) (int64, *framework.Status) {
-	nodes := createNUMANodeList(lh, zones)
-	qos := v1qos.GetPodQOS(pod)
-
+func leastNUMAPodScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo) (int64, *framework.Status) {
 	resources := util.GetPodEffectiveRequest(pod)
 	// if a pod requests only non NUMA resources return max score
-	if onlyNonNUMAResources(nodes, resources) {
+	if onlyNonNUMAResources(info.numaNodes, resources) {
 		return framework.MaxNodeScore, nil
 	}
 
-	numaNodes, isMinAvgDistance := numaNodesRequired(lh, qos, nodes, resources)
+	numaNodes, isMinAvgDistance := numaNodesRequired(lh, info.qos, info.numaNodes, resources)
 	// pod's resources can't fit onto node, return MinNodeScore
 	if numaNodes == nil {
 		// score plugin should be running after resource filter plugin so we should always find sufficient amount of NUMA nodes

--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -67,7 +67,7 @@ func leastNUMAContainerScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo) 
 		return framework.MaxNodeScore, nil
 	}
 
-	return normalizeScore(maxNUMANodesCount, allContainersMinAvgDistance), nil
+	return normalizeScore(maxNUMANodesCount, allContainersMinAvgDistance, info.topologyManager.MaxNUMANodes), nil
 }
 
 func leastNUMAPodScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo) (int64, *framework.Status) {
@@ -85,11 +85,11 @@ func leastNUMAPodScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo) (int64
 		return framework.MinNodeScore, nil
 	}
 
-	return normalizeScore(numaNodes.Count(), isMinAvgDistance), nil
+	return normalizeScore(numaNodes.Count(), isMinAvgDistance, info.topologyManager.MaxNUMANodes), nil
 }
 
-func normalizeScore(numaNodesCount int, isMinAvgDistance bool) int64 {
-	numaNodeScore := framework.MaxNodeScore / highestNUMAID
+func normalizeScore(numaNodesCount int, isMinAvgDistance bool, highestNUMAID int) int64 {
+	numaNodeScore := framework.MaxNodeScore / int64(highestNUMAID)
 	score := framework.MaxNodeScore - int64(numaNodesCount)*numaNodeScore
 	if isMinAvgDistance {
 		// if distance between NUMA domains is optimal add half of numaNodeScore to make this node more favorable

--- a/pkg/noderesourcetopology/least_numa_test.go
+++ b/pkg/noderesourcetopology/least_numa_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/nodeconfig"
 )
 
 const (
@@ -746,7 +747,7 @@ func TestNormalizeScore(t *testing.T) {
 
 	for _, tc := range tcases {
 		t.Run(tc.description, func(t *testing.T) {
-			normalizedScore := normalizeScore(tc.score, tc.optimalDistance)
+			normalizedScore := normalizeScore(tc.score, tc.optimalDistance, nodeconfig.DefaultMaxNUMANodes)
 			if normalizedScore != tc.expectedScore {
 				t.Errorf("Expected normalizedScore to be %d not %d", tc.expectedScore, normalizedScore)
 			}

--- a/pkg/noderesourcetopology/logging/logging.go
+++ b/pkg/noderesourcetopology/logging/logging.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
 // well-known structured log keys
@@ -44,8 +45,9 @@ const (
 )
 
 const (
-	KindContainerInit string = "init"
-	KindContainerApp  string = "app"
+	KindContainerInit    string = "init"
+	KindContainerSidecar string = "sidecar"
+	KindContainerApp     string = "app"
 )
 
 const (
@@ -61,4 +63,11 @@ func PodUID(pod *corev1.Pod) string {
 		return "<nil>"
 	}
 	return string(pod.GetUID())
+}
+
+func GetInitContainerKind(container *corev1.Container) string {
+	if util.IsSidecarInitContainer(container) {
+		return KindContainerSidecar
+	}
+	return KindContainerInit
 }

--- a/pkg/noderesourcetopology/plugin.go
+++ b/pkg/noderesourcetopology/plugin.go
@@ -58,7 +58,14 @@ type filterInfo struct {
 }
 
 type filterFn func(logr.Logger, *v1.Pod, *filterInfo) *framework.Status
-type scoringFn func(logr.Logger, *v1.Pod, topologyv1alpha2.ZoneList) (int64, *framework.Status)
+
+type scoreInfo struct {
+	topologyManager nodeconfig.TopologyManager
+	qos             v1.PodQOSClass
+	numaNodes       NUMANodeList
+}
+
+type scoringFn func(logr.Logger, *v1.Pod, *scoreInfo) (int64, *framework.Status)
 
 // TopologyMatch plugin which run simplified version of TopologyManager's admit handler
 type TopologyMatch struct {

--- a/pkg/noderesourcetopology/plugin.go
+++ b/pkg/noderesourcetopology/plugin.go
@@ -30,6 +30,7 @@ import (
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 	"sigs.k8s.io/scheduler-plugins/apis/config/validation"
 	nrtcache "sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/cache"
+	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/nodeconfig"
 
 	"github.com/go-logr/logr"
 	topologyapi "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology"
@@ -48,7 +49,15 @@ func init() {
 	utilruntime.Must(topologyv1alpha2.AddToScheme(scheme))
 }
 
-type filterFn func(lh logr.Logger, pod *v1.Pod, zones topologyv1alpha2.ZoneList, nodeInfo *framework.NodeInfo) *framework.Status
+type filterInfo struct {
+	nodeName        string // shortcut, used very often
+	node            *framework.NodeInfo
+	topologyManager nodeconfig.TopologyManager
+	numaNodes       NUMANodeList
+	qos             v1.PodQOSClass
+}
+
+type filterFn func(logr.Logger, *v1.Pod, *filterInfo) *framework.Status
 type scoringFn func(logr.Logger, *v1.Pod, topologyv1alpha2.ZoneList) (int64, *framework.Status)
 
 // TopologyMatch plugin which run simplified version of TopologyManager's admit handler

--- a/pkg/noderesourcetopology/plugin.go
+++ b/pkg/noderesourcetopology/plugin.go
@@ -89,7 +89,7 @@ func (tm *TopologyMatch) Name() string {
 
 // New initializes a new plugin and returns it.
 func New(ctx context.Context, args runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	lh := klog.FromContext(ctx).WithValues("plugin", Name)
+	lh := klog.FromContext(ctx)
 
 	lh.V(5).Info("creating new noderesourcetopology plugin")
 	tcfg, ok := args.(*apiconfig.NodeResourceTopologyMatchArgs)

--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -180,10 +180,3 @@ func getForeignPodsDetectMode(lh logr.Logger, cfg *apiconfig.NodeResourceTopolog
 	}
 	return foreignPodsDetect
 }
-
-func logNumaNodes(lh logr.Logger, desc, nodeName string, nodes NUMANodeList) {
-	for _, numaNode := range nodes {
-		numaItems := []interface{}{"numaCell", numaNode.NUMAID}
-		lh.V(6).Info(desc, stringify.ResourceListToLoggableWithValues(numaItems, numaNode.Resources)...)
-	}
-}

--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-logr/logr"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper"
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/numanode"
 
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -105,7 +106,7 @@ func createNUMANodeList(lh logr.Logger, zones topologyv1alpha2.ZoneList) NUMANod
 	nodes := NUMANodeList{}
 	// filter non Node zones and create idToIdx lookup array
 	for i, zone := range zones {
-		if zone.Type != "Node" {
+		if zone.Type != helper.ZoneTypeNUMANode {
 			continue
 		}
 

--- a/pkg/noderesourcetopology/postbind.go
+++ b/pkg/noderesourcetopology/postbind.go
@@ -26,8 +26,7 @@ import (
 )
 
 func (tm *TopologyMatch) PostBind(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeName string) {
-	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues("ExtensionPoint", "PostBind").
-		WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
+	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)
 

--- a/pkg/noderesourcetopology/reserve.go
+++ b/pkg/noderesourcetopology/reserve.go
@@ -27,8 +27,7 @@ import (
 
 func (tm *TopologyMatch) Reserve(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeName string) *framework.Status {
 	// the scheduler framework will add the node/name key/value pair
-	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues("ExtensionPoint", "Reserve").
-		WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
+	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)
 
@@ -39,7 +38,7 @@ func (tm *TopologyMatch) Reserve(ctx context.Context, state *framework.CycleStat
 
 func (tm *TopologyMatch) Unreserve(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeName string) {
 	// the scheduler framework will add the node/name key/value pair
-	lh := klog.FromContext(ctx).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod))
+	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)
 

--- a/pkg/noderesourcetopology/score.go
+++ b/pkg/noderesourcetopology/score.go
@@ -61,8 +61,7 @@ func (rw resourceToWeightMap) weight(r v1.ResourceName) int64 {
 
 func (tm *TopologyMatch) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	// the scheduler framework will add the node/name key/value pair
-	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues("ExtensionPoint", "Score").
-		WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
+	lh := klog.FromContext(klog.NewContext(ctx, tm.logger)).WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)

--- a/pkg/util/sidecar.go
+++ b/pkg/util/sidecar.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// IsSidecarInitContainer assumes the given container is a pod init container;
+// returns true if that container is a sidecar, false otherwise.
+func IsSidecarInitContainer(container *v1.Container) bool {
+	return container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways
+}

--- a/pkg/util/sidecar_test.go
+++ b/pkg/util/sidecar_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestIsSidecarInitContainer(t *testing.T) {
+	always_ := v1.ContainerRestartPolicyAlways
+	testCases := []struct {
+		name     string
+		cnt      *v1.Container
+		expected bool
+	}{
+		{
+			name:     "zero value",
+			cnt:      &v1.Container{},
+			expected: false,
+		},
+		{
+			name: "explicit nil",
+			cnt: &v1.Container{
+				RestartPolicy: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "true sidecar container",
+			cnt: &v1.Container{
+				Name:          "init-1",
+				RestartPolicy: &always_,
+			},
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(string(testCase.name), func(t *testing.T) {
+			got := IsSidecarInitContainer(testCase.cnt)
+			if got != testCase.expected {
+				t.Fatalf("expected %t to equal %t", got, testCase.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
implement support for relevant topology manager functionalities added since roughly 1.27.
Topology manager gained options similar to cpumanager. We begin the support implementing the scheduler equivalent of MaxAllowedNUMANodes.
detect sidecar containers
improve the logging again

#### Which issue(s) this PR fixes:
Fixes NA

#### Special notes for your reviewer:
Likewise the other topology manager settings, the value is node-local so it is better represented as NodeResourceTopology object property rather than a global configuration value.

#### Does this PR introduce a user-facing change?
```release-note
Add support for Topology Manager MaxAllowedNUMANodes, detect sidecar containers, logging improvements.
```
