### PR TITLE
feat: Add configurable pgRejectThreshold to Coscheduling plugin

### DIFF
--- a/apis/config/scheme/scheme_test.go
+++ b/apis/config/scheme/scheme_test.go
@@ -97,6 +97,7 @@ profiles:
 							Name: coscheduling.Name,
 							Args: &config.CoschedulingArgs{
 								PermitWaitingTimeSeconds: 60,
+								PodGroupRejectPercentage: 10,
 							},
 						},
 						{
@@ -380,6 +381,7 @@ profiles:
       kind: CoschedulingArgs
       permitWaitingTimeSeconds: 10
       podGroupBackoffSeconds: 0
+      podGroupRejectPercentage: 0
     name: Coscheduling
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1

--- a/apis/config/types.go
+++ b/apis/config/types.go
@@ -32,6 +32,13 @@ type CoschedulingArgs struct {
 	PermitWaitingTimeSeconds int64
 	// PodGroupBackoffSeconds is the backoff time in seconds before a pod group can be scheduled again.
 	PodGroupBackoffSeconds int64
+	// PodGroupRejectPercentage is the percentage (0-100) of unassigned pods relative to
+	// minMember below which PostFilter will not reject the PodGroup.
+	// When the percentage of unassigned pods is at or below this value, PostFilter
+	// optimistically allows remaining pods to retry scheduling instead of rejecting the group.
+	// Default: 10 (10%). Set to 0 to always reject on any failure.
+	// Set to 100 to never reject (disable PostFilter group rejection).
+	PodGroupRejectPercentage int32
 }
 
 // ModeType is a "string" type.

--- a/apis/config/v1/defaults.go
+++ b/apis/config/v1/defaults.go
@@ -29,6 +29,7 @@ import (
 var (
 	defaultPermitWaitingTimeSeconds int64 = 60
 	defaultPodGroupBackoffSeconds   int64 = 0
+	defaultPodGroupRejectPercentage int32 = 10
 
 	defaultNodeResourcesAllocatableMode = Least
 
@@ -111,6 +112,9 @@ func SetDefaults_CoschedulingArgs(obj *CoschedulingArgs) {
 	}
 	if obj.PodGroupBackoffSeconds == nil {
 		obj.PodGroupBackoffSeconds = &defaultPodGroupBackoffSeconds
+	}
+	if obj.PodGroupRejectPercentage == nil {
+		obj.PodGroupRejectPercentage = &defaultPodGroupRejectPercentage
 	}
 }
 

--- a/apis/config/v1/defaults_test.go
+++ b/apis/config/v1/defaults_test.go
@@ -41,6 +41,7 @@ func TestSchedulingDefaults(t *testing.T) {
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
 				PodGroupBackoffSeconds:   pointer.Int64Ptr(0),
+				PodGroupRejectPercentage: pointer.Int32Ptr(10),
 			},
 		},
 		{
@@ -48,10 +49,12 @@ func TestSchedulingDefaults(t *testing.T) {
 			config: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
 				PodGroupBackoffSeconds:   pointer.Int64Ptr(20),
+				PodGroupRejectPercentage: pointer.Int32Ptr(50),
 			},
 			expect: &CoschedulingArgs{
 				PermitWaitingTimeSeconds: pointer.Int64Ptr(60),
 				PodGroupBackoffSeconds:   pointer.Int64Ptr(20),
+				PodGroupRejectPercentage: pointer.Int32Ptr(50),
 			},
 		},
 		{

--- a/apis/config/v1/types.go
+++ b/apis/config/v1/types.go
@@ -32,6 +32,11 @@ type CoschedulingArgs struct {
 	PermitWaitingTimeSeconds *int64 `json:"permitWaitingTimeSeconds,omitempty"`
 	// PodGroupBackoffSeconds is the backoff time in seconds before a pod group can be scheduled again.
 	PodGroupBackoffSeconds *int64 `json:"podGroupBackoffSeconds,omitempty"`
+	// PodGroupRejectPercentage is the percentage (0-100) of unassigned pods relative to
+	// minMember below which PostFilter will not reject the PodGroup.
+	// Default: 10 (10%). Set to 0 to always reject on any failure.
+	// Set to 100 to never reject (disable PostFilter group rejection).
+	PodGroupRejectPercentage *int32 `json:"podGroupRejectPercentage,omitempty"`
 }
 
 // ModeType is a type "string".

--- a/apis/config/v1/zz_generated.conversion.go
+++ b/apis/config/v1/zz_generated.conversion.go
@@ -210,6 +210,9 @@ func autoConvert_v1_CoschedulingArgs_To_config_CoschedulingArgs(in *Coscheduling
 	if err := metav1.Convert_Pointer_int64_To_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_int32_To_int32(&in.PodGroupRejectPercentage, &out.PodGroupRejectPercentage, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -223,6 +226,9 @@ func autoConvert_config_CoschedulingArgs_To_v1_CoschedulingArgs(in *config.Cosch
 		return err
 	}
 	if err := metav1.Convert_int64_To_Pointer_int64(&in.PodGroupBackoffSeconds, &out.PodGroupBackoffSeconds, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_int32_To_Pointer_int32(&in.PodGroupRejectPercentage, &out.PodGroupRejectPercentage, s); err != nil {
 		return err
 	}
 	return nil

--- a/apis/config/v1/zz_generated.deepcopy.go
+++ b/apis/config/v1/zz_generated.deepcopy.go
@@ -41,6 +41,11 @@ func (in *CoschedulingArgs) DeepCopyInto(out *CoschedulingArgs) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodGroupRejectPercentage != nil {
+		in, out := &in.PodGroupRejectPercentage, &out.PodGroupRejectPercentage
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/apis/config/validation/validation_pluginargs.go
+++ b/apis/config/validation/validation_pluginargs.go
@@ -104,6 +104,10 @@ func ValidateCoschedulingArgs(args *config.CoschedulingArgs, _ *field.Path) erro
 		allErrs = append(allErrs, field.Invalid(field.NewPath("podGroupBackoffSeconds"),
 			args.PodGroupBackoffSeconds, "must be greater than 0"))
 	}
+	if args.PodGroupRejectPercentage < 0 || args.PodGroupRejectPercentage > 100 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("podGroupRejectPercentage"),
+			args.PodGroupRejectPercentage, "must be between 0 and 100"))
+	}
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/apis/config/validation/validation_plugingargs_test.go
+++ b/apis/config/validation/validation_plugingargs_test.go
@@ -83,6 +83,25 @@ func TestValidateCoschedulingArgs(t *testing.T) {
 			args: &config.CoschedulingArgs{
 				PermitWaitingTimeSeconds: 30,
 				PodGroupBackoffSeconds:   60,
+				PodGroupRejectPercentage: 10,
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "valid PodGroupRejectPercentage at boundaries",
+			args: &config.CoschedulingArgs{
+				PermitWaitingTimeSeconds: 30,
+				PodGroupBackoffSeconds:   0,
+				PodGroupRejectPercentage: 0,
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "valid PodGroupRejectPercentage at upper boundary",
+			args: &config.CoschedulingArgs{
+				PermitWaitingTimeSeconds: 30,
+				PodGroupBackoffSeconds:   0,
+				PodGroupRejectPercentage: 100,
 			},
 			expectedErr: nil,
 		},
@@ -91,6 +110,7 @@ func TestValidateCoschedulingArgs(t *testing.T) {
 			args: &config.CoschedulingArgs{
 				PermitWaitingTimeSeconds: -10,
 				PodGroupBackoffSeconds:   60,
+				PodGroupRejectPercentage: 10,
 			},
 			expectedErr: fmt.Errorf("permitWaitingTimeSeconds: Invalid value: %v: must be greater than 0", -10),
 		},
@@ -99,14 +119,34 @@ func TestValidateCoschedulingArgs(t *testing.T) {
 			args: &config.CoschedulingArgs{
 				PermitWaitingTimeSeconds: 30,
 				PodGroupBackoffSeconds:   -20,
+				PodGroupRejectPercentage: 10,
 			},
 			expectedErr: fmt.Errorf("podGroupBackoffSeconds: Invalid value: %v: must be greater than 0", -20),
+		},
+		{
+			description: "invalid PodGroupRejectPercentage (negative value)",
+			args: &config.CoschedulingArgs{
+				PermitWaitingTimeSeconds: 30,
+				PodGroupBackoffSeconds:   0,
+				PodGroupRejectPercentage: -1,
+			},
+			expectedErr: fmt.Errorf("podGroupRejectPercentage: Invalid value: %v: must be between 0 and 100", -1),
+		},
+		{
+			description: "invalid PodGroupRejectPercentage (greater than 100)",
+			args: &config.CoschedulingArgs{
+				PermitWaitingTimeSeconds: 30,
+				PodGroupBackoffSeconds:   0,
+				PodGroupRejectPercentage: 150,
+			},
+			expectedErr: fmt.Errorf("podGroupRejectPercentage: Invalid value: %v: must be between 0 and 100", 150),
 		},
 		{
 			description: "both PermitWaitingTimeSeconds and PodGroupBackoffSeconds are negative",
 			args: &config.CoschedulingArgs{
 				PermitWaitingTimeSeconds: -30,
 				PodGroupBackoffSeconds:   -20,
+				PodGroupRejectPercentage: 10,
 			},
 			expectedErr: fmt.Errorf(
 				"[permitWaitingTimeSeconds: Invalid value: %v: must be greater than 0, podGroupBackoffSeconds: Invalid value: %v: must be greater than 0]",

--- a/kep/42-podgroup-coscheduling/README.md
+++ b/kep/42-podgroup-coscheduling/README.md
@@ -15,6 +15,7 @@
     - [QueueSort](#queuesort)
     - [PreFilter](#prefilter)
     - [PostFilter](#postfilter)
+    - [Backoff](#backoff)
     - [Permit](#permit)
   - [Known Limitations](#known-limitations)
 <!-- /toc -->
@@ -158,7 +159,26 @@ For any pod that gets rejected, their pod group would be added to a backoff list
 
 #### PostFilter
 
-If the gap to reach the quorum of a PodGroup is greater than 10%, we reject the whole PodGroup. Note that this plugin should be configured as the last one among PostFilter plugins.
+PostFilter handles scheduling failures for pods that belong to a PodGroup. When a pod fails Filter, PostFilter evaluates whether the PodGroup should be rejected based on how far it is from meeting its quorum:
+
+1. If the number of assigned pods already meets `minMember`, no action is taken.
+2. If the fraction of unassigned pods is at or below `podGroupRejectPercentage` (default: 10%), PostFilter returns `Unschedulable` without rejecting the group — the remaining pods get another scheduling attempt.
+3. If the fraction of unassigned pods exceeds the threshold, PostFilter rejects all waiting pods in the group and optionally triggers backoff (see below).
+
+The `podGroupRejectPercentage` parameter (default: `10`) is configurable in the scheduler's `CoschedulingArgs`. Set it to `0` to always reject on any failure, or `100` to never reject.
+
+Note that this plugin should be configured as the last one among PostFilter plugins.
+
+#### Backoff
+
+When `podGroupBackoffSeconds` is set to a positive value in `CoschedulingArgs`, PostFilter places a failed PodGroup into a time-based backoff cache after rejection. During the backoff window, PreFilter immediately rejects all pods from the PodGroup with `UnschedulableAndUnresolvable`, preventing wasteful scheduling cycles.
+
+Backoff is triggered only when all of the following conditions are met:
+- `podGroupBackoffSeconds > 0`
+- The fraction of unassigned pods exceeds `podGroupRejectPercentage`
+- The total number of pods with the PodGroup label is at least `minMember`
+
+The backoff state is stored in a TTL-based in-memory cache that auto-evicts entries after the configured duration.
 
 #### Permit
 

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -41,11 +41,12 @@ import (
 
 // Coscheduling is a plugin that schedules pods in a group.
 type Coscheduling struct {
-	logger           klog.Logger
-	frameworkHandler framework.Handle
-	pgMgr            core.Manager
-	scheduleTimeout  *time.Duration
-	pgBackoff        *time.Duration
+	logger            klog.Logger
+	frameworkHandler  framework.Handle
+	pgMgr             core.Manager
+	scheduleTimeout   *time.Duration
+	pgBackoff         *time.Duration
+	pgRejectThreshold float64
 }
 
 var _ framework.QueueSortPlugin = &Coscheduling{}
@@ -97,10 +98,11 @@ func New(ctx context.Context, obj runtime.Object, handle framework.Handle) (fram
 		handle.SharedInformerFactory().Core().V1().Pods(),
 	)
 	plugin := &Coscheduling{
-		logger:           lh,
-		frameworkHandler: handle,
-		pgMgr:            pgMgr,
-		scheduleTimeout:  &scheduleTimeDuration,
+		logger:            lh,
+		frameworkHandler:  handle,
+		pgMgr:             pgMgr,
+		scheduleTimeout:   &scheduleTimeDuration,
+		pgRejectThreshold: float64(args.PodGroupRejectPercentage) / 100.0,
 	}
 	if args.PodGroupBackoffSeconds < 0 {
 		err := fmt.Errorf("parse arguments failed")
@@ -179,10 +181,10 @@ func (cs *Coscheduling) PostFilter(ctx context.Context, state fwk.CycleState, po
 		return &framework.PostFilterResult{}, fwk.NewStatus(fwk.Unschedulable)
 	}
 
-	// If the gap is less than/equal 10%, we may want to try subsequent Pods
+	// If the gap is less than/equal the reject threshold, we may want to try subsequent Pods
 	// to see they can satisfy the PodGroup
-	notAssignedPercentage := float32(int(pg.Spec.MinMember)-assigned) / float32(pg.Spec.MinMember)
-	if notAssignedPercentage <= 0.1 {
+	notAssignedPercentage := float64(int(pg.Spec.MinMember)-assigned) / float64(pg.Spec.MinMember)
+	if notAssignedPercentage <= cs.pgRejectThreshold {
 		lh.V(4).Info("A small gap of pods to reach the quorum", "podGroup", klog.KObj(pg), "percentage", notAssignedPercentage)
 		return &framework.PostFilterResult{}, fwk.NewStatus(fwk.Unschedulable)
 	}

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -122,10 +122,11 @@ func TestPodGroupBackoffTime(t *testing.T) {
 				podInformer,
 			)
 			pl := &Coscheduling{
-				frameworkHandler: f,
-				pgMgr:            pgMgr,
-				scheduleTimeout:  &scheduleDuration,
-				pgBackoff:        pointer.Duration(1 * time.Second),
+				frameworkHandler:  f,
+				pgMgr:             pgMgr,
+				scheduleTimeout:   &scheduleDuration,
+				pgBackoff:         pointer.Duration(1 * time.Second),
+				pgRejectThreshold: 0.1,
 			}
 
 			informerFactory.Start(ctx.Done())
@@ -698,9 +699,10 @@ func TestPostFilter(t *testing.T) {
 				podInformer,
 			)
 			pl := &Coscheduling{
-				frameworkHandler: f,
-				pgMgr:            pgMgr,
-				scheduleTimeout:  &scheduleTimeout,
+				frameworkHandler:  f,
+				pgMgr:             pgMgr,
+				scheduleTimeout:   &scheduleTimeout,
+				pgRejectThreshold: 0.1, // default threshold
 			}
 
 			informerFactory.Start(ctx.Done())
@@ -715,6 +717,159 @@ func TestPostFilter(t *testing.T) {
 			}
 
 			_, got := pl.PostFilter(ctx, framework.NewCycleState(), tt.pod, nodeStatusReader)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Want %v, but got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestPostFilterRejectThreshold(t *testing.T) {
+	scheduleTimeout := 10 * time.Second
+	capacity := map[v1.ResourceName]string{
+		v1.ResourceCPU: "4",
+	}
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node").Capacity(capacity).Obj(),
+	}
+
+	nodeStatusReader := framework.NewDefaultNodeToStatus()
+	nodeStatusReader.Set("node", fwk.NewStatus(fwk.Success, ""))
+
+	// Helper to create N assigned pods (with NodeName set) for a PodGroup.
+	makeAssignedPods := func(count int) []*v1.Pod {
+		var pods []*v1.Pod
+		for i := 0; i < count; i++ {
+			name := fmt.Sprintf("assigned-%d", i)
+			pods = append(pods, st.MakePod().Name(name).Namespace("ns").UID(name).
+				Node("node").Label(v1alpha1.PodGroupLabel, "pg1").Obj())
+		}
+		return pods
+	}
+
+	rejectMsg := func() *fwk.Status {
+		return fwk.NewStatus(
+			fwk.Unschedulable,
+			"PodGroup ns/pg1 gets rejected due to Pod p is unschedulable even after PostFilter",
+		)
+	}
+	noRejectMsg := fwk.NewStatus(fwk.Unschedulable)
+
+	tests := []struct {
+		name          string
+		threshold     float64
+		minMember     int32
+		assignedCount int
+		want          *fwk.Status
+	}{
+		{
+			name:          "default 10%: 9/10 assigned (10% gap) → no rejection",
+			threshold:     0.1,
+			minMember:     10,
+			assignedCount: 9,
+			want:          noRejectMsg,
+		},
+		{
+			name:          "default 10%: 8/10 assigned (20% gap) → rejection",
+			threshold:     0.1,
+			minMember:     10,
+			assignedCount: 8,
+			want:          rejectMsg(),
+		},
+		{
+			name:          "0%: 9/10 assigned (10% gap) → rejection (always reject)",
+			threshold:     0.0,
+			minMember:     10,
+			assignedCount: 9,
+			want:          rejectMsg(),
+		},
+		{
+			name:          "100%: 0/10 assigned (100% gap) → no rejection (never reject)",
+			threshold:     1.0,
+			minMember:     10,
+			assignedCount: 0,
+			want:          noRejectMsg,
+		},
+		{
+			name:          "50%: 6/10 assigned (40% gap) → no rejection",
+			threshold:     0.5,
+			minMember:     10,
+			assignedCount: 6,
+			want:          noRejectMsg,
+		},
+		{
+			name:          "50%: 4/10 assigned (60% gap) → rejection",
+			threshold:     0.5,
+			minMember:     10,
+			assignedCount: 4,
+			want:          rejectMsg(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			assignedPods := makeAssignedPods(tt.assignedCount)
+			// The pod being evaluated in PostFilter (not assigned to a node).
+			pod := st.MakePod().Name("p").Namespace("ns").UID("p").
+				Label(v1alpha1.PodGroupLabel, "pg1").Obj()
+
+			var objs []runtime.Object
+			for _, p := range assignedPods {
+				objs = append(objs, p)
+			}
+			objs = append(objs, pod)
+			objs = append(objs, tu.MakePodGroup().Name("pg1").Namespace("ns").
+				MinMember(tt.minMember).Obj())
+
+			client, err := tu.NewFakeClient(objs...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			registeredPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			f, err := tf.NewFramework(
+				ctx,
+				registeredPlugins,
+				"default-scheduler",
+				fwkruntime.WithWaitingPods(fwkruntime.NewWaitingPodsMap()),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cs := clientsetfake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			podInformer := informerFactory.Core().V1().Pods()
+			pgMgr := core.NewPodGroupManager(
+				client,
+				tu.NewFakeSharedLister(assignedPods, nodes),
+				&scheduleTimeout,
+				podInformer,
+			)
+			pl := &Coscheduling{
+				frameworkHandler:  f,
+				pgMgr:             pgMgr,
+				scheduleTimeout:   &scheduleTimeout,
+				pgRejectThreshold: tt.threshold,
+			}
+
+			informerFactory.Start(ctx.Done())
+			if !clicache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced) {
+				t.Fatal("WaitForCacheSync failed")
+			}
+			addFunc := core.AddPodFactory(pgMgr)
+			for _, p := range assignedPods {
+				podInformer.Informer().GetStore().Add(p)
+				addFunc(p)
+			}
+
+			_, got := pl.PostFilter(ctx, framework.NewCycleState(), pod, nodeStatusReader)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Want %v, but got %v", tt.want, got)
 			}

--- a/site/content/en/docs/plugins/coscheduling.md
+++ b/site/content/en/docs/plugins/coscheduling.md
@@ -132,3 +132,67 @@ nginx-hqhhz   0/1     Pending   0          3s
 nginx-n47r7   0/1     Pending   0          3s
 nginx-n7vtq   0/1     Pending   0          3s
 ```
+
+### Advanced Configuration
+
+The Coscheduling plugin supports additional parameters to control backoff and rejection behavior when PodGroups fail scheduling.
+
+```yaml
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+profiles:
+- schedulerName: default-scheduler
+  pluginConfig:
+  - name: Coscheduling
+    args:
+      permitWaitingTimeSeconds: 60     # How long pods wait in Permit for quorum (default: 60)
+      podGroupBackoffSeconds: 10       # Backoff time after PodGroup rejection (default: 0, disabled)
+      podGroupRejectPercentage: 10      # Percentage of unassigned pods below which PostFilter skips rejection (default: 10)
+  plugins:
+    multiPoint:
+      enabled:
+      - name: Coscheduling
+    queueSort:
+      enabled:
+      - name: Coscheduling
+      disabled:
+      - name: "*"
+```
+
+#### `podGroupBackoffSeconds`
+
+When a PodGroup fails scheduling in PostFilter, setting `podGroupBackoffSeconds` to a positive value causes all pods in the group to be blocked from scheduling for the specified duration. This prevents wasteful scheduling cycles when the cluster clearly cannot accommodate the group.
+
+**How it works:**
+1. A pod fails the Filter phase and enters PostFilter.
+2. If the PodGroup has enough pods to meet its `minMember` quorum but scheduling still fails (e.g., insufficient resources), the PodGroup is placed in a backoff cache with a TTL equal to `podGroupBackoffSeconds`.
+3. During the backoff window, PreFilter immediately rejects all pods from the backed-off PodGroup with `UnschedulableAndUnresolvable`, preventing any scheduling attempts.
+4. After the TTL expires, pods can be scheduled again.
+
+**Important:** Backoff is only triggered when:
+- `podGroupBackoffSeconds > 0` (feature is enabled)
+- The percentage of unassigned pods exceeds `podGroupRejectPercentage` (the group is far from meeting quorum)
+- The total number of pods with the PodGroup label is at least `minMember` (enough pods exist to form the group)
+
+**Recommended values:**
+- `0` (default): Disabled. Pods retry immediately after failure.
+- `5-10`: For clusters with moderate resource contention.
+- `30-60`: For heavily oversubscribed clusters where resources change slowly.
+
+#### `podGroupRejectPercentage`
+
+Controls the percentage of unassigned pods (relative to `minMember`) below which PostFilter will **not** reject the PodGroup. This implements an optimistic scheduling strategy: when a PodGroup is close to meeting its quorum, the remaining pods are allowed to retry rather than rejecting the entire group.
+
+**How it works:**
+- PostFilter calculates the percentage of unassigned pods: `(minMember - assignedPods) / minMember * 100`.
+- If the unassigned percentage is at or below `podGroupRejectPercentage`, PostFilter returns `Unschedulable` without rejecting waiting pods or triggering backoff. The remaining pods get another chance to schedule.
+- If the unassigned percentage exceeds `podGroupRejectPercentage`, PostFilter rejects all waiting pods and (if `podGroupBackoffSeconds > 0`) triggers backoff.
+
+**Example:** With `minMember=100` and `podGroupRejectPercentage=10` (default):
+- 92 pods assigned (8% gap): No rejection — almost there, keep trying.
+- 80 pods assigned (20% gap): Rejection — the group clearly doesn't fit right now.
+
+**Values:**
+- `10` (default): Skip rejection when ≤10% of pods remain unassigned.
+- `0`: Always reject on any failure (disable optimistic behavior).
+- `100`: Never reject (fully optimistic — disable PostFilter group rejection entirely).


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The PostFilter extension point previously used a hardcoded 10% threshold
to decide whether to reject a PodGroup when scheduling fails. If the
percentage of unassigned pods was at or below 10%, PostFilter would
optimistically skip rejection and let remaining pods retry. This
threshold was not configurable or documented.

This commit:
    - Adds PodGroupRejectPercentage (int32, 0-100) to CoschedulingArgs
      with a default of 10 (preserving existing behavior)
    - Replaces the hardcoded 0.1 in PostFilter with the configurable value
      (converted from percentage to fraction internally)
    - Adds validation ensuring the value is between 0 and 100
    - Adds tests for the new parameter (defaults, validation, PostFilter
      behavior at various percentage values)
    - Documents both podGroupBackoffSeconds and PodGroupRejectPercentage
      in the plugin docs and KEP

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:
The newly introduced `PodGroupRejectPercentage` defaults to 10 (i.e. 10%) so there is no change in status quo unless the user chooses to configure this new setting differently for co-scheduling.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduce the new PodGroupRejectPercentage config knob to support both toggle of the rejection w/ backoff feature as well granularly control the percentage of pods (not-assigned to nodes) that can lead to rejection w/ backoff.
```


