### PR TITLE
Revert "add QueueingHintFn to coscheduling EventsToRegister"

### DIFF
--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -28,7 +28,6 @@ import (
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
-	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 	"sigs.k8s.io/scheduler-plugins/apis/config"
 	"sigs.k8s.io/scheduler-plugins/apis/config/validation"
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling"
@@ -112,69 +111,14 @@ func New(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin
 }
 
 func (cs *Coscheduling) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	// To register a custom event, follow the naming convention at:
+	// https://github.com/kubernetes/kubernetes/pull/101394
+	// Please follow: eventhandlers.go#L403-L410
 	pgGVK := fmt.Sprintf("podgroups.v1alpha1.%v", scheduling.GroupName)
 	return []fwk.ClusterEventWithHint{
-		// A new pod being added might complete the sibling count needed for a PodGroup's minMember.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add}, QueueingHintFn: cs.isSchedulableAfterPodAdded},
-		// An assigned pod being deleted (or un-assumed after Permit timeout) frees cluster resources,
-		// which may allow a previously resource-blocked PodGroup to schedule.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: cs.isSchedulableAfterPodDeleted},
-		// A PodGroup being added or updated can make a waiting pod schedulable.
-		{Event: fwk.ClusterEvent{Resource: fwk.EventResource(pgGVK), ActionType: fwk.Add | fwk.Update}, QueueingHintFn: cs.isSchedulableAfterPodGroupChanged},
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add}},
+		{Event: fwk.ClusterEvent{Resource: fwk.EventResource(pgGVK), ActionType: fwk.Add | fwk.Update}},
 	}, nil
-}
-
-func (cs *Coscheduling) isSchedulableAfterPodAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	_, addedPod, err := schedutil.As[*v1.Pod](oldObj, newObj)
-	if err != nil {
-		return fwk.Queue, err
-	}
-
-	pgLabel := util.GetPodGroupLabel(pod)
-	if pgLabel == "" || pod.Namespace != addedPod.Namespace || pgLabel != util.GetPodGroupLabel(addedPod) {
-		logger.V(5).Info("another pod was added but it doesn't belong to the same PodGroup",
-			"pod", klog.KObj(pod), "podGroupLabel", pgLabel, "addedPod", klog.KObj(addedPod))
-		return fwk.QueueSkip, nil
-	}
-
-	logger.V(5).Info("a sibling pod was added, which may make the pod schedulable",
-		"pod", klog.KObj(pod), "podGroupLabel", pgLabel, "addedPod", klog.KObj(addedPod))
-	return fwk.Queue, nil
-}
-
-func (cs *Coscheduling) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	deletedPod, _, err := schedutil.As[*v1.Pod](oldObj, newObj)
-	if err != nil {
-		return fwk.Queue, err
-	}
-
-	if deletedPod.Spec.NodeName == "" {
-		logger.V(5).Info("the deleted pod was unscheduled and wouldn't free cluster resources",
-			"pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-		return fwk.QueueSkip, nil
-	}
-
-	logger.V(5).Info("an assigned pod was deleted, which may free resources and make the pod schedulable",
-		"pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-	return fwk.Queue, nil
-}
-
-func (cs *Coscheduling) isSchedulableAfterPodGroupChanged(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	_, pg, err := schedutil.As[*v1alpha1.PodGroup](oldObj, newObj)
-	if err != nil {
-		return fwk.Queue, err
-	}
-
-	pgLabel := util.GetPodGroupLabel(pod)
-	if pgLabel == "" || pod.Namespace != pg.Namespace || pgLabel != pg.Name {
-		logger.V(5).Info("PodGroup was changed but it doesn't match the pod's PodGroup",
-			"pod", klog.KObj(pod), "podGroupLabel", pgLabel, "changedPodGroup", klog.KObj(pg))
-		return fwk.QueueSkip, nil
-	}
-
-	logger.V(5).Info("PodGroup was changed and it matches the pod's PodGroup, which may make the pod schedulable",
-		"pod", klog.KObj(pod), "podGroupLabel", pgLabel, "changedPodGroup", klog.KObj(pg))
-	return fwk.Queue, nil
 }
 
 // Name returns name of the plugin. It is used in logs, etc.


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake
/kind regression

#### What this PR does / why we need it:

This reverts the QueueingHintFns added in #972, which regressed the `pull-scheduler-plugins-integration-test-master` CI job: TestCoschedulingPlugin consistently times out (120s) in the "different priority" cases (t5/t6) where a higher-priority workload must win a contended node against a lower-priority PodGroup.

With SchedulerQueueingHints GA in k8s 1.35, an unschedulable pod is only re-queued when a registered event's hint returns Queue. The added hints are too restrictive for coscheduling's cross-PodGroup, priority-driven behavior:

  - Pod/Add was limited to same-PodGroup siblings, so a higher-priority group that becomes schedulable is no longer re-queued when another group changes.
  - A new Pod/Delete registration lets a lower-priority gang re-grab memory freed by its own Permit timeouts, livelocking ahead of higher-priority pods.

Under load a lower-priority gang reserves a Permit slot first, and the precise hints suppress the retries that previously let higher-priority pods recover or preempt, so scheduling stalls until the test times out. Reproduced locally: with the hints, 4/4 parallel runs fail; reverted, 4/4 pass.

Restoring the original EventsToRegister (Pod/Add and PodGroup Add|Update with no hints) brings back the behavior that has been stable for years. Precise hints can be revisited separately with integration coverage that exercises these priority/anti-affinity scenarios under load.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
