### PR TITLE
Fix stale controller image default in the chart config table

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/README.md
+++ b/manifests/install/charts/as-a-second-scheduler/README.md
@@ -57,7 +57,7 @@ The following table lists the configurable parameters of the as-a-second-schedul
 | `scheduler.affinity`           | Scheduler affinity           | `{}`                                                                                            |
 | `scheduler.tolerations`        | Scheduler tolerations        | `[]`                                                                                            |
 | `controller.name`              | Controller name              | `scheduler-plugins-controller`                                                                  |
-| `controller.image`             | Controller image             | `registry.k8s.io/scheduler-plugins/controller:v0.29.7`                                          |
+| `controller.image`             | Controller image             | `registry.k8s.io/scheduler-plugins/controller:v0.35.7`                                          |
 | `controller.replicaCount`      | Controller replicaCount      | `1`                                                                                             |
 | `controller.priorityClassName` | Controller priorityClassName | `""`                                                                                            |
 | `controller.resources`         | Controller resources         | `{}`                                                                                            |

--- a/site/content/en/docs/user-guide/installing-the-chart.md
+++ b/site/content/en/docs/user-guide/installing-the-chart.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the as-a-second-schedul
 | `scheduler.affinity`           | Scheduler affinity           | `{}`                                                                                            |
 | `scheduler.tolerations`        | Scheduler tolerations        | `[]`                                                                                            |
 | `controller.name`              | Controller name              | `scheduler-plugins-controller`                                                                  |
-| `controller.image`             | Controller image             | `registry.k8s.io/scheduler-plugins/controller:v0.29.7`                                          |
+| `controller.image`             | Controller image             | `registry.k8s.io/scheduler-plugins/controller:v0.35.7`                                          |
 | `controller.replicaCount`      | Controller replicaCount      | `1`                                                                                             |
 | `controller.priorityClassName` | Controller priorityClassName | `""`                                                                                            |
 | `controller.resources`         | Controller resources         | `{}`                                                                                            |


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The `controller.image` row of the as-a-second-scheduler configuration table still advertises
`registry.k8s.io/scheduler-plugins/controller:v0.29.7`, while `values.yaml` says `v0.35.7`. So the
two rows in the same table disagree by six releases:

| Parameter | documented default | actual default in `values.yaml` |
|---|---|---|
| `scheduler.image` | `kube-scheduler:v0.35.7` | `kube-scheduler:v0.35.7` |
| `controller.image` | `controller:v0.29.7` | `controller:v0.35.7` |

`git log -S 'controller:v0.29.7'` traces the row to 7e5b969a ("doc update for v0.29.7"). Each
release doc update since then has refreshed the `scheduler.image` row directly above it and missed
this one — including #1005 for v0.35.7, which changed exactly one line in this table.

The same table is duplicated in the user guide, which is what renders on
scheduler-plugins.sigs.k8s.io, so both copies are updated here.

Purely cosmetic: nothing consumes these tables, the shipped chart defaults are correct.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Noticed while verifying the v0.35.7 release. Worth a glance at whether the release doc process can
pick this table up automatically, since it has now been missed six times in a row.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
