### PR TITLE
feat(co scheduling): using custom indexer instead of naive lister

### DIFF
--- a/pkg/coscheduling/core/core_test.go
+++ b/pkg/coscheduling/core/core_test.go
@@ -167,7 +167,7 @@ func TestPreFilter(t *testing.T) {
 			pgMgr := &PodGroupManager{
 				client:               client,
 				snapshotSharedLister: tu.NewFakeSharedLister(tt.pendingPods, nodes),
-				podLister:            podInformer.Lister(),
+				podInformer:          podInformer.Informer(),
 				scheduleTimeout:      &scheduleTimeout,
 				permittedPG:          newCache(),
 				backedOffPG:          newCache(),

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -85,7 +85,10 @@ func New(ctx context.Context, obj runtime.Object, handle framework.Handle) (fram
 	}
 
 	// Performance improvement when retrieving list of objects by namespace or we'll log 'index not exist' warning.
-	handle.SharedInformerFactory().Core().V1().Pods().Informer().AddIndexers(cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	handle.SharedInformerFactory().Core().V1().Pods().Informer().AddIndexers(cache.Indexers{
+		cache.NamespaceIndex:  cache.MetaNamespaceIndexFunc,
+		util.LabelIndexerName: util.NewIndexByLabelAndNamespace(v1alpha1.PodGroupLabel),
+	})
 
 	scheduleTimeDuration := time.Duration(args.PermitWaitingTimeSeconds) * time.Second
 	pgMgr := core.NewPodGroupManager(

--- a/pkg/util/client_util.go
+++ b/pkg/util/client_util.go
@@ -3,11 +3,16 @@ package util
 import (
 	"context"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	LabelIndexerName = "label-indexer"
 )
 
 // NewClientWithCachedReader returns a controller runtime Client with cache-baked client.
@@ -29,4 +34,20 @@ func NewClientWithCachedReader(ctx context.Context, config *rest.Config, scheme 
 		},
 	})
 	return c, ccache, err
+}
+
+// NewIndexByLabelAndNamespace returns an indexer function for indexing pods by label and namespace.
+func NewIndexByLabelAndNamespace(label string) func(obj interface{}) ([]string, error) {
+	return func(obj interface{}) ([]string, error) {
+		labels := obj.(metav1.Object).GetLabels()
+		if labels == nil {
+			return nil, nil
+		}
+		if labels[label] == "" {
+			return nil, nil
+		}
+		namespace := obj.(metav1.Object).GetNamespace()
+
+		return []string{namespace + "/" + labels[label]}, nil
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
To improve performance when using co scheduling at informer cache.<br>
When using original lister, the `list` implement seems to be naive for listing all the pods of the namespace, which may encounter some performance issue at large sacle.

```go
// List lists all resources in the indexer matching the given selector.
func (l ResourceIndexer[T]) List(selector labels.Selector) (ret []T, err error) {
	// ListAllByNamespace reverts to ListAll on empty namespaces
	err = cache.ListAllByNamespace(l.indexer, l.namespace, selector, func(m interface{}) {
		ret = append(ret, m.(T))
	})
	return ret, err
}
```
By using custome indexer, we can improve performance


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:




#### Does this PR introduce a user-facing change?


None
```release-note

```
