### PR TITLE
nrt:filter: return early for non-gu pod

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -178,7 +178,7 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState fwk.CycleState, 
 		return fwk.NewStatus(fwk.Error, "node not found")
 	}
 	qos := v1qos.GetPodQOS(pod)
-	if qos == v1.PodQOSBestEffort && !resourcerequests.IncludeNonNative(pod) {
+	if qos != v1.PodQOSGuaranteed && !resourcerequests.IncludeNonNative(pod) {
 		return nil
 	}
 

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -418,8 +418,8 @@ func TestNodeResourceTopology(t *testing.T) {
 		{
 			name: "Burstable QoS, pod fit",
 			pod: makePodByResourceList(&v1.ResourceList{
-				v1.ResourceCPU:  *resource.NewQuantity(4, resource.DecimalSI),
-				nicResourceName: *resource.NewQuantity(3, resource.DecimalSI)}),
+				v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+			}),
 			node:       nodes[1],
 			wantStatus: nil,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Native resources of the burstable pods are consumed from a shared pool hence not reflected in NRT. Return early in Filter phase on non-guaranteed pods that do not request exclusive resources.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
