### PR TITLE
nrt: overreserve: consider only sidecars containers

### DIFF
--- a/pkg/noderesourcetopology/resourcerequests/exclusive.go
+++ b/pkg/noderesourcetopology/resourcerequests/exclusive.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
 func IncludeNonNative(pod *corev1.Pod) bool {
@@ -40,9 +41,22 @@ func IncludeNonNative(pod *corev1.Pod) bool {
 	}
 	return false
 }
+
+// AreExclusiveForPod checks if the given pod's containers are consuming exclusive resources
+// in the steady state of the pod, i.e. after the irrestartable init containers have finished running.
 func AreExclusiveForPod(pod *corev1.Pod) bool {
 	qos := v1qos.GetPodQOS(pod)
-	return areExclusiveForAnyContainer(qos, append(pod.Spec.InitContainers, pod.Spec.Containers...))
+
+	// filter out init containers with restart policy other than Always because these are *supposed* to
+	// run fast and finish, hence not consuming exclusive resources in a steady state while the pod is Running.
+	restartableInitCnts := []corev1.Container{}
+	for _, ctr := range pod.Spec.InitContainers {
+		if !util.IsSidecarInitContainer(&ctr) {
+			continue
+		}
+		restartableInitCnts = append(restartableInitCnts, ctr)
+	}
+	return areExclusiveForAnyContainer(qos, append(restartableInitCnts, pod.Spec.Containers...))
 }
 
 func areExclusiveForAnyContainer(qos corev1.PodQOSClass, containers []corev1.Container) bool {

--- a/pkg/noderesourcetopology/resourcerequests/exclusive_test.go
+++ b/pkg/noderesourcetopology/resourcerequests/exclusive_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 type testCase struct {
@@ -122,6 +123,35 @@ func coreTestCases() []testCase {
 				},
 			},
 			expectedNonNative: false,
+			expectedExclusive: false,
+		},
+		{
+			name: "single-sidecar-initcontainer-gu-no-devs",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							},
+							RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+						},
+					},
+				},
+			},
+			expectedNonNative: false,
 			expectedExclusive: true,
 		},
 		{
@@ -169,6 +199,33 @@ func coreTestCases() []testCase {
 									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
 								},
 							},
+						},
+					},
+				},
+			},
+			expectedNonNative: true,
+			expectedExclusive: false,
+		},
+		{
+			name: "single-sidecar-initcontainer-devs-only",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
+								},
+							},
+							RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
NRT is using PodResourcesAPI to determine the PFP sign which is compared with the one computed by scheduler and is expected to both be synced, hence computing both from each side need to use the same filter on pods.

Non-guaranteed pods with regular (non-restartable) init containers that request exclusive non-native resources (i.e. devices) are not included in the NRT-PFP sign because they are not reported in by the PodResourcesAPI (see https://github.com/kubernetes/kubernetes/issues/126765). The reason for that is that regular init containers are supposed to run fast. The mismatch in PFPs causes the scheduler to stall on `invalid topology data` for the node on which this opd is running.

This commit matches the NRT-computed-PFP filter on pods and drops pods with non-restartable init-containers from being included in the scheduler computed PFP.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #979 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
