### PR TITLE
feat: add NodeMetadata defaults and timestamp validation

### DIFF
--- a/apis/config/scheme/scheme_test.go
+++ b/apis/config/scheme/scheme_test.go
@@ -322,6 +322,7 @@ profiles:
       metadataSource: "Label"
       metadataType: "Number"
       scoringStrategy: "Highest"
+      defaultValue: "100"
 `),
 			wantProfiles: []schedconfig.KubeSchedulerProfile{
 				{
@@ -335,6 +336,7 @@ profiles:
 								MetadataSource:  config.MetadataSourceLabel,
 								MetadataType:    config.MetadataTypeNumber,
 								ScoringStrategy: config.ScoringStrategyHighest,
+								DefaultValue:    "100",
 							},
 						},
 						{
@@ -504,6 +506,7 @@ func TestCodecsEncodePluginConfig(t *testing.T) {
 									MetadataSource:  config.MetadataSourceLabel,
 									MetadataType:    config.MetadataTypeNumber,
 									ScoringStrategy: config.ScoringStrategyHighest,
+									DefaultValue:    "100",
 								},
 							},
 						},
@@ -606,6 +609,7 @@ profiles:
     name: NetworkOverhead
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1
+      defaultValue: "100"
       kind: NodeMetadataArgs
       metadataKey: priority
       metadataSource: Label

--- a/apis/config/types.go
+++ b/apis/config/types.go
@@ -387,4 +387,9 @@ type NodeMetadataArgs struct {
 	//   - Unix timestamp: Use MetadataType "Number" instead
 	//   - Custom: "2006-01-02 15:04:05"
 	TimestampFormat string `json:"timestampFormat,omitempty"`
+
+	// DefaultValue is used when a node does not have MetadataKey. It must be a
+	// valid value for MetadataType and is scored using ScoringStrategy.
+	// Nodes with malformed metadata still receive the lowest score.
+	DefaultValue string `json:"defaultValue,omitempty"`
 }

--- a/apis/config/v1/types.go
+++ b/apis/config/v1/types.go
@@ -384,4 +384,9 @@ type NodeMetadataArgs struct {
 	//   - Unix timestamp: Use MetadataType "Number" instead
 	//   - Custom: "2006-01-02 15:04:05"
 	TimestampFormat *string `json:"timestampFormat,omitempty"`
+
+	// DefaultValue is used when a node does not have MetadataKey. It must be a
+	// valid value for MetadataType and is scored using ScoringStrategy.
+	// Nodes with malformed metadata still receive the lowest score.
+	DefaultValue *string `json:"defaultValue,omitempty"`
 }

--- a/apis/config/v1/zz_generated.conversion.go
+++ b/apis/config/v1/zz_generated.conversion.go
@@ -397,6 +397,9 @@ func autoConvert_v1_NodeMetadataArgs_To_config_NodeMetadataArgs(in *NodeMetadata
 	if err := metav1.Convert_Pointer_string_To_string(&in.TimestampFormat, &out.TimestampFormat, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_string_To_string(&in.DefaultValue, &out.DefaultValue, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -408,6 +411,9 @@ func autoConvert_config_NodeMetadataArgs_To_v1_NodeMetadataArgs(in *config.NodeM
 	// WARNING: in.MetadataType requires manual conversion: inconvertible types (sigs.k8s.io/scheduler-plugins/apis/config.MetadataValueType vs *sigs.k8s.io/scheduler-plugins/apis/config/v1.MetadataValueType)
 	// WARNING: in.ScoringStrategy requires manual conversion: inconvertible types (sigs.k8s.io/scheduler-plugins/apis/config.MetadataScoringStrategy vs *sigs.k8s.io/scheduler-plugins/apis/config/v1.MetadataScoringStrategy)
 	if err := metav1.Convert_string_To_Pointer_string(&in.TimestampFormat, &out.TimestampFormat, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_string_To_Pointer_string(&in.DefaultValue, &out.DefaultValue, s); err != nil {
 		return err
 	}
 	return nil

--- a/apis/config/v1/zz_generated.deepcopy.go
+++ b/apis/config/v1/zz_generated.deepcopy.go
@@ -241,6 +241,11 @@ func (in *NodeMetadataArgs) DeepCopyInto(out *NodeMetadataArgs) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DefaultValue != nil {
+		in, out := &in.DefaultValue, &out.DefaultValue
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/apis/config/validation/validation_pluginargs.go
+++ b/apis/config/validation/validation_pluginargs.go
@@ -18,6 +18,8 @@ package validation
 
 import (
 	"fmt"
+	"strconv"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -180,10 +182,58 @@ func ValidateNodeMetadataArgs(args *config.NodeMetadataArgs, path *field.Path) e
 			allErrs = append(allErrs, field.Invalid(field.NewPath("scoringStrategy"),
 				args.ScoringStrategy, "scoringStrategy \"Highest\" and \"Lowest\" are only valid for metadataType \"Number\""))
 		}
+		if args.TimestampFormat != "" {
+			if err := validateTimestampFormat(args.TimestampFormat); err != nil {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("timestampFormat"),
+					args.TimestampFormat, fmt.Sprintf("timestampFormat must be a valid Go time layout: %v", err)))
+			}
+		}
+	}
+
+	if args.DefaultValue != "" {
+		switch args.MetadataType {
+		case config.MetadataTypeNumber:
+			if _, err := strconv.ParseFloat(args.DefaultValue, 64); err != nil {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("defaultValue"),
+					args.DefaultValue, "defaultValue must be a valid number when metadataType is \"Number\""))
+			}
+		case config.MetadataTypeTimestamp:
+			format := args.TimestampFormat
+			if format == "" {
+				format = time.RFC3339
+			}
+			if _, err := time.Parse(format, args.DefaultValue); err != nil {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("defaultValue"),
+					args.DefaultValue, "defaultValue must match timestampFormat when metadataType is \"Timestamp\""))
+			}
+		}
 	}
 
 	if len(allErrs) == 0 {
 		return nil
 	}
 	return allErrs.ToAggregate()
+}
+
+func validateTimestampFormat(format string) error {
+	sample := time.Date(2026, time.August, 29, 13, 14, 15, 123456789, time.UTC)
+	parsed, err := time.Parse(format, sample.Format(format))
+	if err != nil {
+		return err
+	}
+
+	// Go permits a layout made entirely of literal text. Such a layout cannot
+	// represent a timestamp and usually signals a non-Go layout such as
+	// "YYYY-MM-DD".
+	if parsed.Year() != sample.Year() &&
+		parsed.Month() != sample.Month() &&
+		parsed.Day() != sample.Day() &&
+		parsed.Hour() != sample.Hour() &&
+		parsed.Minute() != sample.Minute() &&
+		parsed.Second() != sample.Second() &&
+		parsed.Nanosecond() != sample.Nanosecond() {
+		return fmt.Errorf("must contain at least one Go reference time component")
+	}
+
+	return nil
 }

--- a/apis/config/validation/validation_plugingargs_test.go
+++ b/apis/config/validation/validation_plugingargs_test.go
@@ -290,6 +290,44 @@ func TestValidateNodeMetadataArgs(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			description: "correct default value",
+			args:        &config.NodeMetadataArgs{MetadataKey: "priority", MetadataSource: config.MetadataSourceLabel, MetadataType: config.MetadataTypeNumber, ScoringStrategy: config.ScoringStrategyHighest, DefaultValue: "100"},
+			expectedErr: nil,
+		},
+		{
+			description: "invalid numeric default value",
+			args:        &config.NodeMetadataArgs{MetadataKey: "priority", MetadataSource: config.MetadataSourceLabel, MetadataType: config.MetadataTypeNumber, ScoringStrategy: config.ScoringStrategyHighest, DefaultValue: "invalid"},
+			expectedErr: fmt.Errorf("defaultValue must be a valid number when metadataType is \"Number\""),
+		},
+		{
+			description: "invalid timestamp default value",
+			args:        &config.NodeMetadataArgs{MetadataKey: "lastUpdate", MetadataSource: config.MetadataSourceAnnotation, MetadataType: config.MetadataTypeTimestamp, ScoringStrategy: config.ScoringStrategyNewest, DefaultValue: "invalid"},
+			expectedErr: fmt.Errorf("defaultValue must match timestampFormat when metadataType is \"Timestamp\""),
+		},
+		{
+			description: "valid timestamp default value does not match timestamp format",
+			args: &config.NodeMetadataArgs{
+				MetadataKey:     "lastUpdate",
+				MetadataSource:  config.MetadataSourceAnnotation,
+				MetadataType:    config.MetadataTypeTimestamp,
+				ScoringStrategy: config.ScoringStrategyNewest,
+				TimestampFormat: "2006-01-02",
+				DefaultValue:    "2026-08-29T13:14:15Z",
+			},
+			expectedErr: fmt.Errorf("defaultValue must match timestampFormat when metadataType is \"Timestamp\""),
+		},
+		{
+			description: "timestamp format without Go reference time components",
+			args: &config.NodeMetadataArgs{
+				MetadataKey:     "lastUpdate",
+				MetadataSource:  config.MetadataSourceAnnotation,
+				MetadataType:    config.MetadataTypeTimestamp,
+				ScoringStrategy: config.ScoringStrategyNewest,
+				TimestampFormat: "YYYY-MM-DD",
+			},
+			expectedErr: fmt.Errorf("timestampFormat must be a valid Go time layout"),
+		},
+		{
 			description: "missing MetadataKey",
 			args: &config.NodeMetadataArgs{
 				MetadataKey:     "",

--- a/kep/942-node-metadata-scoring/README.md
+++ b/kep/942-node-metadata-scoring/README.md
@@ -181,6 +181,7 @@ type NodeMetadataArgs struct {
     MetadataType    MetadataValueType
     ScoringStrategy MetadataScoringStrategy
     TimestampFormat string
+    DefaultValue    string
 }
 ```
 
@@ -193,6 +194,7 @@ Configuration fields:
 | `metadataType` | Yes | `Number` or `Timestamp` |
 | `scoringStrategy` | Yes | `Highest`, `Lowest`, `Newest`, or `Oldest` |
 | `timestampFormat` | Conditional | Go time layout used when `metadataType` is `Timestamp` |
+| `defaultValue` | No | Value used when `metadataKey` is missing; must match `metadataType` |
 
 ### Example
 
@@ -215,6 +217,7 @@ profiles:
           metadataSource: "Annotation"
           metadataType: "Number"
           scoringStrategy: "Lowest"
+          defaultValue: "100"  # Treat missing costs as 100
 ```
 
 ### Plugin registration and extension point
@@ -238,12 +241,23 @@ For each candidate node, the plugin:
    strategy.
 4. Returns raw scores for normalization across all feasible nodes.
 
-If the key is missing or the value cannot be parsed, the plugin returns an
-internal invalid score sentinel for that node. During normalization, invalid
-scores are excluded from the valid score range and are normalized to
-`framework.MinNodeScore`. Valid scores are normalized above that reserved
-minimum, so nodes with valid metadata rank ahead of nodes where metadata is
-absent or malformed.
+If the key is missing and `defaultValue` is configured, the plugin parses and
+scores that value exactly as it would a node value. This gives operators a
+baseline that can rank unlabeled nodes above or below labeled nodes. For
+example, a numeric default of `"100"` ranks an unlabeled node between nodes
+whose values are respectively below and above 100 with the `Highest` strategy;
+with `Lowest`, the same value is inverted with every other numeric value.
+
+For timestamp metadata, `defaultValue` is a timestamp in `timestampFormat`, so
+an unlabeled node ranks as though it carried that timestamp. This makes the
+fallback's meaning explicit and remains valid as time advances.
+
+If the key is missing and no default is configured, or if the node value cannot
+be parsed, the plugin returns an internal invalid score sentinel for that node.
+During normalization, invalid scores are excluded from the valid score range
+and are normalized to `framework.MinNodeScore`. Valid scores are normalized
+above that reserved minimum, so nodes with valid metadata or a configured
+fallback rank ahead of nodes with absent or malformed metadata.
 
 #### Numeric metadata
 
@@ -301,6 +315,10 @@ The proposal includes configuration validation with the following checks:
 - `scoringStrategy` must be one of the supported enum values
 - numeric metadata must use `Highest` or `Lowest`
 - timestamp metadata must use `Newest` or `Oldest`
+- a configured `timestampFormat` must contain at least one Go reference-time
+  component and must round-trip a representative timestamp
+- when set, `defaultValue` must parse as the configured metadata type; timestamp
+  defaults must also match `timestampFormat`
 
 For the v1 config API, `timestampFormat` defaults to RFC3339 when
 `metadataType` is `Timestamp` and the field is omitted.
@@ -310,11 +328,12 @@ For the v1 config API, `timestampFormat` defaults to RFC3339 when
 1. The plugin evaluates exactly one metadata key per configuration.
 2. Metadata values are strings on the `Node` object, so typing and freshness are
    external operational concerns.
-3. The plugin does not distinguish between intentionally absent metadata and
-   malformed metadata; both result in the lowest effective influence.
+3. Without `defaultValue`, absent and malformed metadata both result in the
+   lowest effective influence. With `defaultValue`, only absent metadata uses
+   the fallback; malformed metadata remains lowest-scoring.
 4. The invalid metadata sentinel uses `math.MinInt64`. If a configured metadata
-   value is converted to `math.MinInt64`, the plugin treats it as invalid or
-   absent metadata rather than as a valid score.
+   or fallback value is converted to `math.MinInt64`, the plugin treats it as
+   invalid or absent metadata rather than as a valid score.
 5. Numeric metadata is accepted as `float64`, but the scheduler framework uses
    `int64` scores, so numeric values are rounded before scoring. This can cause
    small precision differences for fractional values; use integer metadata
@@ -329,14 +348,16 @@ The implementation is expected to ship with:
 1. unit tests for
     - argument validation and type/strategy compatibility
     - unit tests for raw score calculation for numeric and timestamp metadata
-    - unit tests for normalization behavior, including equal scores and missing metadata
+    - unit tests for normalization behavior, including equal scores, missing
+      metadata, and configured fallback values
 2. integration tests that run the scheduler with only `NodeMetadata` scoring
    enabled and verify placement for:
     - highest numeric labels
     - lowest numeric annotations
     - newest timestamps
     - oldest timestamps
-    - mixed nodes where some candidates are missing metadata
+    - mixed nodes where some candidates are missing metadata, including a
+      numeric and timestamp `defaultValue`
     - decimal numeric values
     - Unix epoch values represented as numbers
 
@@ -400,9 +421,10 @@ Operators should verify:
 3. the scheduler profile enables the plugin with the intended weight
 4. timestamp layouts match the actual string representation on nodes
 
-Because invalid or missing metadata becomes a low score instead of a scheduling
-error, troubleshooting should include inspecting node metadata directly when the
-observed ranking is weaker than expected.
+Because malformed metadata and missing metadata without a configured fallback
+become a low score instead of a scheduling error, troubleshooting should
+include inspecting node metadata directly when the observed ranking is weaker
+than expected.
 
 ## Implementation History
 

--- a/manifests/nodemetadata/scheduler-config.yaml
+++ b/manifests/nodemetadata/scheduler-config.yaml
@@ -15,6 +15,8 @@ profiles:
           metadataSource: "Label"
           metadataType: "Number"
           scoringStrategy: "Highest"
+          # Missing labels are ranked as priority 100.
+          defaultValue: "100"
 
 ---
 apiVersion: kubescheduler.config.k8s.io/v1

--- a/pkg/nodemetadata/README.md
+++ b/pkg/nodemetadata/README.md
@@ -22,6 +22,7 @@ The plugin accepts the following configuration parameters:
 | `metadataType` | string | Yes | Type of metadata value: `"Number"` or `"Timestamp"` |
 | `scoringStrategy` | string | Yes | How to score nodes (see below) |
 | `timestampFormat` | string | Conditional | Go time format string (required when `metadataType` is `"Timestamp"`) |
+| `defaultValue` | string | No | Value to score when a node is missing `metadataKey`; it must match `metadataType` |
 
 ### Scoring Strategies
 
@@ -34,6 +35,21 @@ The plugin accepts the following configuration parameters:
 
 - **`Newest`** - Nodes with newer (more recent) timestamps get higher scores
 - **`Oldest`** - Nodes with older timestamps get higher scores
+
+### Missing Metadata
+
+By default, nodes without `metadataKey` receive the lowest score. Set
+`defaultValue` to rank missing metadata alongside explicitly configured values.
+The value is parsed and scored exactly like a node value, including the selected
+strategy. For timestamps, provide a value matching `timestampFormat` (or
+RFC3339 when the format is omitted). Malformed node values always receive the
+lowest score; `defaultValue` does not mask them.
+
+For example, this treats an unlabeled node as priority `100`:
+
+```yaml
+defaultValue: "100"
+```
 
 ## Usage Examples
 

--- a/pkg/nodemetadata/node_metadata.go
+++ b/pkg/nodemetadata/node_metadata.go
@@ -90,7 +90,10 @@ func (nm *NodeMetadata) calculateScore(node *v1.Node) (int64, error) {
 	}
 
 	if !found {
-		return 0, fmt.Errorf("metadata key %q not found in %s", nm.args.MetadataKey, nm.args.MetadataSource)
+		if nm.args.DefaultValue == "" {
+			return 0, fmt.Errorf("metadata key %q not found in %s", nm.args.MetadataKey, nm.args.MetadataSource)
+		}
+		metadataValue = nm.args.DefaultValue
 	}
 
 	// Parse the value based on the configured type

--- a/pkg/nodemetadata/node_metadata_test.go
+++ b/pkg/nodemetadata/node_metadata_test.go
@@ -110,6 +110,24 @@ func TestCalculateScore(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:       "missing numeric metadata uses default value with highest strategy",
+			args:       &config.NodeMetadataArgs{MetadataKey: "priority", MetadataSource: config.MetadataSourceLabel, MetadataType: config.MetadataTypeNumber, ScoringStrategy: config.ScoringStrategyHighest, DefaultValue: "100"},
+			node:       &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+			checkScore: func(score int64) bool { return score == 100 },
+		},
+		{
+			name:       "missing numeric metadata uses default value with lowest strategy",
+			args:       &config.NodeMetadataArgs{MetadataKey: "cost", MetadataSource: config.MetadataSourceLabel, MetadataType: config.MetadataTypeNumber, ScoringStrategy: config.ScoringStrategyLowest, DefaultValue: "100"},
+			node:       &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+			checkScore: func(score int64) bool { return score == -100 },
+		},
+		{
+			name:       "missing timestamp metadata uses default value",
+			args:       &config.NodeMetadataArgs{MetadataKey: "last-update", MetadataSource: config.MetadataSourceAnnotation, MetadataType: config.MetadataTypeTimestamp, ScoringStrategy: config.ScoringStrategyNewest, TimestampFormat: time.RFC3339, DefaultValue: time.Now().Add(-time.Hour).Format(time.RFC3339)},
+			node:       &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+			checkScore: func(score int64) bool { return score < 0 },
+		},
+		{
 			name: "invalid numeric value",
 			args: &config.NodeMetadataArgs{
 				MetadataKey:     "priority",
@@ -193,6 +211,26 @@ func TestValidateArgs(t *testing.T) {
 				TimestampFormat: time.RFC3339,
 			},
 			expectError: false,
+		},
+		{
+			name:        "valid default value",
+			args:        &config.NodeMetadataArgs{MetadataKey: "priority", MetadataSource: config.MetadataSourceLabel, MetadataType: config.MetadataTypeNumber, ScoringStrategy: config.ScoringStrategyHighest, DefaultValue: "100"},
+			expectError: false,
+		},
+		{
+			name:        "invalid numeric default value",
+			args:        &config.NodeMetadataArgs{MetadataKey: "priority", MetadataSource: config.MetadataSourceLabel, MetadataType: config.MetadataTypeNumber, ScoringStrategy: config.ScoringStrategyHighest, DefaultValue: "not-a-number"},
+			expectError: true,
+		},
+		{
+			name:        "invalid timestamp default value",
+			args:        &config.NodeMetadataArgs{MetadataKey: "last-update", MetadataSource: config.MetadataSourceAnnotation, MetadataType: config.MetadataTypeTimestamp, ScoringStrategy: config.ScoringStrategyNewest, TimestampFormat: time.RFC3339, DefaultValue: "not-a-timestamp"},
+			expectError: true,
+		},
+		{
+			name:        "invalid timestamp format",
+			args:        &config.NodeMetadataArgs{MetadataKey: "last-update", MetadataSource: config.MetadataSourceAnnotation, MetadataType: config.MetadataTypeTimestamp, ScoringStrategy: config.ScoringStrategyNewest, TimestampFormat: "YYYY-MM-DD"},
+			expectError: true,
 		},
 		{
 			name: "missing metadata key",
@@ -424,6 +462,39 @@ func TestNormalizeScore(t *testing.T) {
 				},
 			},
 			expectedOrder: []string{"node-with-metadata", "node-no-metadata-1", "node-no-metadata-2"},
+		},
+		{
+			name: "numeric default value ranks missing metadata among labeled nodes",
+			args: &config.NodeMetadataArgs{
+				MetadataKey:     "priority",
+				MetadataSource:  config.MetadataSourceLabel,
+				MetadataType:    config.MetadataTypeNumber,
+				ScoringStrategy: config.ScoringStrategyHighest,
+				DefaultValue:    "100",
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-low", Labels: map[string]string{"priority": "50"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-missing"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-high", Labels: map[string]string{"priority": "150"}}},
+			},
+			expectedOrder: []string{"node-high", "node-missing", "node-low"},
+		},
+		{
+			name: "timestamp default value ranks missing metadata among annotated nodes",
+			args: &config.NodeMetadataArgs{
+				MetadataKey:     "last-update",
+				MetadataSource:  config.MetadataSourceAnnotation,
+				MetadataType:    config.MetadataTypeTimestamp,
+				ScoringStrategy: config.ScoringStrategyNewest,
+				TimestampFormat: time.RFC3339,
+				DefaultValue:    time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-old", Annotations: map[string]string{"last-update": time.Now().Add(-72 * time.Hour).Format(time.RFC3339)}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-missing"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-new", Annotations: map[string]string{"last-update": time.Now().Add(-time.Hour).Format(time.RFC3339)}}},
+			},
+			expectedOrder: []string{"node-new", "node-missing", "node-old"},
 		},
 		{
 			name: "all nodes missing metadata",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/kind feature

#### What this PR does / why we need it:

Follow-up to #942, addressing two gaps identified after the original NodeMetadata
plugin was merged:

- [@Huang-Wei asked what happens when `timestampFormat` is invalid](https://github.com/kubernetes-sigs/scheduler-plugins/pull/942#discussion_r3609512572)
  and later suggested [failing early for an illegal timestamp format](https://github.com/kubernetes-sigs/scheduler-plugins/pull/942#discussion_r3792814812).
  This PR validates timestamp layouts at scheduler startup.
- [@remram44 noted](https://github.com/kubernetes-sigs/scheduler-plugins/pull/942#issuecomment-5374730712)
  that missing metadata needs a configurable baseline, so unlabeled nodes can
  rank above or below labeled nodes. This PR adds `defaultValue`.

When a node is missing the configured metadata key, NodeMetadata scores it using
`defaultValue` with the same metadata type and scoring strategy:

- Numeric defaults work with both `Highest` and `Lowest`.
- Timestamp defaults must match `timestampFormat`.
- Malformed node metadata remains lowest-scoring and does not silently use the
  fallback.

The API conversion/deepcopy support, documentation, manifests, KEP, and unit
tests are updated accordingly.

#### Which issue(s) this PR fixes:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NodeMetadata now supports an optional defaultValue for nodes missing configured
metadata, with startup validation for timestamp layouts and timestamp defaults.
```
