### PR TITLE
DO NOT MERGE, TESTING CI

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -47,6 +47,7 @@ func main() {
 	// Register custom plugins to the scheduler framework.
 	// Later they can consist of scheduler profile(s) and hence
 	// used by various kinds of workloads.
+	// TESTING CI
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(capacityscheduling.Name, capacityscheduling.New),
 		app.WithPlugin(coscheduling.Name, coscheduling.New),


### PR DESCRIPTION
DO NOT MERGE, TESTING CI

Trying to check if [pull-scheduler-plugins-integration-test-master](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_scheduler-plugins/996/pull-scheduler-plugins-integration-test-master/2082844256438849536) fails on a PR with no actual change to functionality.