### PR TITLE
nrt: cache: fix assumedResource drift

### DIFF
--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -149,6 +149,10 @@ func (ov *OverReserve) ReserveNodeResources(nodeName string, pod *corev1.Pod) {
 	lh := ov.lh.WithValues(logging.KeyPod, klog.KObj(pod), logging.KeyPodUID, logging.PodUID(pod), logging.KeyNode, nodeName)
 	ov.lock.Lock()
 	defer ov.lock.Unlock()
+	if !ov.nrts.Contains(nodeName) {
+		lh.V(5).Info("ignoring reserve", "nrtinfo", "missing")
+		return
+	}
 	nodeAssumedResources, ok := ov.assumedResources[nodeName]
 	if !ok {
 		nodeAssumedResources = newResourceStore(ov.lh)

--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -157,9 +157,6 @@ func (ov *OverReserve) ReserveNodeResources(nodeName string, pod *corev1.Pod) {
 
 	nodeAssumedResources.AddPod(pod)
 	lh.V(2).Info("post reserve", logging.KeyNode, nodeName, "assumedResources", nodeAssumedResources.String())
-
-	ov.nodesMaybeOverreserved.Delete(nodeName)
-	lh.V(6).Info("reset discard counter", logging.KeyNode, nodeName)
 }
 
 func (ov *OverReserve) UnreserveNodeResources(nodeName string, pod *corev1.Pod) {

--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -268,19 +268,26 @@ func (ov *OverReserve) Resync() {
 		return
 	}
 
+	nrtUpdates := ov.MakeNRTUpdatesForNodes(context.Background(), lh_, nodes)
+
+	ov.FlushNodes(lh_, nrtUpdates...)
+}
+
+func (ov *OverReserve) MakeNRTUpdatesForNodes(ctx context.Context, lh_ logr.Logger, nodes DesyncedNodes) []*topologyv1alpha2.NodeResourceTopology {
+	var nrtUpdates []*topologyv1alpha2.NodeResourceTopology
+
 	// node -> pod identifier (namespace, name)
 	nodeToObjsMap, err := makeNodeToPodDataMap(lh_, ov.podLister, ov.isPodRelevant)
 	if err != nil {
 		lh_.Error(err, "cannot find the mapping between running pods and nodes")
-		return
+		return nrtUpdates
 	}
 
-	var nrtUpdates []*topologyv1alpha2.NodeResourceTopology
 	for _, nodeName := range nodes.MaybeOverReserved {
 		lh := lh_.WithValues(logging.KeyNode, nodeName)
 
 		nrtCandidate := &topologyv1alpha2.NodeResourceTopology{}
-		if err := ov.client.Get(context.Background(), types.NamespacedName{Name: nodeName}, nrtCandidate); err != nil {
+		if err := ov.client.Get(ctx, types.NamespacedName{Name: nodeName}, nrtCandidate); err != nil {
 			lh.V(2).Info("failed to get NodeTopology", "error", err)
 			continue
 		}
@@ -324,7 +331,7 @@ func (ov *OverReserve) Resync() {
 		lh := lh_.WithValues(logging.KeyNode, nodeName)
 
 		nrtCandidate := &topologyv1alpha2.NodeResourceTopology{}
-		if err := ov.client.Get(context.Background(), types.NamespacedName{Name: nodeName}, nrtCandidate); err != nil {
+		if err := ov.client.Get(ctx, types.NamespacedName{Name: nodeName}, nrtCandidate); err != nil {
 			lh.V(2).Info("failed to get NodeTopology", "error", err)
 			continue
 		}
@@ -337,7 +344,7 @@ func (ov *OverReserve) Resync() {
 		nrtUpdates = append(nrtUpdates, nrtCandidate)
 	}
 
-	ov.FlushNodes(lh_, nrtUpdates...)
+	return nrtUpdates
 }
 
 // FlushNodes drops all the cached information about a given node, resetting its state clean.

--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -373,8 +373,10 @@ func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.Node
 }
 
 // to be used only in tests
-func (ov *OverReserve) Store() *nrtStore {
-	return ov.nrts
+func (ov *OverReserve) TestOnlyUpdateNRT(nrt *topologyv1alpha2.NodeResourceTopology) {
+	ov.lock.Lock()
+	defer ov.lock.Unlock()
+	ov.nrts.Update(nrt)
 }
 
 func makeNodeToPodDataMap(lh logr.Logger, podLister podlisterv1.PodLister, isPodRelevant podprovider.PodFilterFunc) (map[string][]podData, error) {

--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -183,6 +183,11 @@ func TestDirtyNodesNotUnmarkedOnReserve(t *testing.T) {
 		"node-4",
 	}
 
+	// NRTs must be in the store for Reserve to track assumed resources
+	for _, nodeName := range availNodes {
+		nrtCache.Store().Update(makeTestNRT(nodeName))
+	}
+
 	for _, nodeName := range availNodes {
 		nrtCache.ReserveNodeResources(nodeName, &corev1.Pod{})
 	}
@@ -203,6 +208,28 @@ func TestDirtyNodesNotUnmarkedOnReserve(t *testing.T) {
 
 	if dirtyNodes.DirtyCount() != 2 {
 		t.Errorf("both nodes should still be dirty after Reserve, got: %v", dirtyNodes.MaybeOverReserved)
+	}
+}
+
+func TestReserveSkipsWithoutNRT(t *testing.T) {
+	fakeClient, err := tu.NewFakeClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nrtCache := mustOverReserve(t, fakeClient, &fakePodLister{})
+
+	// Reserve on a node with no NRT in the store should be a no-op
+	nrtCache.ReserveNodeResources("ghost-node", &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	})
+
+	// assumedResources should not have an entry for the node
+	nrtCache.lock.Lock()
+	_, hasAssumed := nrtCache.assumedResources["ghost-node"]
+	nrtCache.lock.Unlock()
+	if hasAssumed {
+		t.Errorf("Reserve should not accumulate assumedResources for a node without NRT in the store")
 	}
 }
 

--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -168,7 +168,7 @@ func TestDirtyNodesMarkDiscarded(t *testing.T) {
 	}
 }
 
-func TestDirtyNodesUnmarkedOnReserve(t *testing.T) {
+func TestDirtyNodesNotUnmarkedOnReserve(t *testing.T) {
 	fakeClient, err := tu.NewFakeClient()
 	if err != nil {
 		t.Fatal(err)
@@ -196,17 +196,13 @@ func TestDirtyNodesUnmarkedOnReserve(t *testing.T) {
 		nrtCache.NodeMaybeOverReserved(nodeName, &corev1.Pod{})
 	}
 
-	// assume noe update which unblocks node-4
+	// Reserve does NOT clear the dirty flag; only FlushNodes does.
 	nrtCache.ReserveNodeResources("node-4", &corev1.Pod{})
-
-	expectedNodes := []string{
-		"node-1",
-	}
 
 	dirtyNodes = nrtCache.GetDesyncedNodes(klog.Background())
 
-	if !reflect.DeepEqual(dirtyNodes.MaybeOverReserved, expectedNodes) {
-		t.Errorf("got=%v expected=%v", dirtyNodes.MaybeOverReserved, expectedNodes)
+	if dirtyNodes.DirtyCount() != 2 {
+		t.Errorf("both nodes should still be dirty after Reserve, got: %v", dirtyNodes.MaybeOverReserved)
 	}
 }
 
@@ -647,6 +643,101 @@ func isNRTEqual(a, b *topologyv1alpha2.NodeResourceTopology) bool {
 	return equality.Semantic.DeepDerivative(a.Zones, b.Zones) &&
 		equality.Semantic.DeepDerivative(a.TopologyPolicies, b.TopologyPolicies) &&
 		equality.Semantic.DeepDerivative(a.Attributes, b.Attributes)
+}
+
+func TestResyncFingerprintMismatchKeepsNodeDirty(t *testing.T) {
+	fakeClient, err := tu.NewFakeClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fakePodLister := &fakePodLister{}
+
+	nrtCache := mustOverReserve(t, fakeClient, fakePodLister)
+
+	nodeTopologies := makeDefaultTestTopology()
+	for _, obj := range nodeTopologies {
+		nrtCache.Store().Update(obj)
+	}
+
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "namespace1",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node1",
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	// simulate this pod passes filtering
+	nrtCache.ReserveNodeResources("node1", testPod)
+
+	// simulate some time after the node is marked overreserved
+	nrtCache.NodeMaybeOverReserved("node1", &corev1.Pod{})
+
+	// NRT on the API server has a fingerprint that does NOT match the pods
+	// in the lister. This forces a ErrSignatureMismatch in Resync().
+	nrtWithBadFingerprint := &topologyv1alpha2.NodeResourceTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+		Attributes: topologyv1alpha2.AttributeList{
+			{
+				Name:  podfingerprint.Attribute,
+				Value: "pfp0vFFFFdeadbeef000000",
+			},
+		},
+		TopologyPolicies: []string{string(topologyv1alpha2.SingleNUMANodeContainerLevel)},
+		Zones: topologyv1alpha2.ZoneList{
+			{
+				Name: "node-0",
+				Type: "Node",
+				Resources: topologyv1alpha2.ResourceInfoList{
+					MakeTopologyResInfo(cpu, "32", "30"),
+					MakeTopologyResInfo(memory, "64Gi", "60Gi"),
+					MakeTopologyResInfo(nicResourceName, "16", "16"),
+				},
+			},
+			{
+				Name: "node-1",
+				Type: "Node",
+				Resources: topologyv1alpha2.ResourceInfoList{
+					MakeTopologyResInfo(cpu, "32", "22"),
+					MakeTopologyResInfo(memory, "64Gi", "44Gi"),
+					MakeTopologyResInfo(nicResourceName, "16", "16"),
+				},
+			},
+		},
+	}
+
+	runningPod := testPod.DeepCopy()
+	runningPod.Status.Phase = corev1.PodRunning
+
+	if err := fakeClient.Create(context.Background(), nrtWithBadFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	fakePodLister.AddPod(runningPod)
+
+	nrtCache.Resync()
+
+	dirtyNodes := nrtCache.GetDesyncedNodes(klog.Background())
+	if dirtyNodes.Len() != 1 || dirtyNodes.MaybeOverReserved[0] != "node1" {
+		t.Errorf("node should stay dirty after fingerprint mismatch, got: %v", dirtyNodes.MaybeOverReserved)
+	}
 }
 
 func TestUnknownNodeWithForeignPods(t *testing.T) {

--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -767,6 +767,165 @@ func TestResyncFingerprintMismatchKeepsNodeDirty(t *testing.T) {
 	}
 }
 
+func TestResyncReserveInterleaved(t *testing.T) {
+	fakeClient, err := tu.NewFakeClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	fakePodLister := &fakePodLister{}
+
+	nrtCache := mustOverReserve(t, fakeClient, fakePodLister)
+
+	nodeTopologies := makeDefaultTestTopology()
+	for _, obj := range nodeTopologies {
+		nrtCache.Store().Update(obj)
+	}
+
+	initialPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "namespace1",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node1",
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Step 1: pod passes filtering, node gets marked dirty.
+	nrtCache.ReserveNodeResources("node1", initialPod)
+	nrtCache.NodeMaybeOverReserved("node1", &corev1.Pod{}) // pod is only for logging purposes here
+
+	// NRT on the API server has a fingerprint that does NOT match
+	// the pods in the lister, forcing a fingerprint mismatch in
+	// MakeNRTUpdatesForNodes (resync cannot flush).
+	nrtWithBadFingerprint := &topologyv1alpha2.NodeResourceTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+		Attributes: topologyv1alpha2.AttributeList{
+			{
+				Name:  podfingerprint.Attribute,
+				Value: "pfp0vFFFFdeadbeef000000",
+			},
+		},
+		TopologyPolicies: []string{string(topologyv1alpha2.SingleNUMANodeContainerLevel)},
+		Zones: topologyv1alpha2.ZoneList{
+			{
+				Name: "node-0",
+				Type: "Node",
+				Resources: topologyv1alpha2.ResourceInfoList{
+					MakeTopologyResInfo(cpu, "32", "30"),
+					MakeTopologyResInfo(memory, "64Gi", "60Gi"),
+					MakeTopologyResInfo(nicResourceName, "16", "16"),
+				},
+			},
+			{
+				Name: "node-1",
+				Type: "Node",
+				Resources: topologyv1alpha2.ResourceInfoList{
+					MakeTopologyResInfo(cpu, "32", "30"),
+					MakeTopologyResInfo(memory, "64Gi", "60Gi"),
+					MakeTopologyResInfo(nicResourceName, "16", "16"),
+				},
+			},
+		},
+	}
+
+	runningPod := initialPod.DeepCopy()
+	runningPod.Status.Phase = corev1.PodRunning
+
+	if err := fakeClient.Create(ctx, nrtWithBadFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	fakePodLister.AddPod(runningPod)
+
+	// Step 2: Resync begins — get dirty nodes, then compute NRT updates.
+	// The fingerprint mismatch means nrtUpdates will be empty for node1.
+	lh := klog.Background()
+	nodes := nrtCache.GetDesyncedNodes(lh)
+	nrtUpdates := nrtCache.MakeNRTUpdatesForNodes(ctx, lh, nodes)
+
+	if len(nrtUpdates) != 0 {
+		t.Fatalf("expected no NRT updates due to fingerprint mismatch, got %d", len(nrtUpdates))
+	}
+
+	// Step 3: concurrent Reserve() arrives between MakeNRTUpdatesForNodes
+	// and FlushNodes — the exact window where the race occurred.
+	concurrentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "namespace1",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node1",
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	nrtCache.ReserveNodeResources("node1", concurrentPod)
+
+	// Step 4: Resync finishes — FlushNodes with the (empty) update list.
+	nrtCache.FlushNodes(lh, nrtUpdates...)
+
+	// Verify: node1 must still be dirty — the resync failed (fingerprint
+	// mismatch) and Reserve must NOT have cleared the dirty bit.
+	dirtyNodes := nrtCache.GetDesyncedNodes(lh)
+	if dirtyNodes.DirtyCount() != 1 {
+		t.Errorf("node should stay dirty after failed resync + concurrent reserve, got dirty count: %d", dirtyNodes.DirtyCount())
+	}
+
+	// Verify: assumed resources from BOTH pods must still be tracked.
+	// initialPod reserved 8 CPU + 16Gi per zone, concurrentPod reserved
+	// 4 CPU + 8Gi per zone. The base topology has 30 CPU / 60Gi available
+	// per zone, so we expect 30-8-4=18 CPU and 60Gi-16Gi-8Gi=36Gi.
+	nrtObj, _ := nrtCache.GetCachedNRTCopy(ctx, "node1", concurrentPod)
+	if nrtObj == nil {
+		t.Fatal("expected cached NRT for node1, got nil")
+	}
+	for _, zone := range nrtObj.Zones {
+		for _, zoneRes := range zone.Resources {
+			switch zoneRes.Name {
+			case cpu:
+				if expected := resource.MustParse("18"); zoneRes.Available.Cmp(expected) != 0 {
+					t.Errorf("zone %s: expected %s available CPU, got %s", zone.Name, expected.String(), zoneRes.Available.String())
+				}
+			case memory:
+				if expected := resource.MustParse("36Gi"); zoneRes.Available.Cmp(expected) != 0 {
+					t.Errorf("zone %s: expected %s available memory, got %s", zone.Name, expected.String(), zoneRes.Available.String())
+				}
+			}
+		}
+	}
+}
+
 func TestUnknownNodeWithForeignPods(t *testing.T) {
 	fakeClient, err := tu.NewFakeClient()
 	if err != nil {

--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -185,7 +185,7 @@ func TestDirtyNodesNotUnmarkedOnReserve(t *testing.T) {
 
 	// NRTs must be in the store for Reserve to track assumed resources
 	for _, nodeName := range availNodes {
-		nrtCache.Store().Update(makeTestNRT(nodeName))
+		nrtCache.TestOnlyUpdateNRT(makeTestNRT(nodeName))
 	}
 
 	for _, nodeName := range availNodes {
@@ -219,17 +219,45 @@ func TestReserveSkipsWithoutNRT(t *testing.T) {
 
 	nrtCache := mustOverReserve(t, fakeClient, &fakePodLister{})
 
-	// Reserve on a node with no NRT in the store should be a no-op
-	nrtCache.ReserveNodeResources("ghost-node", &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-	})
+	nodeTopologies := makeDefaultTestTopology()
+	for _, obj := range nodeTopologies {
+		nrtCache.TestOnlyUpdateNRT(obj)
+	}
 
-	// assumedResources should not have an entry for the node
-	nrtCache.lock.Lock()
-	_, hasAssumed := nrtCache.assumedResources["ghost-node"]
-	nrtCache.lock.Unlock()
-	if hasAssumed {
-		t.Errorf("Reserve should not accumulate assumedResources for a node without NRT in the store")
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	nrtCache.ReserveNodeResources("ghost-node", testPod)
+
+	nrtObj, _ := nrtCache.GetCachedNRTCopy(context.Background(), "ghost-node", testPod)
+	if nrtObj != nil {
+		t.Errorf("expected nil NRT for ghost node, got %v", nrtObj)
+	}
+
+	realNodeName := nodeTopologies[0].Name
+	nrtObj, _ = nrtCache.GetCachedNRTCopy(context.Background(), realNodeName, testPod)
+	if nrtObj == nil {
+		t.Fatalf("expected NRT for %q, got nil", realNodeName)
+	}
+	if !isNRTEqual(nrtObj, nodeTopologies[0]) {
+		t.Errorf("NRT for %q should be unchanged after ghost-node reserve:\ngot:  %v\nwant: %v", realNodeName, dumpNRT(nrtObj), dumpNRT(nodeTopologies[0]))
 	}
 }
 
@@ -271,7 +299,7 @@ func TestGetCachedNRTCopyReserve(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	testPod := &corev1.Pod{
@@ -323,7 +351,7 @@ func TestGetCachedNRTCopyReleaseNone(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	testPod := &corev1.Pod{
@@ -364,7 +392,7 @@ func TestGetCachedNRTCopyReserveRelease(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	testPod := &corev1.Pod{
@@ -406,7 +434,7 @@ func TestFlush(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	testPod := &corev1.Pod{
@@ -501,7 +529,7 @@ func TestResyncNoPodFingerprint(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	testPod := &corev1.Pod{
@@ -579,7 +607,7 @@ func TestResyncMatchFingerprint(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	testPod := &corev1.Pod{
@@ -684,7 +712,7 @@ func TestResyncFingerprintMismatchKeepsNodeDirty(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	testPod := &corev1.Pod{
@@ -780,7 +808,7 @@ func TestResyncReserveInterleaved(t *testing.T) {
 
 	nodeTopologies := makeDefaultTestTopology()
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	initialPod := &corev1.Pod{
@@ -1005,7 +1033,7 @@ func TestNodeWithForeignPods(t *testing.T) {
 		},
 	}
 	for _, obj := range nodeTopologies {
-		nrtCache.Store().Update(obj)
+		nrtCache.TestOnlyUpdateNRT(obj)
 	}
 
 	target := "node2"
@@ -1023,6 +1051,7 @@ func TestNodeWithForeignPods(t *testing.T) {
 }
 
 func mustOverReserve(t *testing.T, client ctrlclient.WithWatch, podLister podlisterv1.PodLister) *OverReserve {
+	t.Helper()
 	obj, err := NewOverReserve(context.Background(), klog.Background(), nil, client, podLister, podprovider.IsPodRelevantAlways)
 	if err != nil {
 		t.Fatalf("unexpected error creating cache: %v", err)

--- a/pkg/noderesourcetopology/cache/store.go
+++ b/pkg/noderesourcetopology/cache/store.go
@@ -34,7 +34,7 @@ import (
 )
 
 // nrtStore maps the NRT data by node name. It is not thread safe and needs to be protected by a lock.
-// data is intentionally copied each time it enters and exists the store. E.g, no pointer sharing.
+// data is intentionally copied each time it enters and exits the store. E.g, no pointer sharing.
 type nrtStore struct {
 	data map[string]*topologyv1alpha2.NodeResourceTopology
 	lh   logr.Logger


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Previously, when a node was marked dirty, a successful Reserve()  would have marked it clean. The reasoning was that if a node gets selected - thus Reserve() called upon it, then obviously the overallocation was wrong and the node could have run more workload.

If Reserve() happens concurrently with Resync(), Reserve() can clear the dirty node flag and corrupt the
internal state. If that happens, unflushed nodes become effectively invisible to future resync cycles.
The assumedResources become stuck (never flushed) on the affected nodes.
    
The safest fix is remove the dirty node clearing shortcut in Reserve().

Furthermore, ReserveNodeResources() was unconditionally tracking assumedResources
regardless if a node actually had NRT data or not. This caused `assumedResources` to grow unbounded in these cases.  The reason why the data is never cleared is that all the paths that mark a node for resync (NodeMaybeOverReserved, NodeHasForeignPods, nodesWithAttrUpdate) require the NRT to already be in the store.

#### Which issue(s) this PR fixes:
Fixes #N/A

#### Special notes for your reviewer:
Identified during the investigation of another issue: noderesourcetopologymatch doesn't handle correctly NRT objects created *after* the scheduler start. While this is not the recommended usage flow, it may happen on real clusters and must be supported. The fix for that issue depends on these fixes.

#### Does this PR introduce a user-facing change?
```release-note
Fix noderesourcetopology cache drift caused by TOCTOU race with its resync loop
```
