### PR TITLE
nrt: cache: use testr.New in test

### DIFF
--- a/pkg/noderesourcetopology/cache/attr_watch_test.go
+++ b/pkg/noderesourcetopology/cache/attr_watch_test.go
@@ -23,8 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
-	"k8s.io/klog/v2"
-
+	"github.com/go-logr/logr/testr"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 )
 
@@ -135,9 +134,10 @@ func TestWatcherProcessEvent(t *testing.T) {
 		},
 	}
 
+	logger := testr.New(t)
 	wt := Watcher{
-		lh:    klog.Background(),
-		nrts:  newNrtStore(klog.Background(), nrts),
+		lh:    logger,
+		nrts:  newNrtStore(logger, nrts),
 		nodes: newCounter(),
 	}
 

--- a/pkg/noderesourcetopology/cache/discardreserved_test.go
+++ b/pkg/noderesourcetopology/cache/discardreserved_test.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/klog/v2"
 
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,7 +51,7 @@ func TestDiscardReservedNodesGetCachedNRTCopy(t *testing.T) {
 	checkGetCachedNRTCopy(
 		t,
 		func(client ctrlclient.WithWatch, _ podlisterv1.PodLister) (Interface, error) {
-			return NewDiscardReserved(klog.Background(), client), nil
+			return NewDiscardReserved(testr.New(t), client), nil
 		},
 		testCases...,
 	)

--- a/pkg/noderesourcetopology/cache/foreign_pods_test.go
+++ b/pkg/noderesourcetopology/cache/foreign_pods_test.go
@@ -19,11 +19,11 @@ package cache
 import (
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 )
 
 func TestIsForeignPod(t *testing.T) {
@@ -250,7 +250,7 @@ func TestIsForeignPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, profileName := range tt.profileNames {
-				RegisterSchedulerProfileName(klog.Background(), profileName)
+				RegisterSchedulerProfileName(testr.New(t), profileName)
 			}
 			defer CleanRegisteredSchedulerProfileNames()
 			defer TrackAllForeignPods()

--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"github.com/k8stopologyawareschedwg/podfingerprint"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/klog/v2"
 
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -92,7 +92,7 @@ func TestGetCacheResyncMethod(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			got := getCacheResyncMethod(klog.Background(), testCase.cfg)
+			got := getCacheResyncMethod(testr.New(t), testCase.cfg)
 			if got != testCase.expected {
 				t.Errorf("cache resync method got %v expected %v", got, testCase.expected)
 			}
@@ -107,12 +107,12 @@ func TestInitEmptyLister(t *testing.T) {
 
 	fakePodLister := &fakePodLister{}
 	ctx := context.Background()
-	_, err = NewOverReserve(ctx, klog.Background(), nil, nil, fakePodLister, podprovider.IsPodRelevantAlways)
+	_, err = NewOverReserve(ctx, testr.New(t), nil, nil, fakePodLister, podprovider.IsPodRelevantAlways)
 	if err == nil {
 		t.Fatalf("accepted nil lister")
 	}
 
-	_, err = NewOverReserve(ctx, klog.Background(), nil, fakeClient, nil, podprovider.IsPodRelevantAlways)
+	_, err = NewOverReserve(ctx, testr.New(t), nil, fakeClient, nil, podprovider.IsPodRelevantAlways)
 	if err == nil {
 		t.Fatalf("accepted nil indexer")
 	}
@@ -127,7 +127,7 @@ func TestGetDesyncedNodesCount(t *testing.T) {
 	fakePodLister := &fakePodLister{}
 
 	nrtCache := mustOverReserve(t, fakeClient, fakePodLister)
-	dirtyNodes := nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes := nrtCache.GetDesyncedNodes(testr.New(t))
 	if dirtyNodes.DirtyCount() != 0 {
 		t.Errorf("dirty nodes from pristine cache: %v", dirtyNodes)
 	}
@@ -152,7 +152,7 @@ func TestDirtyNodesMarkDiscarded(t *testing.T) {
 		nrtCache.ReserveNodeResources(nodeName, &corev1.Pod{})
 	}
 
-	dirtyNodes := nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes := nrtCache.GetDesyncedNodes(testr.New(t))
 	if dirtyNodes.Len() != 0 {
 		t.Errorf("dirty nodes from pristine cache: %v", dirtyNodes)
 	}
@@ -161,7 +161,7 @@ func TestDirtyNodesMarkDiscarded(t *testing.T) {
 		nrtCache.NodeMaybeOverReserved(nodeName, &corev1.Pod{})
 	}
 
-	dirtyNodes = nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes = nrtCache.GetDesyncedNodes(testr.New(t))
 	sort.Strings(dirtyNodes.MaybeOverReserved)
 
 	if !reflect.DeepEqual(dirtyNodes.MaybeOverReserved, expectedNodes) {
@@ -193,7 +193,7 @@ func TestDirtyNodesNotUnmarkedOnReserve(t *testing.T) {
 		nrtCache.ReserveNodeResources(nodeName, &corev1.Pod{})
 	}
 
-	dirtyNodes := nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes := nrtCache.GetDesyncedNodes(testr.New(t))
 	if dirtyNodes.Len() != 0 {
 		t.Errorf("dirty nodes from pristine cache: %v", dirtyNodes)
 	}
@@ -205,7 +205,7 @@ func TestDirtyNodesNotUnmarkedOnReserve(t *testing.T) {
 	// Reserve does NOT clear the dirty flag; only FlushNodes does.
 	nrtCache.ReserveNodeResources("node-4", &corev1.Pod{})
 
-	dirtyNodes = nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes = nrtCache.GetDesyncedNodes(testr.New(t))
 
 	if dirtyNodes.DirtyCount() != 2 {
 		t.Errorf("both nodes should still be dirty after Reserve, got: %v", dirtyNodes.MaybeOverReserved)
@@ -282,7 +282,7 @@ func TestOverreserveGetCachedNRTCopy(t *testing.T) {
 	checkGetCachedNRTCopy(
 		t,
 		func(client ctrlclient.WithWatch, podLister podlisterv1.PodLister) (Interface, error) {
-			return NewOverReserve(context.Background(), klog.Background(), nil, client, podLister, podprovider.IsPodRelevantAlways)
+			return NewOverReserve(context.Background(), testr.New(t), nil, client, podLister, podprovider.IsPodRelevantAlways)
 		},
 		testCases...,
 	)
@@ -485,7 +485,7 @@ func TestFlush(t *testing.T) {
 		},
 	}
 
-	lh := klog.Background()
+	lh := testr.New(t)
 
 	expectedGen := nrtCache.generation + 1
 	gen1 := nrtCache.FlushNodes(lh, expectedNodeTopology.DeepCopy())
@@ -589,7 +589,7 @@ func TestResyncNoPodFingerprint(t *testing.T) {
 
 	nrtCache.Resync()
 
-	dirtyNodes := nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes := nrtCache.GetDesyncedNodes(testr.New(t))
 
 	if dirtyNodes.Len() != 1 || dirtyNodes.MaybeOverReserved[0] != "node1" {
 		t.Errorf("cleaned nodes after resyncing with bad data: %v", dirtyNodes.MaybeOverReserved)
@@ -683,7 +683,7 @@ func TestResyncMatchFingerprint(t *testing.T) {
 
 	nrtCache.Resync()
 
-	dirtyNodes := nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes := nrtCache.GetDesyncedNodes(testr.New(t))
 	if dirtyNodes.Len() > 0 {
 		t.Errorf("node still dirty after resyncing with good data: %v", dirtyNodes)
 	}
@@ -790,7 +790,7 @@ func TestResyncFingerprintMismatchKeepsNodeDirty(t *testing.T) {
 
 	nrtCache.Resync()
 
-	dirtyNodes := nrtCache.GetDesyncedNodes(klog.Background())
+	dirtyNodes := nrtCache.GetDesyncedNodes(testr.New(t))
 	if dirtyNodes.Len() != 1 || dirtyNodes.MaybeOverReserved[0] != "node1" {
 		t.Errorf("node should stay dirty after fingerprint mismatch, got: %v", dirtyNodes.MaybeOverReserved)
 	}
@@ -886,7 +886,7 @@ func TestResyncReserveInterleaved(t *testing.T) {
 
 	// Step 2: Resync begins — get dirty nodes, then compute NRT updates.
 	// The fingerprint mismatch means nrtUpdates will be empty for node1.
-	lh := klog.Background()
+	lh := testr.New(t)
 	nodes := nrtCache.GetDesyncedNodes(lh)
 	nrtUpdates := nrtCache.MakeNRTUpdatesForNodes(ctx, lh, nodes)
 
@@ -967,7 +967,7 @@ func TestUnknownNodeWithForeignPods(t *testing.T) {
 
 	nrtCache.NodeHasForeignPods("node-bogus", &corev1.Pod{})
 
-	nodes := nrtCache.GetDesyncedNodes(klog.Background())
+	nodes := nrtCache.GetDesyncedNodes(testr.New(t))
 	if nodes.Len() != 0 {
 		t.Errorf("non-existent node has foreign pods!")
 	}
@@ -1040,7 +1040,7 @@ func TestNodeWithForeignPods(t *testing.T) {
 	target := "node2"
 	nrtCache.NodeHasForeignPods(target, &corev1.Pod{})
 
-	nodes := nrtCache.GetDesyncedNodes(klog.Background())
+	nodes := nrtCache.GetDesyncedNodes(testr.New(t))
 	if nodes.Len() != 1 || nodes.MaybeOverReserved[0] != target {
 		t.Errorf("unexpected dirty nodes: %v", nodes.MaybeOverReserved)
 	}
@@ -1053,7 +1053,7 @@ func TestNodeWithForeignPods(t *testing.T) {
 
 func mustOverReserve(t *testing.T, client ctrlclient.WithWatch, podLister podlisterv1.PodLister) *OverReserve {
 	t.Helper()
-	obj, err := NewOverReserve(context.Background(), klog.Background(), nil, client, podLister, podprovider.IsPodRelevantAlways)
+	obj, err := NewOverReserve(context.Background(), testr.New(t), nil, client, podLister, podprovider.IsPodRelevantAlways)
 	if err != nil {
 		t.Fatalf("unexpected error creating cache: %v", err)
 	}
@@ -1288,7 +1288,7 @@ func TestMakeNodeToPodDataMap(t *testing.T) {
 				err:  tcase.err,
 			}
 			nrtResourcesLookup := func(nodeName string) sets.Set[corev1.ResourceName] { return nil }
-			got, err := makeNodeToPodDataMap(klog.Background(), podLister, tcase.isPodRelevant, nrtResourcesLookup)
+			got, err := makeNodeToPodDataMap(testr.New(t), podLister, tcase.isPodRelevant, nrtResourcesLookup)
 			if err != tcase.expectedErr {
 				t.Errorf("error mismatch: got %v expected %v", err, tcase.expectedErr)
 			}
@@ -1312,7 +1312,7 @@ func TestOverresevedGetCachedNRTCopyWithForeignPods(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	lh := klog.Background()
+	lh := testr.New(t)
 	nrtCache, err := NewOverReserve(ctx, lh, nil, fakeClient, fakePodLister, podprovider.IsPodRelevantAlways)
 	if err != nil {
 		t.Fatalf("unexpected error creating cache: %v", err)

--- a/pkg/noderesourcetopology/cache/passthrough_test.go
+++ b/pkg/noderesourcetopology/cache/passthrough_test.go
@@ -19,9 +19,9 @@ package cache
 import (
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/klog/v2"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,7 +45,7 @@ func TestPassthroughGetCachedNRTCopy(t *testing.T) {
 	checkGetCachedNRTCopy(
 		t,
 		func(client ctrlclient.WithWatch, _ podlisterv1.PodLister) (Interface, error) {
-			return NewPassthrough(klog.Background(), client), nil
+			return NewPassthrough(testr.New(t), client), nil
 		},
 		testCases...,
 	)

--- a/pkg/noderesourcetopology/cache/store_test.go
+++ b/pkg/noderesourcetopology/cache/store_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/klog/v2"
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 
 	"github.com/k8stopologyawareschedwg/podfingerprint"
@@ -333,7 +333,7 @@ func TestNRTStoreGet(t *testing.T) {
 			},
 		},
 	}
-	ns := newNrtStore(klog.Background(), nrts)
+	ns := newNrtStore(testr.New(t), nrts)
 
 	obj := ns.GetNRTCopyByNodeName("node-0")
 	obj.TopologyPolicies[0] = "single-numa-node"
@@ -369,7 +369,7 @@ func TestNRTStoreUpdate(t *testing.T) {
 			},
 		},
 	}
-	ns := newNrtStore(klog.Background(), nrts)
+	ns := newNrtStore(testr.New(t), nrts)
 
 	nrt3 := &topologyv1alpha2.NodeResourceTopology{
 		ObjectMeta: metav1.ObjectMeta{
@@ -389,14 +389,14 @@ func TestNRTStoreUpdate(t *testing.T) {
 }
 
 func TestNRTStoreGetMissing(t *testing.T) {
-	ns := newNrtStore(klog.Background(), nil)
+	ns := newNrtStore(testr.New(t), nil)
 	if ns.GetNRTCopyByNodeName("node-missing") != nil {
 		t.Errorf("missing node returned non-nil data")
 	}
 }
 
 func TestNRTStoreContains(t *testing.T) {
-	ns := newNrtStore(klog.Background(), nil)
+	ns := newNrtStore(testr.New(t), nil)
 	if ns.Contains("node-0") {
 		t.Errorf("unexpected node found")
 	}
@@ -419,7 +419,7 @@ func TestNRTStoreContains(t *testing.T) {
 			},
 		},
 	}
-	ns = newNrtStore(klog.Background(), nrts)
+	ns = newNrtStore(testr.New(t), nrts)
 	if !ns.Contains("node-0") {
 		t.Errorf("missing node")
 	}
@@ -540,7 +540,7 @@ func TestResourceStoreAddPod(t *testing.T) {
 		},
 	}
 
-	rs := newResourceStore(klog.Background())
+	rs := newResourceStore(testr.New(t))
 	existed := rs.AddPod(&pod)
 	if existed {
 		t.Fatalf("replaced a pod into a empty resourceStore")
@@ -572,7 +572,7 @@ func TestResourceStoreDeletePod(t *testing.T) {
 		},
 	}
 
-	rs := newResourceStore(klog.Background())
+	rs := newResourceStore(testr.New(t))
 	existed := rs.DeletePod(&pod)
 	if existed {
 		t.Fatalf("deleted a pod into a empty resourceStore")
@@ -639,7 +639,7 @@ func TestResourceStoreUpdate(t *testing.T) {
 		},
 	}
 
-	rs := newResourceStore(klog.Background())
+	rs := newResourceStore(testr.New(t))
 	existed := rs.AddPod(&pod)
 	if existed {
 		t.Fatalf("replacing a pod into a empty resourceStore")
@@ -712,7 +712,7 @@ func TestCheckPodFingerprintForNode(t *testing.T) {
 
 	for _, tcase := range tcases {
 		t.Run(tcase.description, func(t *testing.T) {
-			gotErr := checkPodFingerprintForNode(klog.Background(), tcase.objs, "test-node", tcase.pfp, tcase.onlyExclRes)
+			gotErr := checkPodFingerprintForNode(testr.New(t), tcase.objs, "test-node", tcase.pfp, tcase.onlyExclRes)
 			if !errors.Is(gotErr, tcase.expectedErr) {
 				t.Errorf("got error %v expected %v", gotErr, tcase.expectedErr)
 			}

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -29,7 +30,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	nrtcache "sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/cache"
@@ -686,7 +686,7 @@ func TestNodeResourceTopology(t *testing.T) {
 	}
 
 	tm := TopologyMatch{
-		nrtCache: nrtcache.NewPassthrough(klog.Background(), fakeClient),
+		nrtCache: nrtcache.NewPassthrough(testr.New(t), fakeClient),
 	}
 
 	for _, tt := range tests {
@@ -905,7 +905,7 @@ func TestNodeResourceTopologyMultiContainerPodScope(t *testing.T) {
 			}
 
 			tm := TopologyMatch{
-				nrtCache: nrtcache.NewPassthrough(klog.Background(), fakeClient),
+				nrtCache: nrtcache.NewPassthrough(testr.New(t), fakeClient),
 			}
 
 			nodeInfo := framework.NewNodeInfo()
@@ -1167,7 +1167,7 @@ func TestNodeResourceTopologyMultiContainerContainerScope(t *testing.T) {
 			}
 
 			tm := TopologyMatch{
-				nrtCache: nrtcache.NewPassthrough(klog.Background(), fakeClient),
+				nrtCache: nrtcache.NewPassthrough(testr.New(t), fakeClient),
 			}
 
 			nodeInfo := framework.NewNodeInfo()

--- a/pkg/noderesourcetopology/least_numa_test.go
+++ b/pkg/noderesourcetopology/least_numa_test.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/nodeconfig"
 )
@@ -685,7 +685,7 @@ func TestNUMANodesRequired(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			bm, isMinDistance := numaNodesRequired(klog.Background(), v1.PodQOSGuaranteed, tc.numaNodes, tc.podResources)
+			bm, isMinDistance := numaNodesRequired(testr.New(t), v1.PodQOSGuaranteed, tc.numaNodes, tc.podResources)
 
 			if bm != nil && !bm.IsEqual(tc.expectedBitmask) {
 				t.Errorf("wrong bitmask expected: %d got: %d", tc.expectedBitmask, bm)
@@ -903,7 +903,7 @@ func TestMinDistance(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		t.Run(tc.description, func(t *testing.T) {
-			distance := minAvgDistanceInCombinations(klog.Background(), tc.numaNodes, tc.combinations)
+			distance := minAvgDistanceInCombinations(testr.New(t), tc.numaNodes, tc.combinations)
 			if distance != tc.expected {
 				t.Errorf("Expected distance to be %f not %f", tc.expected, distance)
 			}

--- a/pkg/noderesourcetopology/nodeconfig/topologymanager_test.go
+++ b/pkg/noderesourcetopology/nodeconfig/topologymanager_test.go
@@ -20,7 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/klog/v2"
+	"github.com/go-logr/logr/testr"
+
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
@@ -418,7 +419,7 @@ func TestConfigFromAttributes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := TopologyManager{}
 			cfg := &got // shortcut
-			cfg.updateFromAttributes(klog.Background(), tt.attrs)
+			cfg.updateFromAttributes(testr.New(t), tt.attrs)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("conf got=%+#v expected=%+#v", got, tt.expected)
 			}
@@ -488,7 +489,7 @@ func TestConfigFromPolicies(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := TopologyManager{}
 			cfg := &got // shortcut\
-			cfg.updateFromPolicies(klog.Background(), "", tt.policies)
+			cfg.updateFromPolicies(testr.New(t), "", tt.policies)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("conf got=%+#v expected=%+#v", got, tt.expected)
 			}
@@ -596,7 +597,7 @@ func TestConfigFromNRT(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := TopologyManagerFromNodeResourceTopology(klog.Background(), &tt.nrt)
+			got := TopologyManagerFromNodeResourceTopology(testr.New(t), &tt.nrt)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("conf got=%+#v expected=%+#v", got, tt.expected)
 			}

--- a/pkg/noderesourcetopology/pluginhelpers_test.go
+++ b/pkg/noderesourcetopology/pluginhelpers_test.go
@@ -19,9 +19,10 @@ package noderesourcetopology
 import (
 	"testing"
 
+	"github.com/go-logr/logr/testr"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/klog/v2"
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 )
 
@@ -149,7 +150,7 @@ func TestGetForeignPodsDetectMode(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			got := getForeignPodsDetectMode(klog.Background(), testCase.cfg)
+			got := getForeignPodsDetectMode(testr.New(t), testCase.cfg)
 			if got != testCase.expected {
 				t.Errorf("foreign pods detect mode got %v expected %v", got, testCase.expected)
 			}

--- a/pkg/noderesourcetopology/score_test.go
+++ b/pkg/noderesourcetopology/score_test.go
@@ -21,13 +21,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
+
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	fwk "k8s.io/kube-scheduler/framework"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -150,7 +151,7 @@ func TestNodeResourceScorePlugin(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tm := &TopologyMatch{
 				scoreStrategyFunc: test.strategy,
-				nrtCache:          nrtcache.NewPassthrough(klog.Background(), lister),
+				nrtCache:          nrtcache.NewPassthrough(testr.New(t), lister),
 			}
 
 			for _, req := range test.requests {
@@ -447,7 +448,7 @@ func TestNodeResourceScorePluginLeastNUMA(t *testing.T) {
 
 			tm := &TopologyMatch{
 				scoreStrategyType: apiconfig.LeastNUMANodes,
-				nrtCache:          nrtcache.NewPassthrough(klog.Background(), lister),
+				nrtCache:          nrtcache.NewPassthrough(testr.New(t), lister),
 			}
 			nodeToScore := make(nodeToScoreMap, len(nodesMap))
 			pod := makePodByResourceLists(tc.podRequests...)
@@ -575,7 +576,7 @@ func TestNodeResourcePartialDataScorePlugin(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tm := &TopologyMatch{
 				scoreStrategyFunc: test.strategy,
-				nrtCache:          nrtcache.NewPassthrough(klog.Background(), lister),
+				nrtCache:          nrtcache.NewPassthrough(testr.New(t), lister),
 			}
 
 			for _, req := range test.requests {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
avoid new instance of klog.Background() to make sure all the logs are routed correctly and uniformly.


#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
Spawn from #973 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
