### PR TITLE
doc update for v0.34.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,22 @@ changed.
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch                                                       |
 |-------------------|---------------------------|-----------------------------------------------------------|------------------------------------------------------------|
+| v0.34.7           | v1.34.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.33.5           | v1.33.5                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.32.7           | v1.32.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.32.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
-| v0.31.8           | v1.31.8                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 
 | Controller | Compiled With k8s Version | Container Image                                       | Arch                                                       |
 |------------|---------------------------|-------------------------------------------------------|------------------------------------------------------------|
+| v0.34.7    | v1.34.7                   | registry.k8s.io/scheduler-plugins/controller:v0.34.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.33.5    | v1.33.5                   | registry.k8s.io/scheduler-plugins/controller:v0.33.5  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.32.7    | v1.32.7                   | registry.k8s.io/scheduler-plugins/controller:v0.32.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
-| v0.31.8    | v1.31.8                   | registry.k8s.io/scheduler-plugins/controller:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 
 <details>
 <summary>Older releases</summary>
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch                                                       |
 |-------------------|---------------------------|-----------------------------------------------------------|------------------------------------------------------------|
+| v0.31.8           | v1.31.8                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.30.12          | v1.30.12                  | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.30.12 | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.29.7           | v1.29.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.29.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.28.9           | v1.28.9                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.28.9  | linux/amd64<br>linux/arm64                                 |
@@ -91,6 +92,7 @@ changed.
 
 | Controller | Compiled With k8s Version | Container Image                                       | Arch                                                       |
 |------------|---------------------------|-------------------------------------------------------|------------------------------------------------------------|
+| v0.31.8    | v1.31.8                   | registry.k8s.io/scheduler-plugins/controller:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.30.12   | v1.30.12                  | registry.k8s.io/scheduler-plugins/controller:v0.30.12 | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.29.7    | v1.29.7                   | registry.k8s.io/scheduler-plugins/controller:v0.29.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.28.9    | v1.28.9                   | registry.k8s.io/scheduler-plugins/controller:v0.28.9  | linux/amd64<br>linux/arm64                                 |

--- a/doc/install.md
+++ b/doc/install.md
@@ -4,7 +4,7 @@
 
 <!-- toc -->
 - [Create a Kubernetes Cluster](#create-a-kubernetes-cluster)
-- [Install release v0.33.5 and use Coscheduling](#install-release-v0335-and-use-coscheduling)
+- [Install release v0.34.7 and use Coscheduling](#install-release-v0347-and-use-coscheduling)
   - [As a second scheduler](#as-a-second-scheduler)
   - [As a single scheduler (replacing the vanilla default-scheduler)](#as-a-single-scheduler-replacing-the-vanilla-default-scheduler)
 - [Test Coscheduling](#test-coscheduling)
@@ -24,7 +24,7 @@ If you do not have a cluster yet, create one by using one of the following provi
 * [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)
 * [minikube](https://minikube.sigs.k8s.io/)
 
-## Install release v0.33.5 and use Coscheduling
+## Install release v0.34.7 and use Coscheduling
 
 Note: we provide two ways to install the scheduler-plugin artifacts: as a second scheduler
 and as a single scheduler. Their pros and cons are as below:
@@ -152,7 +152,7 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     -     - --kubeconfig=/etc/kubernetes/scheduler.conf
     -     - --leader-elect=true
     19,20c20
-    +     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5
+    +     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7
     ---
     -     image: registry.k8s.io/kube-scheduler:v1.28.9
     50,52d49
@@ -166,14 +166,14 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     +     name: sched-cc
     ```
    
-1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5`
+1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7`
 
     ```bash
     $ kubectl get pod -n kube-system | grep kube-scheduler
     kube-scheduler-kind-control-plane            1/1     Running   0          3m27s
 
     $ kubectl get pods -l component=kube-scheduler -n kube-system -o=jsonpath="{.items[0].spec.containers[0].image}{'\n'}"
-    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5
+    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7
     ```
    
     > **⚠️Troubleshooting:** If the kube-scheudler is not up, you may need to restart kubelet service inside the kind control plane (`systemctl restart kubelet.service`)

--- a/manifests/appgroup/deploy-sig-scheduling-controller-and-scheduler.yaml
+++ b/manifests/appgroup/deploy-sig-scheduling-controller-and-scheduler.yaml
@@ -89,7 +89,7 @@ spec:
       serviceAccountName: scheduler-plugins-controller
       containers:
         - name: scheduler-plugins-controller
-          image: registry.k8s.io/scheduler-plugins/controller:v0.33.5
+          image: registry.k8s.io/scheduler-plugins/controller:v0.34.7
           imagePullPolicy: IfNotPresent
 ---
 # Install the scheduler
@@ -113,7 +113,7 @@ spec:
       nodeSelector: # To deploy in master node
         node-role.kubernetes.io/master: ""
       containers:
-        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5
+        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7
           args: # For extra info, please add verbose level: e.g., - -v=9
             - --authentication-kubeconfig=/etc/kubernetes/scheduler.conf
             - --authorization-kubeconfig=/etc/kubernetes/scheduler.conf

--- a/manifests/install/all-in-one.yaml
+++ b/manifests/install/all-in-one.yaml
@@ -96,5 +96,5 @@ spec:
       serviceAccountName: scheduler-plugins-controller
       containers:
       - name: scheduler-plugins-controller
-        image: registry.k8s.io/scheduler-plugins/controller:v0.33.5
+        image: registry.k8s.io/scheduler-plugins/controller:v0.34.7
         imagePullPolicy: IfNotPresent

--- a/manifests/install/charts/as-a-second-scheduler/Chart.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.5
+version: 0.34.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.33.5
+appVersion: 0.34.7

--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the as-a-second-schedul
 | Parameter                      | Description                  | Default                                                                                         |
 |--------------------------------|------------------------------|-------------------------------------------------------------------------------------------------|
 | `scheduler.name`               | Scheduler name               | `scheduler-plugins-scheduler`                                                                   |
-| `scheduler.image`              | Scheduler image              | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5`                                      |
+| `scheduler.image`              | Scheduler image              | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7`                                      |
 | `scheduler.command`            | Scheduler command            | `["/bin/kube-scheduler"]`                                                                       |
 | `scheduler.leaderElect`        | Scheduler leaderElection     | `false`                                                                                         |
 | `scheduler.replicaCount`       | Scheduler replicaCount       | `1`                                                                                             |

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -4,7 +4,7 @@
 
 scheduler:
   name: scheduler-plugins-scheduler
-  image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5
+  image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7
   command:
   - /bin/kube-scheduler
   replicaCount: 1
@@ -17,7 +17,7 @@ scheduler:
 
 controller:
   name: scheduler-plugins-controller
-  image: registry.k8s.io/scheduler-plugins/controller:v0.33.5
+  image: registry.k8s.io/scheduler-plugins/controller:v0.34.7
   replicaCount: 1
   leaderElect: false
   priorityClassName: ""

--- a/manifests/networktopology/deploy-sig-scheduling-controller-and-scheduler.yaml
+++ b/manifests/networktopology/deploy-sig-scheduling-controller-and-scheduler.yaml
@@ -89,7 +89,7 @@ spec:
       serviceAccountName: scheduler-plugins-controller
       containers:
         - name: scheduler-plugins-controller
-          image: registry.k8s.io/scheduler-plugins/controller:v0.33.5
+          image: registry.k8s.io/scheduler-plugins/controller:v0.34.7
           imagePullPolicy: IfNotPresent
 ---
 # Install the scheduler
@@ -113,7 +113,7 @@ spec:
       nodeSelector: # To deploy in master node
         node-role.kubernetes.io/master: ""
       containers:
-        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5
+        - image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7
           args: # For extra info, please add verbose level: e.g., - -v=9
             - --authentication-kubeconfig=/etc/kubernetes/scheduler.conf
             - --authorization-kubeconfig=/etc/kubernetes/scheduler.conf

--- a/site/content/en/_index.md
+++ b/site/content/en/_index.md
@@ -62,21 +62,22 @@ changed.
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch                                                       |
 |-------------------|---------------------------|-----------------------------------------------------------|------------------------------------------------------------|
+| v0.34.7           | v1.34.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.33.5           | v1.33.5                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.32.7           | v1.32.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.32.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
-| v0.31.8           | v1.31.8                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 
 | Controller | Compiled With k8s Version | Container Image                                       | Arch                                                       |
 |------------|---------------------------|-------------------------------------------------------|------------------------------------------------------------|
+| v0.34.7    | v1.34.7                   | registry.k8s.io/scheduler-plugins/controller:v0.34.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.33.5    | v1.33.5                   | registry.k8s.io/scheduler-plugins/controller:v0.33.5  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.32.7    | v1.32.7                   | registry.k8s.io/scheduler-plugins/controller:v0.32.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
-| v0.31.8    | v1.31.8                   | registry.k8s.io/scheduler-plugins/controller:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 
 <details>
 <summary>Older releases</summary>
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch                                                       |
 |-------------------|---------------------------|-----------------------------------------------------------|------------------------------------------------------------|
+| v0.31.8           | v1.31.8                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.30.12          | v1.30.12                  | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.30.12 | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.29.7           | v1.29.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.29.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.28.9           | v1.28.9                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.28.9  | linux/amd64<br>linux/arm64                                 |
@@ -94,6 +95,7 @@ changed.
 
 | Controller | Compiled With k8s Version | Container Image                                       | Arch                                                       |
 |------------|---------------------------|-------------------------------------------------------|------------------------------------------------------------|
+| v0.31.8    | v1.31.8                   | registry.k8s.io/scheduler-plugins/controller:v0.31.8  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.30.12   | v1.30.12                  | registry.k8s.io/scheduler-plugins/controller:v0.30.12 | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.29.7    | v1.29.7                   | registry.k8s.io/scheduler-plugins/controller:v0.29.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.28.9    | v1.28.9                   | registry.k8s.io/scheduler-plugins/controller:v0.28.9  | linux/amd64<br>linux/arm64                                 |

--- a/site/content/en/docs/user-guide/installation.md
+++ b/site/content/en/docs/user-guide/installation.md
@@ -8,7 +8,7 @@ weight: 1
 
 <!-- toc -->
 - [Create a Kubernetes Cluster](#create-a-kubernetes-cluster)
-- [Install release v0.33.5 and use Coscheduling](#install-release-v0335-and-use-coscheduling)
+- [Install release v0.34.7 and use Coscheduling](#install-release-v0347-and-use-coscheduling)
   - [As a second scheduler](#as-a-second-scheduler)
   - [As a single scheduler (replacing the vanilla default-scheduler)](#as-a-single-scheduler-replacing-the-vanilla-default-scheduler)
 - [Test Coscheduling](#test-coscheduling)
@@ -28,7 +28,7 @@ If you do not have a cluster yet, create one by using one of the following provi
 * [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)
 * [minikube](https://minikube.sigs.k8s.io/)
 
-## Install release v0.33.5 and use Coscheduling
+## Install release v0.34.7 and use Coscheduling
 
 Note: we provide two ways to install the scheduler-plugin artifacts: as a second scheduler
 and as a single scheduler. Their pros and cons are as below:
@@ -150,7 +150,7 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     >     - --kubeconfig=/etc/kubernetes/scheduler.conf
     >     - --leader-elect=true
     19,20c20
-    <     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5
+    <     image: registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7
     ---
     >     image: registry.k8s.io/kube-scheduler:v1.28.9
     50,52d49
@@ -164,14 +164,14 @@ any vanilla Kubernetes scheduling capability. Instead, a lot of extra out-of-box
     <     name: sched-cc
     ```
 
-1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5`
+1. Verify that kube-scheduler pod is running properly with a correct image: `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7`
 
     ```bash
     $ kubectl get pod -n kube-system | grep kube-scheduler
     kube-scheduler-kind-control-plane            1/1     Running   0          3m27s
 
     $ kubectl get pods -l component=kube-scheduler -n kube-system -o=jsonpath="{.items[0].spec.containers[0].image}{'\n'}"
-    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5
+    registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7
     ```
 
     > **⚠️Troubleshooting:** If the kube-scheudler is not up, you may need to restart kubelet service inside the kind control plane (`systemctl restart kubelet.service`)

--- a/site/content/en/docs/user-guide/installing-the-chart.md
+++ b/site/content/en/docs/user-guide/installing-the-chart.md
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the as-a-second-schedul
 | Parameter                      | Description                  | Default                                                                                         |
 |--------------------------------|------------------------------|-------------------------------------------------------------------------------------------------|
 | `scheduler.name`               | Scheduler name               | `scheduler-plugins-scheduler`                                                                   |
-| `scheduler.image`              | Scheduler image              | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5`                                      |
+| `scheduler.image`              | Scheduler image              | `registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7`                                      |
 | `scheduler.command`            | Scheduler command            | `["/bin/kube-scheduler"]`                                                                       |
 | `scheduler.leaderElect`        | Scheduler leaderElection     | `false`                                                                                         |
 | `scheduler.replicaCount`       | Scheduler replicaCount       | `1`                                                                                             |


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

> [!NOTE]
> Merging this PR doesn't meant registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7 is live.
> In terms of release process, merging this and then cut a v0.34.7 tag can ensure tag-based Helm chart is in-sync.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
