### PR TITLE
docs: add Kubernetes 1.35 compatibility matrix entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ on demand, (e.g., `v0.18.800`) are used to indicated that the k8s client package
 changed since the previous release, and that only scheduler plugins code (features or bug fixes) was
 changed.
 
+The `master` branch currently builds against Kubernetes `v1.35.4` and the matching `k8s.io/*`
+staging modules at `v0.35.4`. Release image rows below are updated after the corresponding
+scheduler-plugins release artifacts are published.
+
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch                                                       |
 |-------------------|---------------------------|-----------------------------------------------------------|------------------------------------------------------------|
 | v0.34.7           | v1.34.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |


### PR DESCRIPTION
## Summary
- Add scheduler and controller compatibility matrix entries for scheduler-plugins v0.35.4 with Kubernetes v1.35.4.
- Keep the architecture list consistent with the existing v0.34/v0.33/v0.32 rows.

Fixes #988

## Test Plan
- git diff --check
- go mod tidy produced no go.mod/go.sum diff
- go build -v -ldflags "-X k8s.io/component-base/version.gitVersion=v0.35.4 -w" -o bin/kube-scheduler cmd/scheduler/main.go
- go build -v -ldflags "-X k8s.io/component-base/version.gitVersion=v0.35.4 -w" -o bin/controller cmd/controller/controller.go
- go test ./pkg/... -run "^$"
- go test ./pkg/noderesourcetopology/...
- go test -v -count=1 -timeout=10m ./test/integration -run "^TestTopologyMatchPluginValidation$"
- go test -v -count=1 -timeout=40m ./test/integration -run "^(TestTopologyMatchPlugin|TestTopologyCachePluginWithoutUpdates|TestTopologyCachePluginWithPodFingerprintUpdates|TestTopologyCachePluginWithAttributeUpdates)$"