### PR TITLE
docs: add Kubernetes 1.35 compatibility matrix entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ changed.
 
 | Scheduler Plugins | Compiled With k8s Version | Container Image                                           | Arch                                                       |
 |-------------------|---------------------------|-----------------------------------------------------------|------------------------------------------------------------|
+| v0.35.7           | v1.35.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.35.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.34.7           | v1.34.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.34.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.33.5           | v1.33.5                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.32.7           | v1.32.7                   | registry.k8s.io/scheduler-plugins/kube-scheduler:v0.32.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 
 | Controller | Compiled With k8s Version | Container Image                                       | Arch                                                       |
 |------------|---------------------------|-------------------------------------------------------|------------------------------------------------------------|
+| v0.35.7    | v1.35.7                   | registry.k8s.io/scheduler-plugins/controller:v0.35.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.34.7    | v1.34.7                   | registry.k8s.io/scheduler-plugins/controller:v0.34.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.33.5    | v1.33.5                   | registry.k8s.io/scheduler-plugins/controller:v0.33.5  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |
 | v0.32.7    | v1.32.7                   | registry.k8s.io/scheduler-plugins/controller:v0.32.7  | linux/amd64<br>linux/arm64<br>linux/s390x<br>linux/ppc64le |


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add scheduler and controller compatibility matrix entries for scheduler-plugins v0.35.4 with Kubernetes v1.35.4.

#### Which issue(s) this PR fixes:

Fixes #988

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
