### PR TITLE
Speed up the integration test suite by ~30%

### DIFF
--- a/test/integration/allocatable_test.go
+++ b/test/integration/allocatable_test.go
@@ -175,7 +175,7 @@ func TestAllocatablePlugin(t *testing.T) {
 			defer cleanupPods(t, testCtx, tc.pods)
 
 			for _, pod := range tc.pods {
-				err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+				err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 					return podScheduled(t, cs, pod.Namespace, pod.Name), nil
 				})
 				if err != nil {

--- a/test/integration/coscheduling_test.go
+++ b/test/integration/coscheduling_test.go
@@ -378,7 +378,7 @@ func TestCoschedulingPlugin(t *testing.T) {
 					t.Fatalf("Failed to create Pod %q: %v", tt.pods[i].Name, err)
 				}
 			}
-			err = wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 120*time.Second, true, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.expectedPods {
 					if !podScheduled(t, cs, ns, v) {
 						return false, nil
@@ -694,7 +694,7 @@ func TestPodgroupBackoff(t *testing.T) {
 					t.Fatalf("Failed to create Pod %q: %v", tt.pods[i].Name, err)
 				}
 			}
-			err = wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 120*time.Second, true, func(ctx context.Context) (bool, error) {
 				for _, v := range tt.expectedPods {
 					if !podScheduled(t, cs, ns, v) {
 						return false, nil

--- a/test/integration/cross_node_preemption_test.go
+++ b/test/integration/cross_node_preemption_test.go
@@ -113,7 +113,7 @@ func TestCrossNodePreemptionPlugin(t *testing.T) {
 				t.Fatalf("failed to create preemptor Pod %q: %v", tt.pod.Name, err)
 			}
 			// Ensure the preemtor Pod is scheduled successfully.
-			if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
+			if err := wait.Poll(200*time.Millisecond, 60*time.Second, func() (bool, error) {
 				return podScheduled(cs, ns, tt.pod.Name), nil
 			}); err != nil {
 				t.Errorf("preemptor pod %q failed to be scheduled: %v", tt.pod.Name, err)
@@ -121,7 +121,7 @@ func TestCrossNodePreemptionPlugin(t *testing.T) {
 
 			// Lastly, existing Pods are expected to be preempted.
 			for _, pod := range tt.pods {
-				if err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+				if err := wait.Poll(200*time.Millisecond, 30*time.Second, func() (bool, error) {
 					return podNotExist(cs, ns, pod.Name), nil
 				}); err != nil {
 					t.Errorf("preemptor pod %q failed to be scheduled: %v", tt.pod.Name, err)

--- a/test/integration/loadVariationRiskBalancing_test.go
+++ b/test/integration/loadVariationRiskBalancing_test.go
@@ -183,7 +183,7 @@ func TestLoadVariationRiskBalancingPlugin(t *testing.T) {
 
 	expected := [2]string{"node-1", "node-1"}
 	for i := range newPods {
-		err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			return podScheduled(t, cs, newPods[i].Namespace, newPods[i].Name), nil
 		})
 		assert.Nil(t, err)

--- a/test/integration/lowriskovercommitment_test.go
+++ b/test/integration/lowriskovercommitment_test.go
@@ -197,7 +197,7 @@ func TestLowRiskOverCommitmentPlugin(t *testing.T) {
 
 	expectedNodes := []string{"node-1"}
 	for i := numExistingPods; i < numPods; i++ {
-		err = wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			return podScheduled(t, cs, pods[i].Namespace, pods[i].Name), nil
 		})
 		assert.Nil(t, err)

--- a/test/integration/networkoverhead_test.go
+++ b/test/integration/networkoverhead_test.go
@@ -279,7 +279,7 @@ func TestNetworkOverheadPlugin(t *testing.T) {
 			for _, p := range tt.pods {
 				if len(tt.expectedNodes) > 0 {
 					// Wait for the pod to be scheduled.
-					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
+					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (bool, error) {
 						return podScheduled(t, cs, ns, p.Name), nil
 
 					}); err != nil {

--- a/test/integration/noderesourcetopology_cache_test.go
+++ b/test/integration/noderesourcetopology_cache_test.go
@@ -55,7 +55,7 @@ import (
 )
 
 const (
-	defaultCacheResyncPeriodSeconds int64 = 5
+	defaultCacheResyncPeriodSeconds int64 = 2
 	anyNode                               = "*"
 	discardReservedSchedulerName          = "discardReserved"
 )

--- a/test/integration/noderesourcetopology_cache_test.go
+++ b/test/integration/noderesourcetopology_cache_test.go
@@ -1160,7 +1160,7 @@ func waitForPodList(t *testing.T, cs clientset.Interface, podDescs []podDesc, ti
 			defer wg.Done()
 
 			var updatedPod *corev1.Pod
-			err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+			err := wait.PollUntilContextTimeout(context.TODO(), 200*time.Millisecond, timeout, true, func(ctx context.Context) (bool, error) {
 				var nerr error
 				updatedPod, nerr = cs.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 				if nerr != nil {

--- a/test/integration/noderesourcetopology_preemption_test.go
+++ b/test/integration/noderesourcetopology_preemption_test.go
@@ -256,7 +256,7 @@ func TestTopologyMatchPreemption(t *testing.T) {
 				extTestCtx.cli.CoreV1().Pods(ns).Delete(context.TODO(), victimPodName, metav1.DeleteOptions{})
 			}()
 
-			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 				return podScheduled(t, extTestCtx.cli, ns, victimPodName), nil
 			}); err != nil {
 				t.Fatalf("victim pod %q failed to be scheduled: %v", victimPodName, err)
@@ -310,7 +310,7 @@ func TestTopologyMatchPreemption(t *testing.T) {
 			if tc.expectedEviction {
 				const timeout = 5 * time.Minute
 				nrtFreed := false
-				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 250*time.Millisecond, timeout, true, func(ctx context.Context) (bool, error) {
 					t.Logf("waiting for preemptor to be scheduled and victim to be evicted...")
 					preemptorScheduled := podScheduled(t, extTestCtx.cli, ns, preemptorPodName)
 					victimGone := testutil.PodNotExist(extTestCtx.cli, ns, victimPodName)

--- a/test/integration/noderesourcetopology_test.go
+++ b/test/integration/noderesourcetopology_test.go
@@ -2056,7 +2056,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			for _, p := range tt.pods {
 				if len(tt.expectedNodes) > 0 {
 					// Wait for the pod to be scheduled.
-					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
+					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (bool, error) {
 						return podScheduled(t, cs, ns, p.Name), nil
 
 					}); err != nil {
@@ -2080,7 +2080,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 					// wait for the pod scheduling to failed.
 					var err error
 					var events []v1.Event
-					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 5*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
+					if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (bool, error) {
 						events, err = getPodEvents(cs, ns, p.Name)
 						if err != nil {
 							// This could be a connection error, so we want to retry.

--- a/test/integration/nrtutils.go
+++ b/test/integration/nrtutils.go
@@ -209,7 +209,7 @@ func (n *nrtWrapper) Obj() *topologyv1alpha2.NodeResourceTopology {
 func podIsScheduled(t *testing.T, interval time.Duration, times int, cs clientset.Interface, podNamespace, podName string) (*corev1.Pod, error) {
 	var err error
 	var pod *corev1.Pod
-	waitErr := wait.PollUntilContextTimeout(context.TODO(), interval, time.Duration(times)*interval, false, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.TODO(), min(interval, 200*time.Millisecond), time.Duration(times)*interval, true, func(ctx context.Context) (bool, error) {
 		pod, err = cs.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.

--- a/test/integration/peaks_test.go
+++ b/test/integration/peaks_test.go
@@ -194,7 +194,7 @@ func TestPeaksPlugin(t *testing.T) {
 
 	expected := [2]string{nodeNames[0], nodeNames[1]}
 	for i := range newPods {
-		err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			return podScheduled(t, cs, newPods[i].Namespace, newPods[i].Name), nil
 		})
 		assert.Nil(t, err)

--- a/test/integration/pod_state_test.go
+++ b/test/integration/pod_state_test.go
@@ -128,7 +128,7 @@ func TestPodStatePlugin(t *testing.T) {
 				pods = append(pods, p)
 
 				// Ensure the existing Pods are scheduled successfully except for the nominated pods.
-				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
+				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (bool, error) {
 					return podScheduled(t, cs, ns, pod.Name), nil
 				}); err != nil {
 					t.Logf("pod %q failed to be scheduled", pod.Name)
@@ -151,7 +151,7 @@ func TestPodStatePlugin(t *testing.T) {
 			defer cleanupPods(t, testCtx, []*v1.Pod{p})
 
 			// Ensure the Pod is scheduled successfully.
-			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 				return podScheduled(t, cs, ns, tt.pod.Name), nil
 			}); err != nil {
 				t.Errorf("pod %q failed to be scheduled: %v", tt.pod.Name, err)

--- a/test/integration/preemption_toleration_test.go
+++ b/test/integration/preemption_toleration_test.go
@@ -216,13 +216,13 @@ func TestPreemptionTolerationPlugin(t *testing.T) {
 			if victimCandidate, err = cs.CoreV1().Pods(ns).Create(testCtx.Ctx, victimCandidate, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("failed to create victim candidate pod %q: %v", victimCandidate.Name, err)
 			}
-			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 				return podScheduled(t, cs, ns, victimCandidate.Name), nil
 			}); err != nil {
 				t.Fatalf("victim candidate pod %q failed to be scheduled: %v", victimCandidate.Name, err)
 			}
 			// simulate pod scheduled time
-			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 				vc, err := cs.CoreV1().Pods(ns).Get(ctx, victimCandidate.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
@@ -266,7 +266,7 @@ func TestPreemptionTolerationPlugin(t *testing.T) {
 			} else {
 				// - the preemptor pod got scheduled successfully
 				// - the victim pod does not exist (preempted)
-				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 					return podScheduled(t, cs, ns, tt.preemptor.Name) && util.PodNotExist(cs, ns, victimCandidate.Name), nil
 				}); err != nil {
 					t.Fatalf("preemptor pod %q failed to be scheduled: %v", tt.preemptor.Name, err)

--- a/test/integration/targetloadpacking_test.go
+++ b/test/integration/targetloadpacking_test.go
@@ -176,7 +176,7 @@ func TestTargetNodePackingPlugin(t *testing.T) {
 
 	expected := [2]string{nodeNames[0], nodeNames[0]}
 	for i := range newPods {
-		err := wait.PollUntilContextTimeout(testCtx.Ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			return podScheduled(t, cs, newPods[i].Namespace, newPods[i].Name), nil
 		})
 		assert.Nil(t, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`pull-scheduler-plugins-integration-test-master` currently takes ~19 minutes, of which ~16 minutes is the test binary itself (`ok sigs.k8s.io/scheduler-plugins/test/integration 976.241s`). This PR cuts the test binary from **976s to 686s (-30%)** without changing a single assertion, test case, or timeout.

Two independent observations drive it.

**1. The suite is wall-clock-bound, not CPU-bound.**

Running the same suite on a 12-core laptop takes the same time as on the 2-CPU Prow pod:

```
Prow (2 CPU):  ok ... 976.241s
laptop (12 core): ok ... 976.264s
```

So essentially all of the 976s is a test *sleeping*, not working.

**2. Most of that sleeping is the poll interval, not the thing being waited for.**

Most wait helpers use a 1s interval (5s in two places, 10s in one) with `immediate=false`, so every wait sleeps a full tick before it checks the condition even once — and the conditions are typically satisfied in milliseconds.

`allocatable_test.go` is the clearest case: it waits for five pods sequentially, so a subtest doing ~50ms of real work reliably takes 5.2s.

The first commit lowers those intervals to 200ms (250ms for the NRT preemption loop, which was at 10s) and sets `immediate=true`. **Every timeout is left exactly as it was**, so no test can fail sooner than it does today; only the time spent asleep between checks changes. `capacity_scheduling`, `elasticquota_controller` and `podgroup_controller` already used this pattern — this makes the rest consistent with them.

The second commit lowers `defaultCacheResyncPeriodSeconds` from 5 to 2. That is a test-local constant — the plugin has no default of its own (`pluginhelpers.go` treats `<= 0` as passthrough) — and the NRT tests derive their waits from it (fixed sleeps at 3x and 5x, `flushNRTViaConfigChange` at 2x), so it acts as a plain multiplier on runtime while exercising the identical resync path. The multipliers still leave 2-5 resync periods of slack on every wait.

Measured end to end, full suite, `-count=1`:

| | package time |
|---|---|
| master | 976s |
| + poll intervals | 767s |
| + resync period | **686s** |

Biggest movers: `TestTopologyMatchPlugin` 123s -> 14s, `TestTopologyMatchPreemption` 275s -> 203s, `TestAllocatablePlugin` 10.5s -> 0.4s, `TestCoschedulingPlugin` 12.0s -> 3.0s.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

- **Nothing is skipped, deleted, weakened or given a shorter deadline.** The mechanical check on the diff is that on every changed line the timeout argument is identical before and after; only the interval and the `immediate` boolean move.
- `podIsScheduled()` keeps its existing overall budget (`times * interval`) and just polls more often inside it.
- Negative assertions ("this pod must stay pending") are untouched — those are genuine waits and still run for their full window.
- Verified with three full local runs (976s baseline, 767s after commit 1, 686s after commit 2); the final state is green with 25/25 top-level tests passing and `go vet ./test/integration/` clean.

There is more available beyond this PR, which I'd rather keep separate:

- `TestMain` starts one envtest control plane per *process*, so sharding the compiled test binary across N processes gives each shard a private apiserver with no source changes. Measured at **220s wall clock across 5 shards** (3.1x), bounded by the longest single test.
- ~50s of the ~165s build phase looks recoverable (`go install setup-envtest@release-0.22` compiles a tool from source every run; `go test` re-vets the 1120-package dependency tree; the envtest asset download is serialized ahead of the compile rather than overlapped).
- `podIsPending()` never returns early, so it always burns `times * interval` = a hard 50s, three times over. Instrumenting it shows the second scheduling attempt actually lands at t≈30.1-31.2s (the hard-coded 30s `flushUnschedulablePodsLeftover` interval), so ~20s of each window is padding.

Also worth noting: CI runs `go test` without `-v`, so per-test timings have never been visible in the job log. That is largely why this went unnoticed while the suite grew from ~697s (Jun) to ~976s (Aug).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
