### PR TITLE
update helm chart index to include version 0.32.7

### DIFF
--- a/site/static/index.yaml
+++ b/site/static/index.yaml
@@ -2,6 +2,16 @@ apiVersion: v1
 entries:
   scheduler-plugins:
   - apiVersion: v2
+    appVersion: 0.32.7
+    created: "2025-08-07T09:16:18.62617-07:00"
+    description: deploy scheduler plugin as a second scheduler in cluster
+    digest: 89c4a4c67a9cccc613e9541c7b81fb6766a15ab8d3b84ee0483c8fa222218fa1
+    name: scheduler-plugins
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/scheduler-plugins/releases/download/v0.32.7/scheduler-plugins-0.32.7.tgz
+    version: 0.32.7
+  - apiVersion: v2
     appVersion: 0.31.8
     created: "2025-04-28T09:30:52.624313-07:00"
     description: deploy scheduler plugin as a second scheduler in cluster
@@ -41,4 +51,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/scheduler-plugins/releases/download/v0.28.9/scheduler-plugins-0.28.9.tgz
     version: 0.28.8
-generated: "2025-04-28T09:30:52.623876-07:00"
+generated: "2025-08-07T09:16:18.625676-07:00"


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area helm

#### What this PR does / why we need it:

Update Helm charts' index so helm repo update will show latest v0.32.7 chart:

- Step 1: download helm artifacts https://github.com/kubernetes-sigs/scheduler-plugins/releases/download/v0.32.7/scheduler-plugins-0.32.7.tgz to ./site/static/
- Step 2: cd into `./site/static/`
- Step 3: run `helm repo index . --merge index.yaml`
- Step 4: replace `urls[0]` with `https://github.com/kubernetes-sigs/scheduler-plugins/releases/download/v0.32.7/scheduler-plugins-0.32.7.tgz`
 
#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
update helm chart index to include version 0.32.7
```
