### PR TITLE
nrt: cleanup: use ContainerIter to iterate in place

### DIFF
--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	podlisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -481,20 +482,20 @@ func categorizePodForPreemption(pod *corev1.Pod, nrtResources sets.Set[corev1.Re
 		Name:      pod.Name,
 	}
 
-	for _, ctr := range pod.Spec.InitContainers {
+	for ctr := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers) {
 		// filter out init containers with restart policy other than Always because these are *supposed* to
 		// run fast and finish, hence not consuming exclusive resources in a steady state while the pod is Running.
-		if !util.IsSidecarInitContainer(&ctr) {
+		if !util.IsSidecarInitContainer(ctr) {
 			continue
 		}
-		if !resourcerequests.IsExclusiveForContainer(qos, ctr, nrtResources) {
+		if !resourcerequests.IsExclusiveForContainer(qos, *ctr, nrtResources) {
 			continue
 		}
 		ret.PinnedContainers = append(ret.PinnedContainers, ctr.Name)
 	}
 
-	for _, ctr := range pod.Spec.Containers {
-		if !resourcerequests.IsExclusiveForContainer(qos, ctr, nrtResources) {
+	for ctr := range podutil.ContainerIter(&pod.Spec, podutil.Containers) {
+		if !resourcerequests.IsExclusiveForContainer(qos, *ctr, nrtResources) {
 			continue
 		}
 		ret.PinnedContainers = append(ret.PinnedContainers, ctr.Name)

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	bm "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
@@ -43,8 +44,8 @@ func singleNUMAContainerLevelHandler(lh logr.Logger, pod *v1.Pod, info *filterIn
 	// the init containers are running SERIALLY and BEFORE the normal containers.
 	// https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#understanding-init-containers
 	// therefore, we don't need to accumulate their resources together
-	for _, initContainer := range pod.Spec.InitContainers {
-		cntKind := logging.GetInitContainerKind(&initContainer)
+	for initContainer := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers) {
+		cntKind := logging.GetInitContainerKind(initContainer)
 		clh := lh.WithValues(logging.KeyContainer, initContainer.Name, logging.KeyContainerKind, cntKind)
 		clh.V(6).Info("desired resources", stringify.ResourceListToLoggable(initContainer.Resources.Requests)...)
 
@@ -57,7 +58,7 @@ func singleNUMAContainerLevelHandler(lh logr.Logger, pod *v1.Pod, info *filterIn
 		}
 	}
 
-	for _, container := range pod.Spec.Containers {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.Containers) {
 		clh := lh.WithValues(logging.KeyContainer, container.Name, logging.KeyContainerKind, logging.KindContainerApp)
 		clh.V(6).Info("container requests", stringify.ResourceListToLoggable(container.Resources.Requests)...)
 

--- a/pkg/noderesourcetopology/filter_preemption_test.go
+++ b/pkg/noderesourcetopology/filter_preemption_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
@@ -128,7 +129,7 @@ func makeNodeFromNRT(nrt *topologyv1alpha2.NodeResourceTopology) *v1.Node {
 
 func makeEncodedInfoForPod(pod *v1.Pod, numaNode int) *numaplacement.EncodedInfo {
 	affinities := make([]numaplacement.ContainerAffinity, 0, len(pod.Spec.Containers))
-	for _, container := range pod.Spec.Containers {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.Containers) {
 		affinities = append(affinities, numaplacement.ContainerAffinity{
 			ID: numaplacement.ContainerID{
 				Namespace:     pod.Namespace,

--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -19,6 +19,7 @@ package noderesourcetopology
 import (
 	v1 "k8s.io/api/core/v1"
 	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 
 	"github.com/go-logr/logr"
@@ -37,7 +38,7 @@ func leastNUMAContainerScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo) 
 	allContainersMinAvgDistance := true
 	// the order how TopologyManager asks for hint is important so doing it in the same order
 	// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/topologymanager/scope_container.go#L52
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		// if a container requests only non NUMA just continue
 		if onlyNonNUMAResources(info.numaNodes, container.Resources.Requests) {
 			continue

--- a/pkg/noderesourcetopology/preemption/preemption.go
+++ b/pkg/noderesourcetopology/preemption/preemption.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/cache"
@@ -73,7 +74,7 @@ func accumulateResourcesToAddPerNUMA(victims []corev1.Pod, numaPlacementInfo *nu
 			continue
 		}
 
-		for _, container := range victim.Spec.Containers {
+		for container := range podutil.ContainerIter(&victim.Spec, podutil.Containers) {
 			containerID := numaplacement.ContainerID{
 				Namespace:     victim.Namespace,
 				PodName:       victim.Name,

--- a/pkg/noderesourcetopology/resourcerequests/exclusive.go
+++ b/pkg/noderesourcetopology/resourcerequests/exclusive.go
@@ -20,21 +20,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
 func IncludeNonNative(pod *corev1.Pod) bool {
-	for _, initContainer := range pod.Spec.InitContainers {
-		for resource := range initContainer.Resources.Requests {
-			if !v1helper.IsNativeResource(resource) {
-				return true
-			}
-		}
-	}
-	for _, container := range pod.Spec.Containers {
-		for resource := range container.Resources.Requests {
+	for ctr := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		for resource := range ctr.Resources.Requests {
 			if !v1helper.IsNativeResource(resource) {
 				return true
 			}
@@ -48,18 +42,18 @@ func IncludeNonNative(pod *corev1.Pod) bool {
 func AreExclusiveForPod(pod *corev1.Pod, nrtResources sets.Set[corev1.ResourceName]) bool {
 	qos := v1qos.GetPodQOS(pod)
 
-	for _, ctr := range pod.Spec.InitContainers {
+	for ctr := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers) {
 		// skip init containers with restart policy other than Always because these are *supposed* to
 		// run fast and finish, hence not consuming exclusive resources in a steady state while the pod is Running.
-		if !util.IsSidecarInitContainer(&ctr) {
+		if !util.IsSidecarInitContainer(ctr) {
 			continue
 		}
-		if IsExclusiveForContainer(qos, ctr, nrtResources) {
+		if IsExclusiveForContainer(qos, *ctr, nrtResources) {
 			return true
 		}
 	}
-	for _, ctr := range pod.Spec.Containers {
-		if IsExclusiveForContainer(qos, ctr, nrtResources) {
+	for ctr := range podutil.ContainerIter(&pod.Spec, podutil.Containers) {
+		if IsExclusiveForContainer(qos, *ctr, nrtResources) {
 			return true
 		}
 	}

--- a/pkg/noderesourcetopology/score.go
+++ b/pkg/noderesourcetopology/score.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
@@ -152,12 +153,12 @@ func podScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo, scorerFn scoreS
 func containerScopeScore(lh logr.Logger, pod *v1.Pod, info *scoreInfo, scorerFn scoreStrategyFn, resourceToWeightMap resourceToWeightMap) (int64, *fwk.Status) {
 	// This code is in Admit implementation of container scope
 	// https://github.com/kubernetes/kubernetes/blob/9ff3b7e744b34c099c1405d9add192adbef0b6b1/pkg/kubelet/cm/topologymanager/scope_container.go#L52
-	containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
-	contScore := make([]float64, len(containers))
+	contScore := make([]float64, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
 
-	for i, container := range containers {
-		contScore[i] = float64(scoreForEachNUMANode(lh, container.Resources.Requests, info.numaNodes, scorerFn, resourceToWeightMap))
-		lh.V(6).Info("container scope scoring", "container", container.Name, "score", contScore[i])
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		score := float64(scoreForEachNUMANode(lh, container.Resources.Requests, info.numaNodes, scorerFn, resourceToWeightMap))
+		contScore = append(contScore, score)
+		lh.V(6).Info("container scope scoring", "container", container.Name, "score", score)
 	}
 	finalScore := int64(stat.Mean(contScore, nil))
 	lh.V(3).Info("container scope scoring final node score", "finalScore", finalScore)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The pre-iterator standard pattern of using `append(pod.Spec.InitContainers, pod.Spec.Containers...)` to iterate over containers was causeing allocation of backing slices and copies, creating GC pressure.

We now have a kube utility to iterate in place, let's use it. No intended change of behavior.

#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
Note: this means the previous code MUST not mutate containers - that was never the intent anyway, but this change may now expose latent hidden bugs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
