### PR TITLE
[NodeTopologyMatch]: improve exclusive resource detection

### DIFF
--- a/pkg/noderesourcetopology/cache/foreign_pods.go
+++ b/pkg/noderesourcetopology/cache/foreign_pods.go
@@ -39,14 +39,15 @@ var (
 	onlyExclusiveResources = false
 )
 
-func SetupForeignPodsDetector(lh logr.Logger, schedProfileName string, podInformer k8scache.SharedInformer, cc Interface) {
+func SetupForeignPodsDetector(lh logr.Logger, schedProfileName string, podInformer k8scache.SharedInformer, cc *OverReserve) {
 	foreignCache := func(obj interface{}) {
 		pod, ok := obj.(*corev1.Pod)
 		if !ok {
 			lh.V(3).Info("unsupported object", "kind", fmt.Sprintf("%T", obj))
 			return
 		}
-		if !IsForeignPod(pod) {
+		nrtResources := cc.nrtResNames.Get(pod.Spec.NodeName)
+		if !IsForeignPod(pod, nrtResources) {
 			return
 		}
 
@@ -78,7 +79,7 @@ func RegisterSchedulerProfileName(lh logr.Logger, schedProfileName string) {
 	lh.V(5).Info("registered scheduler profiles", "names", schedProfileNames.UnsortedList())
 }
 
-func IsForeignPod(pod *corev1.Pod) bool {
+func IsForeignPod(pod *corev1.Pod, nrtResources sets.Set[corev1.ResourceName]) bool {
 	if pod.Spec.NodeName == "" {
 		// nothing to do yet
 		return false
@@ -90,7 +91,7 @@ func IsForeignPod(pod *corev1.Pod) bool {
 	if !onlyExclusiveResources {
 		return true
 	}
-	return resourcerequests.AreExclusiveForPod(pod)
+	return resourcerequests.AreExclusiveForPod(pod, nrtResources)
 }
 
 // for testing only; NOT thread safe

--- a/pkg/noderesourcetopology/cache/foreign_pods_test.go
+++ b/pkg/noderesourcetopology/cache/foreign_pods_test.go
@@ -22,15 +22,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
 func TestIsForeignPod(t *testing.T) {
 	tests := []struct {
-		name         string
-		profileNames []string
-		pod          *corev1.Pod
-		expected     bool
+		name          string
+		profileNames  []string
+		pod           *corev1.Pod
+		nrtResources  sets.Set[corev1.ResourceName]
+		exclusiveOnly bool
+		expected      bool
 	}{
 		{
 			name: "empty",
@@ -191,6 +194,57 @@ func TestIsForeignPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "exclusive-only-dev-in-nrt",
+			profileNames:  []string{"secondary-scheduler"},
+			exclusiveOnly: true,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "random-node",
+					Containers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtResources: sets.New(corev1.ResourceName("veryfast.io/fpga")),
+			expected:     true,
+		},
+		{
+			name:          "exclusive-only-dev-not-in-nrt",
+			profileNames:  []string{"secondary-scheduler"},
+			exclusiveOnly: true,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "random-node",
+					Containers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -199,8 +253,13 @@ func TestIsForeignPod(t *testing.T) {
 				RegisterSchedulerProfileName(klog.Background(), profileName)
 			}
 			defer CleanRegisteredSchedulerProfileNames()
+			defer TrackAllForeignPods()
 
-			got := IsForeignPod(tt.pod)
+			if tt.exclusiveOnly {
+				TrackOnlyForeignPodsWithExclusiveResources()
+			}
+
+			got := IsForeignPod(tt.pod, tt.nrtResources)
 			if got != tt.expected {
 				t.Errorf("%s: pod %q foreign status got %v expected %v", tt.name, tt.pod.Name, got, tt.expected)
 			}

--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -47,6 +47,7 @@ type OverReserve struct {
 	lock             sync.Mutex
 	generation       uint64
 	nrts             *nrtStore
+	nrtResNames      *nrtResourcesStore
 	assumedResources map[string]*resourceStore // nodeName -> resourceStore
 	// nodesMaybeOverreserved counts how many times a node is filtered out. This is used as trigger condition to try
 	// to resync nodes. See The documentation of Resync() below for more details.
@@ -77,6 +78,7 @@ func NewOverReserve(ctx context.Context, lh logr.Logger, cfg *apiconfig.NodeReso
 		lh:                     lh,
 		client:                 client,
 		nrts:                   newNrtStore(lh, nrtObjs.Items),
+		nrtResNames:            newNrtResourcesStore(nrtObjs.Items),
 		assumedResources:       make(map[string]*resourceStore),
 		nodesMaybeOverreserved: newCounter(),
 		nodesWithForeignPods:   newCounter(),
@@ -277,7 +279,7 @@ func (ov *OverReserve) MakeNRTUpdatesForNodes(ctx context.Context, lh_ logr.Logg
 	var nrtUpdates []*topologyv1alpha2.NodeResourceTopology
 
 	// node -> pod identifier (namespace, name)
-	nodeToObjsMap, err := makeNodeToPodDataMap(lh_, ov.podLister, ov.isPodRelevant)
+	nodeToObjsMap, err := makeNodeToPodDataMap(lh_, ov.podLister, ov.isPodRelevant, ov.nrtResNames.Get)
 	if err != nil {
 		lh_.Error(err, "cannot find the mapping between running pods and nodes")
 		return nrtUpdates
@@ -355,6 +357,7 @@ func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.Node
 	for _, nrt := range nrts {
 		lh.V(2).Info("flushing", logging.KeyNode, nrt.Name)
 		ov.nrts.Update(nrt)
+		ov.nrtResNames.Update(nrt)
 		delete(ov.assumedResources, nrt.Name)
 		ov.nodesMaybeOverreserved.Delete(nrt.Name)
 		ov.nodesWithForeignPods.Delete(nrt.Name)
@@ -379,7 +382,7 @@ func (ov *OverReserve) TestOnlyUpdateNRT(nrt *topologyv1alpha2.NodeResourceTopol
 	ov.nrts.Update(nrt)
 }
 
-func makeNodeToPodDataMap(lh logr.Logger, podLister podlisterv1.PodLister, isPodRelevant podprovider.PodFilterFunc) (map[string][]podData, error) {
+func makeNodeToPodDataMap(lh logr.Logger, podLister podlisterv1.PodLister, isPodRelevant podprovider.PodFilterFunc, nrtResourcesLookup NRTResourcesLookupFunc) (map[string][]podData, error) {
 	nodeToObjsMap := make(map[string][]podData)
 	pods, err := podLister.List(labels.Everything())
 	if err != nil {
@@ -389,11 +392,12 @@ func makeNodeToPodDataMap(lh logr.Logger, podLister podlisterv1.PodLister, isPod
 		if !isPodRelevant(lh, pod) {
 			continue
 		}
+		nrtResources := nrtResourcesLookup(pod.Spec.NodeName)
 		nodeObjs := nodeToObjsMap[pod.Spec.NodeName]
 		nodeObjs = append(nodeObjs, podData{
 			Namespace:             pod.Namespace,
 			Name:                  pod.Name,
-			HasExclusiveResources: resourcerequests.AreExclusiveForPod(pod),
+			HasExclusiveResources: resourcerequests.AreExclusiveForPod(pod, nrtResources),
 		})
 		nodeToObjsMap[pod.Spec.NodeName] = nodeObjs
 	}

--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
@@ -1286,7 +1287,8 @@ func TestMakeNodeToPodDataMap(t *testing.T) {
 				pods: tcase.pods,
 				err:  tcase.err,
 			}
-			got, err := makeNodeToPodDataMap(klog.Background(), podLister, tcase.isPodRelevant)
+			nrtResourcesLookup := func(nodeName string) sets.Set[corev1.ResourceName] { return nil }
+			got, err := makeNodeToPodDataMap(klog.Background(), podLister, tcase.isPodRelevant, nrtResourcesLookup)
 			if err != tcase.expectedErr {
 				t.Errorf("error mismatch: got %v expected %v", err, tcase.expectedErr)
 			}

--- a/pkg/noderesourcetopology/cache/store.go
+++ b/pkg/noderesourcetopology/cache/store.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/go-logr/logr"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
@@ -67,6 +68,20 @@ func (nrs *nrtStore) GetNRTCopyByNodeName(nodeName string) *topologyv1alpha2.Nod
 		return nil
 	}
 	return obj.DeepCopy()
+}
+
+// ResourceNamesFromNRT returns the set of resource names listed in the given NRT zones.
+func ResourceNamesFromNRT(nrt *topologyv1alpha2.NodeResourceTopology) sets.Set[corev1.ResourceName] {
+	if nrt == nil {
+		return nil
+	}
+	res := sets.New[corev1.ResourceName]()
+	for _, zone := range nrt.Zones {
+		for _, resInfo := range zone.Resources {
+			res.Insert(corev1.ResourceName(resInfo.Name))
+		}
+	}
+	return res
 }
 
 // Update adds or replace the Node Resource Topology associated to a node. Always do a copy.

--- a/pkg/noderesourcetopology/cache/store.go
+++ b/pkg/noderesourcetopology/cache/store.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -82,6 +83,44 @@ func ResourceNamesFromNRT(nrt *topologyv1alpha2.NodeResourceTopology) sets.Set[c
 		}
 	}
 	return res
+}
+
+// NRTResourcesLookupFunc returns the set of resource names for the given node.
+type NRTResourcesLookupFunc func(nodeName string) sets.Set[corev1.ResourceName]
+
+// nrtResourcesStore is a lightweight, thread-safe per-node cache of resource names
+// extracted from NRT zones. It is decoupled from the main nrtStore/OverReserve lock
+// so that foreign-pod detection can look up resource names without contending with
+// the scheduling hot path.
+type nrtResourcesStore struct {
+	mu   sync.RWMutex
+	data map[string]sets.Set[corev1.ResourceName]
+}
+
+func newNrtResourcesStore(nrts []topologyv1alpha2.NodeResourceTopology) *nrtResourcesStore {
+	data := make(map[string]sets.Set[corev1.ResourceName], len(nrts))
+	for _, nrt := range nrts {
+		data[nrt.Name] = ResourceNamesFromNRT(&nrt)
+	}
+	return &nrtResourcesStore{data: data}
+}
+
+func (rs *nrtResourcesStore) Get(nodeName string) sets.Set[corev1.ResourceName] {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	return rs.data[nodeName]
+}
+
+func (rs *nrtResourcesStore) Update(nrt *topologyv1alpha2.NodeResourceTopology) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.data[nrt.Name] = ResourceNamesFromNRT(nrt)
+}
+
+func (rs *nrtResourcesStore) Delete(nodeName string) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	delete(rs.data, nodeName)
 }
 
 // Update adds or replace the Node Resource Topology associated to a node. Always do a copy.

--- a/pkg/noderesourcetopology/cache/store_test.go
+++ b/pkg/noderesourcetopology/cache/store_test.go
@@ -28,12 +28,89 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 
 	"github.com/k8stopologyawareschedwg/podfingerprint"
 )
+
+func TestResourceNamesFromNRT(t *testing.T) {
+	tcases := []struct {
+		name     string
+		nrt      *topologyv1alpha2.NodeResourceTopology
+		expected sets.Set[corev1.ResourceName]
+	}{
+		{
+			name:     "nil",
+			nrt:      nil,
+			expected: nil,
+		},
+		{
+			name:     "no zones",
+			nrt:      &topologyv1alpha2.NodeResourceTopology{},
+			expected: sets.New[corev1.ResourceName](),
+		},
+		{
+			name: "single zone",
+			nrt: &topologyv1alpha2.NodeResourceTopology{
+				Zones: topologyv1alpha2.ZoneList{
+					{
+						Resources: topologyv1alpha2.ResourceInfoList{
+							MakeTopologyResInfo(cpu, "4", "4"),
+							MakeTopologyResInfo(memory, "8Gi", "8Gi"),
+						},
+					},
+				},
+			},
+			expected: sets.New(
+				corev1.ResourceCPU,
+				corev1.ResourceMemory,
+			),
+		},
+		{
+			name: "multiple zones deduplicates resource names",
+			nrt:  makeTestNRT("node-1"),
+			expected: sets.New(
+				corev1.ResourceCPU,
+				corev1.ResourceMemory,
+				corev1.ResourceName(nicResourceName),
+			),
+		},
+		{
+			name: "extended resource in zone",
+			nrt: &topologyv1alpha2.NodeResourceTopology{
+				Zones: topologyv1alpha2.ZoneList{
+					{
+						Resources: topologyv1alpha2.ResourceInfoList{
+							MakeTopologyResInfo("slow.io/accelerator", "1", "1"),
+						},
+					},
+				},
+			},
+			expected: sets.New(corev1.ResourceName("slow.io/accelerator")),
+		},
+	}
+
+	for _, tt := range tcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResourceNamesFromNRT(tt.nrt)
+			if tt.expected == nil {
+				if got != nil {
+					t.Fatalf("expected nil set, got %v", got.UnsortedList())
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %v, got nil", tt.expected.UnsortedList())
+			}
+			if !got.Equal(tt.expected) {
+				t.Fatalf("expected %v, got %v", tt.expected.UnsortedList(), got.UnsortedList())
+			}
+		})
+	}
+}
 
 func TestFingerprintFromNRT(t *testing.T) {
 	nrt := &topologyv1alpha2.NodeResourceTopology{

--- a/pkg/noderesourcetopology/cache/store_test.go
+++ b/pkg/noderesourcetopology/cache/store_test.go
@@ -112,6 +112,59 @@ func TestResourceNamesFromNRT(t *testing.T) {
 	}
 }
 
+func TestNrtResourcesStoreGetUpdateDelete(t *testing.T) {
+	nrts := []topologyv1alpha2.NodeResourceTopology{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-0"},
+			Zones: topologyv1alpha2.ZoneList{
+				{
+					Resources: topologyv1alpha2.ResourceInfoList{
+						MakeTopologyResInfo(cpu, "4", "4"),
+						MakeTopologyResInfo(nicResourceName, "2", "2"),
+					},
+				},
+			},
+		},
+	}
+
+	rs := newNrtResourcesStore(nrts)
+
+	got := rs.Get("node-0")
+	expected := sets.New(corev1.ResourceCPU, corev1.ResourceName(nicResourceName))
+	if !got.Equal(expected) {
+		t.Errorf("Get after init: got %v expected %v", got.UnsortedList(), expected.UnsortedList())
+	}
+
+	if got := rs.Get("node-missing"); got != nil {
+		t.Errorf("Get missing node: got %v expected nil", got.UnsortedList())
+	}
+
+	updatedNRT := &topologyv1alpha2.NodeResourceTopology{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-0"},
+		Zones: topologyv1alpha2.ZoneList{
+			{
+				Resources: topologyv1alpha2.ResourceInfoList{
+					MakeTopologyResInfo(cpu, "4", "4"),
+					MakeTopologyResInfo(nicResourceName, "2", "2"),
+					MakeTopologyResInfo("newdevice.io/gpu", "1", "1"),
+				},
+			},
+		},
+	}
+	rs.Update(updatedNRT)
+
+	got = rs.Get("node-0")
+	expected = sets.New(corev1.ResourceCPU, corev1.ResourceName(nicResourceName), corev1.ResourceName("newdevice.io/gpu"))
+	if !got.Equal(expected) {
+		t.Errorf("Get after Update: got %v expected %v", got.UnsortedList(), expected.UnsortedList())
+	}
+
+	rs.Delete("node-0")
+	if got := rs.Get("node-0"); got != nil {
+		t.Errorf("Get after Delete: got %v expected nil", got.UnsortedList())
+	}
+}
+
 func TestFingerprintFromNRT(t *testing.T) {
 	nrt := &topologyv1alpha2.NodeResourceTopology{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/noderesourcetopology/resourcerequests/exclusive.go
+++ b/pkg/noderesourcetopology/resourcerequests/exclusive.go
@@ -19,6 +19,7 @@ package resourcerequests
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
@@ -44,7 +45,7 @@ func IncludeNonNative(pod *corev1.Pod) bool {
 
 // AreExclusiveForPod checks if the given pod's containers are consuming exclusive resources
 // in the steady state of the pod, i.e. after the irrestartable init containers have finished running.
-func AreExclusiveForPod(pod *corev1.Pod) bool {
+func AreExclusiveForPod(pod *corev1.Pod, nrtResources sets.Set[corev1.ResourceName]) bool {
 	qos := v1qos.GetPodQOS(pod)
 
 	// filter out init containers with restart policy other than Always because these are *supposed* to
@@ -56,13 +57,13 @@ func AreExclusiveForPod(pod *corev1.Pod) bool {
 		}
 		restartableInitCnts = append(restartableInitCnts, ctr)
 	}
-	return areExclusiveForAnyContainer(qos, append(restartableInitCnts, pod.Spec.Containers...))
+	return areExclusiveForAnyContainer(qos, append(restartableInitCnts, pod.Spec.Containers...), nrtResources)
 }
 
-func areExclusiveForAnyContainer(qos corev1.PodQOSClass, containers []corev1.Container) bool {
+func areExclusiveForAnyContainer(qos corev1.PodQOSClass, containers []corev1.Container, nrtResources sets.Set[corev1.ResourceName]) bool {
 	for _, ctr := range containers {
 		for resource, quantity := range ctr.Resources.Requests {
-			if ok := IsExclusive(qos, resource, quantity); ok {
+			if ok := IsExclusive(qos, resource, quantity, nrtResources); ok {
 				return true
 			}
 		}
@@ -70,11 +71,13 @@ func areExclusiveForAnyContainer(qos corev1.PodQOSClass, containers []corev1.Con
 	return false
 }
 
-func IsExclusive(qos corev1.PodQOSClass, resource corev1.ResourceName, quantity resource.Quantity) bool {
-	// devices accessed via device plugins are non-shareable
-	// note until we reach better clarity we treat extended resources as devices
+func IsExclusive(qos corev1.PodQOSClass, resource corev1.ResourceName, quantity resource.Quantity, nrtResources sets.Set[corev1.ResourceName]) bool {
+	// Devices accessed via device plugins are non-shareable.
+	// However, devices which are accessed via device plugins but are not topology-bound,
+	// or extended resources which are not backed by a device plugin, should not be considered exclusive.
+	// our source of truth for this kind of distinctions is the NRT.
 	if !v1helper.IsNativeResource(resource) {
-		return true
+		return nrtResources.Has(resource)
 	}
 	if qos != corev1.PodQOSGuaranteed {
 		// nothing more we can check, bail out ASAP

--- a/pkg/noderesourcetopology/resourcerequests/exclusive_test.go
+++ b/pkg/noderesourcetopology/resourcerequests/exclusive_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 )
 
@@ -45,12 +46,127 @@ func TestIncludeNonNative(t *testing.T) {
 }
 
 func TestAreExclusiveForPod(t *testing.T) {
+	nrtResources := sets.New(corev1.ResourceName("veryfast.io/fpga"))
 	tcases := coreTestCases()
 	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AreExclusiveForPod(tt.pod)
+			got := AreExclusiveForPod(tt.pod, nrtResources)
 			if got != tt.expectedExclusive {
 				t.Errorf("%s: exclusive resources detected %v expected %v", tt.name, got, tt.expectedExclusive)
+			}
+		})
+	}
+}
+
+func TestAreExclusiveForPodNRTScoped(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		nrtResources sets.Set[corev1.ResourceName]
+		expected     bool
+	}{
+		{
+			name: "device-in-nrt-is-exclusive",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtResources: sets.New(corev1.ResourceName("veryfast.io/fpga")),
+			expected:     true,
+		},
+		{
+			name: "device-not-in-nrt-is-not-exclusive",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nrtResources: sets.New[corev1.ResourceName](),
+			expected:     false,
+		},
+		{
+			name: "nil-nrt-resources-device-not-exclusive",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("veryfast.io/fpga"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "gu-cpu-exclusive-regardless-of-nrt",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "cnt",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AreExclusiveForPod(tt.pod, tt.nrtResources)
+			if got != tt.expected {
+				t.Errorf("%s: exclusive resources detected %v expected %v", tt.name, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

[Extended resources](https://kubernetes.io/docs/tasks/administer-cluster/extended-resource-node/) are only treated as exclusive when they appear in the node's NRT, aligning exclusive-resource detection with topology exporter accounting and pod fingerprint (PFP) matching.

* Gate `IsExclusive` non-native resources on `nrtResources.Has(resource)` instead of treating every extended resource as exclusive.
* Add `ResourceNamesFromNRT` and pass a per-node resource set from PFP resync and foreign-pod detection
* Native CPU/memory/hugepage exclusivity rules are unchanged.

**Test plan**

- [x] go test ./pkg/noderesourcetopology/resourcerequests/...

- [x] go test ./pkg/noderesourcetopology/cache/...

- [x] Deploy locally built scheduler image and verify foreign-pod / cache resync behavior with pods requesting extended resources not listed in NRT

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes-sigs/scheduler-plugins/issues/985
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
