### PR TITLE
Exclude scheduling-gated pods from PodGroup quorum in PreFilter

### DIFF
--- a/pkg/coscheduling/core/core.go
+++ b/pkg/coscheduling/core/core.go
@@ -259,9 +259,21 @@ func (pgMgr *PodGroupManager) PreFilter(ctx context.Context, pod *corev1.Pod) er
 		return fmt.Errorf("podLister list pods failed: %w", err)
 	}
 
-	if len(pods) < int(pg.Spec.MinMember) {
+	quorumGap := int(pg.Spec.MinMember) - len(pods)
+	if quorumGap > 0 {
 		return fmt.Errorf("pre-filter pod %v cannot find enough sibling pods, "+
 			"current pods number: %v, minMember of group: %v", pod.Name, len(pods), pg.Spec.MinMember)
+	}
+
+	// Extra check to see how many SchedulingGated Pods can be tolerated.
+	// quorumGap can be negative if a PodGroup's minMember < a workload's replicas.
+	for _, p := range pods {
+		if len(p.Spec.SchedulingGates) > 0 {
+			quorumGap++
+		}
+		if quorumGap > 0 {
+			return fmt.Errorf("pre-filter pod %v cannot proceed due to gated pods in the same PodGroup", pod.Name)
+		}
 	}
 
 	if pg.Spec.MinResources == nil {

--- a/pkg/coscheduling/core/core_test.go
+++ b/pkg/coscheduling/core/core_test.go
@@ -112,6 +112,46 @@ func TestPreFilter(t *testing.T) {
 			expectedSuccess: true,
 		},
 		{
+			name: "gated pods but still meeting quorum (minMember < replicas)",
+			pod:  st.MakePod().Name("p1a").Namespace("ns").UID("p1a").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			pendingPods: []*corev1.Pod{
+				st.MakePod().Name("p1b").Namespace("ns").UID("p1b").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+				st.MakePod().Name("p1c").Namespace("ns").UID("p1c").Label(v1alpha1.PodGroupLabel, "pg1").
+					SchedulingGates([]string{"example-gate"}).Obj(),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(2).Obj(),
+			},
+			expectedSuccess: true,
+		},
+		{
+			name: "gated pods push group below quorum",
+			pod:  st.MakePod().Name("p1a").Namespace("ns").UID("p1a").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			pendingPods: []*corev1.Pod{
+				st.MakePod().Name("p1b").Namespace("ns").UID("p1b").Label(v1alpha1.PodGroupLabel, "pg1").
+					SchedulingGates([]string{"example-gate"}).Obj(),
+				st.MakePod().Name("p1c").Namespace("ns").UID("p1c").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(3).Obj(),
+			},
+			expectedSuccess: false,
+		},
+		{
+			name: "all sibling pods are gated",
+			pod:  st.MakePod().Name("p1a").Namespace("ns").UID("p1a").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
+			pendingPods: []*corev1.Pod{
+				st.MakePod().Name("p1b").Namespace("ns").UID("p1b").Label(v1alpha1.PodGroupLabel, "pg1").
+					SchedulingGates([]string{"example-gate"}).Obj(),
+				st.MakePod().Name("p1c").Namespace("ns").UID("p1c").Label(v1alpha1.PodGroupLabel, "pg1").
+					SchedulingGates([]string{"example-gate"}).Obj(),
+			},
+			pgs: []*v1alpha1.PodGroup{
+				tu.MakePodGroup().Name("pg1").Namespace("ns").MinMember(2).Obj(),
+			},
+			expectedSuccess: false,
+		},
+		{
 			// Previously we defined 2 nodes, each with 4 cpus. Now the PodGroup's minResources req is 6 cpus.
 			name: "cluster's resource satisfies minResource", // Although it'd fail in Filter()
 			pod:  st.MakePod().Name("p1a").Namespace("ns").UID("p1a").Label(v1alpha1.PodGroupLabel, "pg1").Obj(),
@@ -179,7 +219,7 @@ func TestPreFilter(t *testing.T) {
 			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
 				t.Fatal("WaitForCacheSync failed")
 			}
-			for _, p := range tt.pendingPods {
+			for _, p := range append(tt.pendingPods, tt.pod) {
 				podInformer.Informer().GetStore().Add(p)
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

A PodGroup may have pods **_partially_** scheduling-gated - esp. when it integrates with Kueue TAS. When an ungated pod enters `PreFilter()`, gated pods should not count toward the quorum since they cannot be scheduled yet. This change adds a second pass after the initial minMember check to verify that enough ungated pods exist to satisfy the quorum.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is more an enhancement to reduce churn for partially-gated PodGroup.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Exclude scheduling-gated pods from PodGroup quorum in PreFilter
```
