### PR TITLE
build: fix deprecated cloudbuild base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ local-image: REGISTRY="localhost:5000/scheduler-plugins"
 local-image: EXTRA_ARGS="--load"
 local-image: clean build-images
 
-.PHONY: release-images
+.PHONY: push-images
 push-images: EXTRA_ARGS="--push"
 push-images: build-images
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,12 +9,13 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
   # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     env:
     - RELEASE_VERSION=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint
+    - GOTOOLCHAIN=auto
     args:
     - push-images
 substitutions:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Lastest image push failed in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-scheduler-plugins-push-images/2045326721602818048:

```
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36" failed: error pulling build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36": retry budget exhausted (10 attempts): step exited with non-zero status: 1
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
