### PR TITLE
restrict helm release workflow to exact vX.Y.Z tags

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -2,7 +2,7 @@ name: Releases
 on:
   push:
     tags:
-    - v*
+    - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   releases:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area release

#### What this PR does / why we need it:

Avoid triggering the release workflow on pre-release or suffixed tags like v1.2.3-rc1 by narrowing the tag filter pattern.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
release: restrict helm release workflow to exact vX.Y.Z tags
```
