### PR TITLE
docs: clarify that `scoringStrategy` affects worker node selection

### DIFF
--- a/pkg/noderesourcetopology/README.md
+++ b/pkg/noderesourcetopology/README.md
@@ -119,6 +119,9 @@ profiles:
 #### ScoringStrategy
 
 The topology-aware scheduler supports four scoring strategies. You can set a strategy via SchedulerConfigConfiguration, by setting the scoringStrategy option.
+
+**NOTE:** The scoring strategy affects **worker node** selection only — it determines how worker nodes are ranked relative to each other. It does **not** control which NUMA node is selected within a worker node. Once the scheduler has selected a worker node for a pod, it is the **kubelet** (running on that worker node) that decides which NUMA node(s) to use based on its Topology Manager policy. 
+
 There are four supported strategies:
 
 * MostAllocated
@@ -126,12 +129,12 @@ There are four supported strategies:
 * LeastAllocated
 * LeastNUMANodes
 
-The MostAllocated, BalancedAllocation and LeastAllocated strategies only work with the single-numa-node Topology Manager policy and indicate how score of the worker
+The MostAllocated, BalancedAllocation and LeastAllocated strategies only work with the single-numa-node Topology Manager policy and indicate how the score of each worker
 node will be calculated based on current utilization:
 
-* MostAllocated - favors node with the least amount of available resources
-* BalancedAllocation - favors node with balanced resource usage rate
-* LeastAllocated - favors node with the most amount of available resource
+* MostAllocated - favors the worker node with the least amount of available resources
+* BalancedAllocation - favors the worker node with balanced resource usage rate
+* LeastAllocated - favors the worker node with the most amount of available resources
 
 The LeastNUMANodes strategy works with all the Topology Manager policies and favors nodes which require the least amount of topology zones to satisfy the resource requests for a given pod.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

Users may mistakenly expect the scoringStrategy (e.g. LeastAllocated) to influence NUMA node selection within a worker node. Clarify that the strategy only ranks worker nodes against each other, and that NUMA node assignment is the kubelet's responsibility.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes-sigs/scheduler-plugins/issues/956

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
