### PR TITLE
fix: use configured rest.Config for controller manager

### DIFF
--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -47,7 +47,7 @@ func Run(s *ServerRunOptions) error {
 
 	// Controller Runtime Controllers
 	ctrl.SetLogger(klogr.New())
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: s.MetricsAddr,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The controller manager was calling `ctrl.GetConfigOrDie()` directly when creating the manager, ignoring the QPS and Burst settings that were already configured on the `rest.Config` variable. This fix uses the existing `config` variable which already has `ApiServerQPS` and `ApiServerBurst` applied.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The `config` variable is created at the top of `Run()` via `ctrl.GetConfigOrDie()` and then has QPS/Burst set on it. The old code was calling `ctrl.GetConfigOrDie()` a second time in `ctrl.NewManager()`, effectively discarding those settings.

#### Does this PR introduce a user-facing change?

```release-note
Fix controller manager to respect ApiServerQPS and ApiServerBurst flag settings.
```