### PR TITLE
release: pin gh actions to commit SHAs and replace softprops/action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -11,8 +11,8 @@ jobs:
       contents: write
     if: github.event_name != 'pull_request'
     steps:
-    - uses: actions/checkout@v4
-    - uses: azure/setup-helm@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
       with:
          version: 'latest'
          token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,7 +22,7 @@ jobs:
       run: |
         helm package ./manifests/install/charts/as-a-second-scheduler
     - name: Upload to Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: "*.tgz"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -22,7 +22,7 @@ jobs:
       run: |
         helm package ./manifests/install/charts/as-a-second-scheduler
     - name: Upload to Release
-      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: "*.tgz"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload ${{ github.ref_name }} *.tgz


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area release

#### What this PR does / why we need it:

It seems latests GitHub action requires a sha commit instead of tag:

```
Error: The actions actions/checkout@v4, azure/setup-helm@v3, and softprops/action-gh-release@v1 are not allowed in kubernetes-sigs/scheduler-plugins because all actions must be pinned to a full-length commit SHA.
```

This PR introduces changes to:

- Pin the following actions to their verified commit SHAs:
    - actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
    - azure/setup-helm@v3 → 5119fcb9089d432beecbf79bb2c7915207344b78
- Eliminate dependency on softprops/action-gh-release to use `gh` CLI directly

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
