### PR TITLE
Deflake TestCoschedulingPlugin by disabling async preemption

### DIFF
--- a/test/integration/coscheduling_test.go
+++ b/test/integration/coscheduling_test.go
@@ -28,7 +28,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	schedapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	fwkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
@@ -44,6 +47,18 @@ import (
 )
 
 func TestCoschedulingPlugin(t *testing.T) {
+	// This test has a high-priority workload preempt a lower-priority PodGroup whose
+	// Pods are parked on Permit. Such a victim is only *assumed*, and coscheduling
+	// releases it (ForgetPod, NominatedNodeName cleared) before the async preemption
+	// goroutine deletes it - at which point deletePodFromSchedulingQueue emits no
+	// cluster event at all. The preemptor then stays gated by DefaultPreemption's
+	// PreEnqueue in unschedulablePods with nothing left to wake it up, not even
+	// flushUnschedulablePodsLeftover, which skips gated Pods. Turning async preemption
+	// off removes that gate; without this the test stalls in roughly a third of runs.
+	// See #1007 and kubernetes/kubernetes#141694.
+	// TODO: drop this once the upstream wake-up gap is fixed.
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncPreemption, false)
+
 	testCtx := &testContext{}
 	testCtx.Ctx, testCtx.CancelFn = context.WithCancel(context.Background())
 
@@ -79,6 +94,9 @@ func TestCoschedulingPlugin(t *testing.T) {
 	cfg.Profiles[0].Plugins.PreFilter.Enabled = append(cfg.Profiles[0].Plugins.PreFilter.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].Plugins.PostFilter.Enabled = append(cfg.Profiles[0].Plugins.PostFilter.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].Plugins.Permit.Enabled = append(cfg.Profiles[0].Plugins.Permit.Enabled, schedapi.Plugin{Name: coscheduling.Name})
+	// Coscheduling implements Reserve/Unreserve and the shipped `multiPoint` config
+	// enables it there, so mirror that here - otherwise Unreserve never runs.
+	cfg.Profiles[0].Plugins.Reserve.Enabled = append(cfg.Profiles[0].Plugins.Reserve.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].PluginConfig = append(cfg.Profiles[0].PluginConfig, schedapi.PluginConfig{
 		Name: coscheduling.Name,
 		Args: &schedconfig.CoschedulingArgs{
@@ -412,6 +430,9 @@ func TestPodCompleted(t *testing.T) {
 	cfg.Profiles[0].Plugins.PreFilter.Enabled = append(cfg.Profiles[0].Plugins.PreFilter.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].Plugins.PostFilter.Enabled = append(cfg.Profiles[0].Plugins.PostFilter.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].Plugins.Permit.Enabled = append(cfg.Profiles[0].Plugins.Permit.Enabled, schedapi.Plugin{Name: coscheduling.Name})
+	// Coscheduling implements Reserve/Unreserve and the shipped `multiPoint` config
+	// enables it there, so mirror that here - otherwise Unreserve never runs.
+	cfg.Profiles[0].Plugins.Reserve.Enabled = append(cfg.Profiles[0].Plugins.Reserve.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].PluginConfig = append(cfg.Profiles[0].PluginConfig, schedapi.PluginConfig{
 		Name: coscheduling.Name,
 		Args: &schedconfig.CoschedulingArgs{
@@ -544,6 +565,9 @@ func TestPodgroupBackoff(t *testing.T) {
 	cfg.Profiles[0].Plugins.PreFilter.Enabled = append(cfg.Profiles[0].Plugins.PreFilter.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].Plugins.PostFilter.Enabled = append(cfg.Profiles[0].Plugins.PostFilter.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].Plugins.Permit.Enabled = append(cfg.Profiles[0].Plugins.Permit.Enabled, schedapi.Plugin{Name: coscheduling.Name})
+	// Coscheduling implements Reserve/Unreserve and the shipped `multiPoint` config
+	// enables it there, so mirror that here - otherwise Unreserve never runs.
+	cfg.Profiles[0].Plugins.Reserve.Enabled = append(cfg.Profiles[0].Plugins.Reserve.Enabled, schedapi.Plugin{Name: coscheduling.Name})
 	cfg.Profiles[0].PluginConfig = append(cfg.Profiles[0].PluginConfig, schedapi.PluginConfig{
 		Name: coscheduling.Name,
 		Args: &schedconfig.CoschedulingArgs{


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind failing-test

#### What this PR does / why we need it:

`TestCoschedulingPlugin/different priority, not sequentially pg1 meet min and 3 regular pods` (t6)
times out in **~38% of CI runs** — 40 of the 105 completed runs of
`pull-scheduler-plugins-integration-test-master` retained in GCS (2026-06-09 → 2026-09-04), across
**17 unrelated PRs** (e.g. #971, which changes one line of `.github/workflows/helm.yaml`; #992, a
KEP markdown file; #1005, release docs). The subtest always burns exactly its 120 s poll budget,
never an intermediate value — it deadlocks rather than runs slowly.

The stall is an upstream kube-scheduler wake-up gap, not a coscheduling bug:

1. The `pg6-1` Pods park on Permit. They are *assumed*, so they hold node memory in the scheduler
   cache, but their API objects carry no `.spec.nodeName`.
2. `t6-p4` (high priority) fails Filter. `DefaultPreemption` selects those assumed-and-waiting Pods
   as victims, starts async preemption, and gates `t6-p4` in its `PreEnqueue`.
3. Coscheduling's `PostFilter` rejects the waiting siblings, so `ForgetPod` releases their memory
   and `NominatedNodeName` is cleared. The resulting `AssignedPodDelete` reaches `t6-p4` while the
   gate is still shut, and it bounces back to `unschedulablePods`.
4. The preemption goroutine then deletes the victims. They are by now neither assumed nor
   nominated, so `deletePodFromSchedulingQueue` returns without emitting a cluster event.
5. `preempting` is cleared — the gate is open, but nothing re-evaluates it.

`t6-p4` is then stuck indefinitely: since 1.34, `movePodsToActiveOrBackoffQueue` skips gated Pods
unless the event matches the gating plugin's registered events, and `DefaultPreemption` registers
only `Pod/Delete`, so `flushUnschedulablePodsLeftover` cannot rescue it either.

This PR turns `SchedulerAsyncPreemption` off for that one test, which removes the `PreEnqueue` gate
entirely. Measured locally over 16 parallel runs per variant on a 12-core machine:

| variant | t6 failures |
|---|---|
| master | 5/16 |
| `--pod-max-in-unschedulable-pods-duration=10s` | 5/16 |
| **this PR** | **0/16** (and 0/32 on a confirmation run) |

`TestPodCompleted` and `TestPodgroupBackoff` use a single priority, so preemption never fires there
and they are left as-is.

It also registers Coscheduling at `Reserve` in all three tests. The plugin implements
`Reserve`/`Unreserve` and the shipped `multiPoint` config enables it there, so without this the
tests have never exercised `Unreserve` — `pgMgr.Unreserve`, `DeletePermittedPodGroup` and
`MarkPodGroupScheduleFailure` were all dead code under test. This is a fidelity fix and does not
affect the flake rate on its own (4/16 measured).

#### Which issue(s) this PR fixes:

Related: #1007 (kept open — this is a workaround, not the fix) and
kubernetes/kubernetes#141694 upstream.

#### Special notes for your reviewer:

This is deliberately a workaround with a `TODO`, not a fix. The real fix belongs in
`prepareCandidateAsync`, which should activate the preemptor on completion rather than relying on a
victim-deletion event that a no-op or already-forgotten victim never produces. Upstream #141694
tracks two other triggers for the same gap; the coscheduling one is a third.

The cost of this workaround is that `TestCoschedulingPlugin` no longer exercises async preemption.
The alternative that also measured 0/16 — dropping coscheduling's optimistic rejection of waiting
siblings in `PostFilter` — removes a real feature, so I did not take it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
