### PR TITLE
fix: create GitHub release before uploading helm chart asset

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -25,4 +25,6 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload ${{ github.ref_name }} *.tgz
+      run: |
+        gh release create ${{ github.ref_name }} --generate-notes || true
+        gh release upload ${{ github.ref_name }} *.tgz --clobber


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/area release

#### What this PR does / why we need it:

The previous fix (fdb7d62) replaced softprops/action-gh-release with `gh release upload`, but `gh release upload` only attaches assets to an existing release - it does not create one. The old action handled release creation implicitly, so the helm chart upload now fails with "release not found" when no release exists for the tag.

```
Run gh release upload v0.34.7 *.tgz
  gh release upload v0.34.7 *.tgz
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
release not found
Error: Process completed with exit code 1.
```

This PR fixes this by first running `gh release create` (with `|| true` to no-op if the release already exists), then uploading the chart with `--clobber` to allow safe re-runs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
